### PR TITLE
4626 variant: Ownable + pull pattern support

### DIFF
--- a/src/4626/4626Deploy.sol
+++ b/src/4626/4626Deploy.sol
@@ -8,27 +8,34 @@ import {CompoundERC4626} from "@protocol/4626/CompoundERC4626.sol";
 import {Comptroller as IComptroller} from "@protocol/Comptroller.sol";
 
 contract Compound4626Deploy {
-    function deployVaults(Addresses addresses, address rewardReceiver) public {
+    function deployVaults(
+        Addresses addresses,
+        address owner,
+        address rewardHandler
+    ) public {
         /// deploy the ERC20 wrapper for USDC
         CompoundERC4626 usdcVault = new CompoundERC4626(
+            owner,
             ERC20(addresses.getAddress("USDC")),
             MErc20(addresses.getAddress("MOONWELL_USDC")),
-            rewardReceiver,
-            IComptroller(addresses.getAddress("UNITROLLER"))
+            IComptroller(addresses.getAddress("UNITROLLER")),
+            rewardHandler
         );
 
         CompoundERC4626 wethVault = new CompoundERC4626(
+            owner,
             ERC20(addresses.getAddress("WETH")),
             MErc20(addresses.getAddress("MOONWELL_WETH")),
-            rewardReceiver,
-            IComptroller(addresses.getAddress("UNITROLLER"))
+            IComptroller(addresses.getAddress("UNITROLLER")),
+            rewardHandler
         );
 
         CompoundERC4626 cbethVault = new CompoundERC4626(
+            owner,
             ERC20(addresses.getAddress("cbETH")),
             MErc20(addresses.getAddress("MOONWELL_cbETH")),
-            rewardReceiver,
-            IComptroller(addresses.getAddress("UNITROLLER"))
+            IComptroller(addresses.getAddress("UNITROLLER")),
+            rewardHandler
         );
 
         addresses.addAddress("USDC_VAULT", address(usdcVault));

--- a/test/proposals/Deploy4626Vaults.s.sol
+++ b/test/proposals/Deploy4626Vaults.s.sol
@@ -43,7 +43,8 @@ contract Deploy4626Vaults is Script, Compound4626Deploy, Test {
 
     function run() public {
         address deployerAddress = vm.addr(PRIVATE_KEY);
-        address rewardRecipient = addresses.getAddress("REWARDS_RECEIVER");
+        address vault4626Owner = addresses.getAddress("4626_OWNER");
+        address rewardHandler = addresses.getAddress("REWARD_HANDLER");
 
         console.log("deployer address: %s", deployerAddress);
 
@@ -67,7 +68,7 @@ contract Deploy4626Vaults is Script, Compound4626Deploy, Test {
 
         vm.startBroadcast(PRIVATE_KEY);
 
-        deployVaults(addresses, rewardRecipient);
+        deployVaults(addresses, vault4626Owner, rewardHandler);
 
         address unitroller = addresses.getAddress("UNITROLLER");
 
@@ -81,7 +82,7 @@ contract Deploy4626Vaults is Script, Compound4626Deploy, Test {
                 addresses.getAddress("MOONWELL_USDC")
             );
             assertEq(address(vault.comptroller()), unitroller);
-            assertEq(vault.rewardRecipient(), rewardRecipient);
+            assertEq(vault.rewardHandler(), rewardHandler);
 
             console.log("deployed USDC vault: ", address(vault));
 
@@ -100,7 +101,7 @@ contract Deploy4626Vaults is Script, Compound4626Deploy, Test {
                 addresses.getAddress("MOONWELL_WETH")
             );
             assertEq(address(vault.comptroller()), unitroller);
-            assertEq(vault.rewardRecipient(), rewardRecipient);
+            assertEq(vault.rewardHandler(), rewardHandler);
 
             console.log("deployed WETH vault: ", address(vault));
 
@@ -119,7 +120,7 @@ contract Deploy4626Vaults is Script, Compound4626Deploy, Test {
                 addresses.getAddress("MOONWELL_cbETH")
             );
             assertEq(address(vault.comptroller()), unitroller);
-            assertEq(vault.rewardRecipient(), rewardRecipient);
+            assertEq(vault.rewardHandler(), rewardHandler);
 
             console.log("deployed cbETH vault: ", address(vault));
 


### PR DESCRIPTION
- `owner` to be set to multisig
- `rewardHandler` can be updated by owner
- even if owner is compromised, mtokens cannot be given allowances so vault principal is always secured and untouchable. worst case is only rewards are lost. 
- when assigning new reward handlers, owner should revokeAllowances on the old reward handler

<img width="670" alt="image" src="https://github.com/moonwell-fi/moonwell-contracts-v2/assets/985052/12fb76a8-b10f-4fd9-819f-d4500ec12604">
