### PR TITLE
Renames USDC -> USDbC

### DIFF
--- a/docs/MULTIREWARDDISTRIBUTOR.md
+++ b/docs/MULTIREWARDDISTRIBUTOR.md
@@ -1,6 +1,6 @@
 # MultiRewardDistributor
 
-The MultiRewardDistributor contract is responsible for distributing rewards to users for interacting with the protocol. The logic for this contract was inspired by the flywheel logic in the Comptroller. The MultiRewardDistributor allows for distributions of multiple token types per MToken. This means that a user could mint as an example mUSDC, and then receive rewards in WELL, USDC and WETH.
+The MultiRewardDistributor contract is responsible for distributing rewards to users for interacting with the protocol. The logic for this contract was inspired by the flywheel logic in the Comptroller. The MultiRewardDistributor allows for distributions of multiple token types per MToken. This means that a user could mint as an example mUSDbC, and then receive rewards in WELL, USDC and WETH.
 
 
 ## Upgradability

--- a/src/4626/4626Deploy.sol
+++ b/src/4626/4626Deploy.sol
@@ -12,7 +12,7 @@ contract Compound4626Deploy {
         /// deploy the ERC20 wrapper for USDC
         CompoundERC4626 usdcVault = new CompoundERC4626(
             ERC20(addresses.getAddress("USDC")),
-            MErc20(addresses.getAddress("MOONWELL_USDC")),
+            MErc20(addresses.getAddress("MOONWELL_USDBC")),
             rewardReceiver,
             IComptroller(addresses.getAddress("UNITROLLER"))
         );

--- a/test/integration/BaseLiveSystem.t.sol
+++ b/test/integration/BaseLiveSystem.t.sol
@@ -104,19 +104,19 @@ contract LiveSystemBaseTest is Test, Configs {
 
     function testEmissionsAdminCanChangeRewardStream() public {
         address emissionsAdmin = addresses.getAddress("DAI_EMISSIONS_ADMIN");
-        MToken musdc = MToken(addresses.getAddress("MOONWELL_USDC"));
+        MToken mUSDbC = MToken(addresses.getAddress("MOONWELL_USDBC"));
 
         vm.prank(emissionsAdmin);
-        mrd._updateOwner(musdc, address(well), emissionsAdmin);
+        mrd._updateOwner(mUSDbC, address(well), emissionsAdmin);
 
         vm.prank(emissionsAdmin);
-        mrd._updateBorrowSpeed(musdc, address(well), 1e18);
+        mrd._updateBorrowSpeed(mUSDbC, address(well), 1e18);
     }
 
     function testUpdateEmissionConfigSupplyUsdcSuccess() public {
         vm.startPrank(addresses.getAddress("TEMPORAL_GOVERNOR"));
         mrd._updateSupplySpeed(
-            MToken(addresses.getAddress("MOONWELL_USDC")), /// reward mUSDC
+            MToken(addresses.getAddress("MOONWELL_USDBC")), /// reward mUSDbC
             well, /// rewards paid in WELL
             1e18 /// pay 1 well per second in rewards
         );
@@ -130,7 +130,7 @@ contract LiveSystemBaseTest is Test, Configs {
 
         MultiRewardDistributorCommon.MarketConfig memory config = mrd
             .getConfigForMarket(
-                MToken(addresses.getAddress("MOONWELL_USDC")),
+                MToken(addresses.getAddress("MOONWELL_USDBC")),
                 addresses.getAddress("WELL")
             );
 
@@ -147,7 +147,7 @@ contract LiveSystemBaseTest is Test, Configs {
     function testUpdateEmissionConfigBorrowUsdcSuccess() public {
         vm.startPrank(addresses.getAddress("DAI_EMISSIONS_ADMIN"));
         mrd._updateBorrowSpeed(
-            MToken(addresses.getAddress("MOONWELL_USDC")), /// reward mUSDC
+            MToken(addresses.getAddress("MOONWELL_USDBC")), /// reward mUSDbC
             well, /// rewards paid in WELL
             1e18 /// pay 1 well per second in rewards to borrowers
         );
@@ -161,7 +161,7 @@ contract LiveSystemBaseTest is Test, Configs {
 
         MultiRewardDistributorCommon.MarketConfig memory config = mrd
             .getConfigForMarket(
-                MToken(addresses.getAddress("MOONWELL_USDC")),
+                MToken(addresses.getAddress("MOONWELL_USDBC")),
                 addresses.getAddress("WELL")
             );
 
@@ -222,7 +222,7 @@ contract LiveSystemBaseTest is Test, Configs {
 
         IERC20 token = IERC20(addresses.getAddress("USDC"));
         MErc20Delegator mToken = MErc20Delegator(
-            payable(addresses.getAddress("MOONWELL_USDC"))
+            payable(addresses.getAddress("MOONWELL_USDBC"))
         );
         uint256 startingTokenBalance = token.balanceOf(address(mToken));
 
@@ -243,7 +243,7 @@ contract LiveSystemBaseTest is Test, Configs {
         assertTrue(
             comptroller.checkMembership(
                 sender,
-                MToken(addresses.getAddress("MOONWELL_USDC"))
+                MToken(addresses.getAddress("MOONWELL_USDBC"))
             )
         ); /// ensure sender and mToken is in market
 
@@ -311,7 +311,7 @@ contract LiveSystemBaseTest is Test, Configs {
 
         IERC20 token = IERC20(addresses.getAddress("USDC"));
         MErc20Delegator mToken = MErc20Delegator(
-            payable(addresses.getAddress("MOONWELL_USDC"))
+            payable(addresses.getAddress("MOONWELL_USDBC"))
         );
 
         address[] memory mTokens = new address[](1);
@@ -345,13 +345,13 @@ contract LiveSystemBaseTest is Test, Configs {
         );
 
         address[] memory mTokens = new address[](1);
-        mTokens[0] = addresses.getAddress("MOONWELL_USDC");
+        mTokens[0] = addresses.getAddress("MOONWELL_USDBC");
 
         comptroller.enterMarkets(mTokens);
         assertTrue(
             comptroller.checkMembership(
                 sender,
-                MToken(addresses.getAddress("MOONWELL_USDC"))
+                MToken(addresses.getAddress("MOONWELL_USDBC"))
             )
         ); /// ensure sender and mToken is in market
 
@@ -385,7 +385,7 @@ contract LiveSystemBaseTest is Test, Configs {
 
         MultiRewardDistributorCommon.RewardInfo[] memory rewards = mrd
             .getOutstandingRewardsForUser(
-                MToken(addresses.getAddress("MOONWELL_USDC")),
+                MToken(addresses.getAddress("MOONWELL_USDBC")),
                 address(this)
             );
 
@@ -413,7 +413,7 @@ contract LiveSystemBaseTest is Test, Configs {
 
         MultiRewardDistributorCommon.RewardInfo[] memory rewards = mrd
             .getOutstandingRewardsForUser(
-                MToken(addresses.getAddress("MOONWELL_USDC")),
+                MToken(addresses.getAddress("MOONWELL_USDBC")),
                 address(this)
             );
 
@@ -443,7 +443,7 @@ contract LiveSystemBaseTest is Test, Configs {
 
         MultiRewardDistributorCommon.RewardInfo[] memory rewards = mrd
             .getOutstandingRewardsForUser(
-                MToken(addresses.getAddress("MOONWELL_USDC")),
+                MToken(addresses.getAddress("MOONWELL_USDBC")),
                 address(this)
             );
 
@@ -474,7 +474,7 @@ contract LiveSystemBaseTest is Test, Configs {
 
         vm.warp(block.timestamp + toWarp);
 
-        MToken mToken = MToken(addresses.getAddress("MOONWELL_USDC"));
+        MToken mToken = MToken(addresses.getAddress("MOONWELL_USDBC"));
 
         /// borrower is now underwater on loan
         deal(
@@ -512,7 +512,7 @@ contract LiveSystemBaseTest is Test, Configs {
 
         MultiRewardDistributorCommon.RewardInfo[] memory rewards = mrd
             .getOutstandingRewardsForUser(
-                MToken(addresses.getAddress("MOONWELL_USDC")),
+                MToken(addresses.getAddress("MOONWELL_USDBC")),
                 address(this)
             );
 
@@ -555,7 +555,7 @@ contract LiveSystemBaseTest is Test, Configs {
         testMintMWethMTokenSucceeds();
 
         address[] memory mTokens = new address[](3);
-        mTokens[0] = addresses.getAddress("MOONWELL_USDC");
+        mTokens[0] = addresses.getAddress("MOONWELL_USDBC");
         mTokens[1] = addresses.getAddress("MOONWELL_WETH");
         mTokens[2] = addresses.getAddress("MOONWELL_cbETH");
 
@@ -566,7 +566,7 @@ contract LiveSystemBaseTest is Test, Configs {
 
         MToken[] memory assets = comptroller.getAssetsIn(address(this));
 
-        assertEq(address(assets[0]), addresses.getAddress("MOONWELL_USDC"));
+        assertEq(address(assets[0]), addresses.getAddress("MOONWELL_USDBC"));
         assertEq(address(assets[1]), addresses.getAddress("MOONWELL_WETH"));
         assertEq(address(assets[2]), addresses.getAddress("MOONWELL_cbETH"));
     }
@@ -575,7 +575,7 @@ contract LiveSystemBaseTest is Test, Configs {
         testAddLiquidityMultipleAssets();
 
         uint256 usdcMintAmount = _getMaxSupplyAmount(
-            addresses.getAddress("MOONWELL_USDC")
+            addresses.getAddress("MOONWELL_USDBC")
         );
         uint256 wethMintAmount = _getMaxSupplyAmount(
             addresses.getAddress("MOONWELL_WETH")
@@ -584,7 +584,7 @@ contract LiveSystemBaseTest is Test, Configs {
             addresses.getAddress("MOONWELL_cbETH")
         ) - 100e18;
 
-        _addLiquidity(addresses.getAddress("MOONWELL_USDC"), usdcMintAmount);
+        _addLiquidity(addresses.getAddress("MOONWELL_USDBC"), usdcMintAmount);
         _addLiquidity(addresses.getAddress("MOONWELL_WETH"), wethMintAmount);
         _addLiquidity(addresses.getAddress("MOONWELL_cbETH"), cbEthMintAmount);
 
@@ -652,11 +652,11 @@ contract LiveSystemBaseTest is Test, Configs {
         testAddCloseToMaxLiquidity();
 
         uint256 borrowAmount = _getMaxSupplyAmount(
-            addresses.getAddress("MOONWELL_USDC")
+            addresses.getAddress("MOONWELL_USDBC")
         );
-        address musdc = addresses.getAddress("MOONWELL_USDC");
+        address mUSDbC = addresses.getAddress("MOONWELL_USDBC");
 
-        assertEq(MErc20(musdc).borrow(borrowAmount), 0);
+        assertEq(MErc20(mUSDbC).borrow(borrowAmount), 0);
         assertEq(
             IERC20(addresses.getAddress("USDC")).balanceOf(address(this)),
             borrowAmount

--- a/test/integration/CompoundERC4626.t.sol
+++ b/test/integration/CompoundERC4626.t.sol
@@ -230,24 +230,24 @@ contract CompoundERC4626LiveSystemBaseTest is Test, Compound4626Deploy {
 
     function testMaxMint() public {
         uint256 maxMint = vault.maxMint(address(this));
-        uint256 borrowCap = comptroller.borrowCaps(
+        uint256 supplyCap = comptroller.supplyCaps(
             addresses.getAddress("MOONWELL_USDBC")
         );
 
         assertGt(maxMint, 0);
         assertGt(maxMint, 10_000_000e6);
-        assertLt(maxMint, borrowCap);
+        assertLt(maxMint, supplyCap);
     }
 
     function testMaxMintDepositSucceedsMaxMintZero() public {
         uint256 maxMint = vault.maxMint(address(this));
-        uint256 borrowCap = comptroller.borrowCaps(
+        uint256 supplyCap = comptroller.supplyCaps(
             addresses.getAddress("MOONWELL_USDBC")
         );
 
         assertGt(maxMint, 0);
         assertGt(maxMint, 10_000_000e6);
-        assertLt(maxMint, borrowCap);
+        assertLt(maxMint, supplyCap);
 
         deal(address(underlying), address(this), maxMint);
 

--- a/test/integration/CompoundERC4626.t.sol
+++ b/test/integration/CompoundERC4626.t.sol
@@ -61,7 +61,7 @@ contract CompoundERC4626LiveSystemBaseTest is Test, Compound4626Deploy {
         assertEq(address(vault.asset()), address(underlying));
         assertEq(
             address(vault.mToken()),
-            addresses.getAddress("MOONWELL_USDC")
+            addresses.getAddress("MOONWELL_USDBC")
         );
         assertEq(
             address(vault.comptroller()),
@@ -153,7 +153,7 @@ contract CompoundERC4626LiveSystemBaseTest is Test, Compound4626Deploy {
 
     function testWithdrawWithZeroCashFails() public {
         testMaxMintDepositSucceedsMaxMintZero();
-        deal(address(underlying), addresses.getAddress("MOONWELL_USDC"), 0);
+        deal(address(underlying), addresses.getAddress("MOONWELL_USDBC"), 0);
 
         uint256 withdrawAmount = vault.balanceOf(address(this));
 
@@ -185,7 +185,7 @@ contract CompoundERC4626LiveSystemBaseTest is Test, Compound4626Deploy {
 
     function testSweepFailsMToken() public {
         address[] memory tokens = new address[](1);
-        tokens[0] = addresses.getAddress("MOONWELL_USDC");
+        tokens[0] = addresses.getAddress("MOONWELL_USDBC");
 
         vm.expectRevert("CompoundERC4626: cannot sweep mToken");
         vm.prank(rewardRecipient);
@@ -207,7 +207,7 @@ contract CompoundERC4626LiveSystemBaseTest is Test, Compound4626Deploy {
     function testMintGuardianPausedMaxMintReturnsZero() public {
         vm.startPrank(addresses.getAddress("TEMPORAL_GOVERNOR"));
         comptroller._setMintPaused(
-            MToken(addresses.getAddress("MOONWELL_USDC")),
+            MToken(addresses.getAddress("MOONWELL_USDBC")),
             true
         );
         vm.stopPrank();
@@ -220,7 +220,7 @@ contract CompoundERC4626LiveSystemBaseTest is Test, Compound4626Deploy {
         supplyCaps[0] = 0;
 
         MToken[] memory mTokens = new MToken[](1);
-        mTokens[0] = MToken(addresses.getAddress("MOONWELL_USDC"));
+        mTokens[0] = MToken(addresses.getAddress("MOONWELL_USDBC"));
 
         vm.prank(addresses.getAddress("TEMPORAL_GOVERNOR"));
         comptroller._setMarketSupplyCaps(mTokens, supplyCaps);
@@ -231,7 +231,7 @@ contract CompoundERC4626LiveSystemBaseTest is Test, Compound4626Deploy {
     function testMaxMint() public {
         uint256 maxMint = vault.maxMint(address(this));
         uint256 borrowCap = comptroller.borrowCaps(
-            addresses.getAddress("MOONWELL_USDC")
+            addresses.getAddress("MOONWELL_USDBC")
         );
 
         assertGt(maxMint, 0);
@@ -242,7 +242,7 @@ contract CompoundERC4626LiveSystemBaseTest is Test, Compound4626Deploy {
     function testMaxMintDepositSucceedsMaxMintZero() public {
         uint256 maxMint = vault.maxMint(address(this));
         uint256 borrowCap = comptroller.borrowCaps(
-            addresses.getAddress("MOONWELL_USDC")
+            addresses.getAddress("MOONWELL_USDBC")
         );
 
         assertGt(maxMint, 0);
@@ -324,7 +324,7 @@ contract CompoundERC4626LiveSystemBaseTest is Test, Compound4626Deploy {
         supplyCaps[0] = 0;
 
         MToken[] memory mTokens = new MToken[](1);
-        mTokens[0] = MToken(addresses.getAddress("MOONWELL_USDC"));
+        mTokens[0] = MToken(addresses.getAddress("MOONWELL_USDBC"));
 
         vm.startPrank(addresses.getAddress("TEMPORAL_GOVERNOR"));
         comptroller._setMarketSupplyCaps(mTokens, supplyCaps);

--- a/test/integration/IRModelWethUpgradeLiveSystem.t.sol
+++ b/test/integration/IRModelWethUpgradeLiveSystem.t.sol
@@ -17,7 +17,7 @@ contract IRModelWethUpgradeLiveSystemBaseTest is Test, Configs {
     Comptroller comptroller;
     TestProposals proposals;
     Addresses addresses;
-    MErc20 mUsdc;
+    MErc20 mUSDbC;
     MErc20 mWeth;
     MErc20 mcbEth;
 
@@ -40,7 +40,7 @@ contract IRModelWethUpgradeLiveSystemBaseTest is Test, Configs {
             true
         ); /// only setup after deploy, build, and run, do not validate
         comptroller = Comptroller(addresses.getAddress("UNITROLLER"));
-        mUsdc = MErc20(addresses.getAddress("MOONWELL_USDC"));
+        mUSDbC = MErc20(addresses.getAddress("MOONWELL_USDBC"));
         mWeth = MErc20(addresses.getAddress("MOONWELL_WETH"));
         mcbEth = MErc20(addresses.getAddress("MOONWELL_cbETH"));
     }

--- a/test/integration/LiveSystem.t.sol
+++ b/test/integration/LiveSystem.t.sol
@@ -75,19 +75,19 @@ contract LiveSystemTest is Test {
 
     function testEmissionsAdminCanChangeRewardStream() public {
         address emissionsAdmin = addresses.getAddress("EMISSIONS_ADMIN");
-        MToken musdc = MToken(addresses.getAddress("MOONWELL_USDC"));
+        MToken mUSDbC = MToken(addresses.getAddress("MOONWELL_USDBC"));
 
         vm.prank(emissionsAdmin);
-        mrd._updateOwner(musdc, address(well), emissionsAdmin);
+        mrd._updateOwner(mUSDbC, address(well), emissionsAdmin);
 
         vm.prank(emissionsAdmin);
-        mrd._updateBorrowSpeed(musdc, address(well), 1e18);
+        mrd._updateBorrowSpeed(mUSDbC, address(well), 1e18);
     }
 
     function testUpdateEmissionConfigSupplyUsdcSuccess() public {
         vm.startPrank(addresses.getAddress("TEMPORAL_GOVERNOR"));
         mrd._updateSupplySpeed(
-            MToken(addresses.getAddress("MOONWELL_USDC")), /// reward mUSDC
+            MToken(addresses.getAddress("MOONWELL_USDBC")), /// reward mUSDbC
             well, /// rewards paid in WELL
             1e18 /// pay 1 well per second in rewards
         );
@@ -101,7 +101,7 @@ contract LiveSystemTest is Test {
 
         MultiRewardDistributorCommon.MarketConfig memory config = mrd
             .getConfigForMarket(
-                MToken(addresses.getAddress("MOONWELL_USDC")),
+                MToken(addresses.getAddress("MOONWELL_USDBC")),
                 addresses.getAddress("WELL")
             );
 
@@ -116,7 +116,7 @@ contract LiveSystemTest is Test {
     function testUpdateEmissionConfigBorrowUsdcSuccess() public {
         vm.startPrank(addresses.getAddress("EMISSIONS_ADMIN"));
         mrd._updateBorrowSpeed(
-            MToken(addresses.getAddress("MOONWELL_USDC")), /// reward mUSDC
+            MToken(addresses.getAddress("MOONWELL_USDBC")), /// reward mUSDbC
             well, /// rewards paid in WELL
             1e18 /// pay 1 well per second in rewards to borrowers
         );
@@ -130,7 +130,7 @@ contract LiveSystemTest is Test {
 
         MultiRewardDistributorCommon.MarketConfig memory config = mrd
             .getConfigForMarket(
-                MToken(addresses.getAddress("MOONWELL_USDC")),
+                MToken(addresses.getAddress("MOONWELL_USDBC")),
                 addresses.getAddress("WELL")
             );
 
@@ -148,7 +148,7 @@ contract LiveSystemTest is Test {
 
         IERC20 token = IERC20(addresses.getAddress("USDC"));
         MErc20Delegator mToken = MErc20Delegator(
-            payable(addresses.getAddress("MOONWELL_USDC"))
+            payable(addresses.getAddress("MOONWELL_USDBC"))
         );
         uint256 startingTokenBalance = token.balanceOf(address(mToken));
 
@@ -171,7 +171,7 @@ contract LiveSystemTest is Test {
 
         IERC20 token = IERC20(addresses.getAddress("USDC"));
         MErc20Delegator mToken = MErc20Delegator(
-            payable(addresses.getAddress("MOONWELL_USDC"))
+            payable(addresses.getAddress("MOONWELL_USDBC"))
         );
 
         address[] memory mTokens = new address[](1);
@@ -206,13 +206,13 @@ contract LiveSystemTest is Test {
         );
 
         address[] memory mTokens = new address[](1);
-        mTokens[0] = addresses.getAddress("MOONWELL_USDC");
+        mTokens[0] = addresses.getAddress("MOONWELL_USDBC");
 
         comptroller.enterMarkets(mTokens);
         assertTrue(
             comptroller.checkMembership(
                 sender,
-                MToken(addresses.getAddress("MOONWELL_USDC"))
+                MToken(addresses.getAddress("MOONWELL_USDBC"))
             )
         ); /// ensure sender and mToken is in market
 
@@ -242,7 +242,7 @@ contract LiveSystemTest is Test {
 
         MultiRewardDistributorCommon.RewardInfo[] memory rewards = mrd
             .getOutstandingRewardsForUser(
-                MToken(addresses.getAddress("MOONWELL_USDC")),
+                MToken(addresses.getAddress("MOONWELL_USDBC")),
                 address(this)
             );
 
@@ -272,7 +272,7 @@ contract LiveSystemTest is Test {
 
         MultiRewardDistributorCommon.RewardInfo[] memory rewards = mrd
             .getOutstandingRewardsForUser(
-                MToken(addresses.getAddress("MOONWELL_USDC")),
+                MToken(addresses.getAddress("MOONWELL_USDBC")),
                 address(this)
             );
 
@@ -303,7 +303,7 @@ contract LiveSystemTest is Test {
 
         MultiRewardDistributorCommon.RewardInfo[] memory rewards = mrd
             .getOutstandingRewardsForUser(
-                MToken(addresses.getAddress("MOONWELL_USDC")),
+                MToken(addresses.getAddress("MOONWELL_USDBC")),
                 address(this)
             );
 
@@ -337,7 +337,7 @@ contract LiveSystemTest is Test {
 
         vm.warp(block.timestamp + toWarp);
 
-        MToken mToken = MToken(addresses.getAddress("MOONWELL_USDC"));
+        MToken mToken = MToken(addresses.getAddress("MOONWELL_USDBC"));
 
         /// borrower is now underwater on loan
         deal(
@@ -375,7 +375,7 @@ contract LiveSystemTest is Test {
 
         MultiRewardDistributorCommon.RewardInfo[] memory rewards = mrd
             .getOutstandingRewardsForUser(
-                MToken(addresses.getAddress("MOONWELL_USDC")),
+                MToken(addresses.getAddress("MOONWELL_USDBC")),
                 address(this)
             );
 

--- a/test/integration/SupplyBorrowCapsBaseLiveSystem.t.sol
+++ b/test/integration/SupplyBorrowCapsBaseLiveSystem.t.sol
@@ -17,7 +17,7 @@ contract SupplyBorrowCapsLiveSystemBaseTest is Test, Configs {
     Comptroller comptroller;
     TestProposals proposals;
     Addresses addresses;
-    MErc20 mUsdc;
+    MErc20 mUSDbC;
     MErc20 mWeth;
     MErc20 mcbEth;
 
@@ -48,18 +48,18 @@ contract SupplyBorrowCapsLiveSystemBaseTest is Test, Configs {
         ); /// only build, run and validate
         addresses = proposals.addresses();
         comptroller = Comptroller(addresses.getAddress("UNITROLLER"));
-        mUsdc = MErc20(addresses.getAddress("MOONWELL_USDC"));
+        mUSDbC = MErc20(addresses.getAddress("MOONWELL_USDBC"));
         mWeth = MErc20(addresses.getAddress("MOONWELL_WETH"));
         mcbEth = MErc20(addresses.getAddress("MOONWELL_cbETH"));
     }
 
     function testSupplyingOverSupplyCapFailsUsdc() public {
-        address underlying = address(mUsdc.underlying());
+        address underlying = address(mUSDbC.underlying());
         deal(underlying, address(this), 50_000_000e6);
 
-        IERC20(underlying).approve(address(mUsdc), 50_000_000e6);
+        IERC20(underlying).approve(address(mUSDbC), 50_000_000e6);
         vm.expectRevert("market supply cap reached");
-        mUsdc.mint(50_000_000e6);
+        mUSDbC.mint(50_000_000e6);
     }
 
     function testSupplyingOverSupplyCapFailsWeth() public {
@@ -133,23 +133,23 @@ contract SupplyBorrowCapsLiveSystemBaseTest is Test, Configs {
 
     function testBorrowingOverBorrowCapFailsUsdc() public {
         uint256 usdcMintAmount = _getMaxSupplyAmount(
-            addresses.getAddress("MOONWELL_USDC")
+            addresses.getAddress("MOONWELL_USDBC")
         ) - 1_000e6;
         uint256 borrowAmount = 33_000_000e6;
-        address underlying = address(mUsdc.underlying());
+        address underlying = address(mUSDbC.underlying());
 
         deal(underlying, address(this), usdcMintAmount);
 
-        IERC20(underlying).approve(address(mUsdc), usdcMintAmount);
-        mUsdc.mint(usdcMintAmount);
+        IERC20(underlying).approve(address(mUSDbC), usdcMintAmount);
+        mUSDbC.mint(usdcMintAmount);
 
         address[] memory mToken = new address[](1);
-        mToken[0] = address(mUsdc);
+        mToken[0] = address(mUSDbC);
 
         comptroller.enterMarkets(mToken);
 
         vm.expectRevert("market borrow cap reached");
-        mUsdc.borrow(borrowAmount);
+        mUSDbC.borrow(borrowAmount);
     }
 
     function _getMaxSupplyAmount(

--- a/test/proposals/Addresses.sol
+++ b/test/proposals/Addresses.sol
@@ -215,12 +215,12 @@ contract Addresses is Test, ChainIds {
             0x8DDc78645E18CDb4b6fcE65777642ef4fFdC6115
         );
         _addAddress(
-            "JUMP_RATE_IRM_MOONWELL_USDC",
+            "JUMP_RATE_IRM_MOONWELL_USDBC",
             84531,
             0x4696f537Ad80ef53D314624AD502f9d82397357e
         );
         _addAddress(
-            "MOONWELL_USDC",
+            "MOONWELL_USDBC",
             84531,
             0x765741AB1937d85D4758e004Ef906A5E18839EFe
         );
@@ -489,7 +489,7 @@ contract Addresses is Test, ChainIds {
             0x1FADFF493529C3Fcc7EE04F1f15D19816ddA45B7
         );
         _addAddress(
-            "JUMP_RATE_IRM_MOONWELL_USDC",
+            "JUMP_RATE_IRM_MOONWELL_USDBC",
             8453,
             0x1603178b26C3bc2cd321e9A64644ab62643d138B
         );
@@ -504,7 +504,7 @@ contract Addresses is Test, ChainIds {
             0xbc93DdFAE192926BE036c6A6Dd544a0e250Ab97D
         );
         _addAddress(
-            "MOONWELL_USDC",
+            "MOONWELL_USDBC",
             8453,
             0x703843C3379b52F9FF486c9f5892218d2a065cC8
         );

--- a/test/proposals/Configs.sol
+++ b/test/proposals/Configs.sol
@@ -235,8 +235,8 @@ contract Configs is Test {
                     priceFeedName: "USDC_ORACLE",
                     tokenAddressName: "USDC",
                     name: "Moonwell USDC",
-                    symbol: "mUSDC",
-                    addressesString: "MOONWELL_USDC",
+                    symbol: "mUSDbC",
+                    addressesString: "MOONWELL_USDBC",
                     jrm: jrmConfig
                 });
 
@@ -303,8 +303,8 @@ contract Configs is Test {
                     priceFeedName: "USDC_ORACLE",
                     tokenAddressName: "USDC",
                     name: "Moonwell USDC",
-                    symbol: "mUSDC",
-                    addressesString: "MOONWELL_USDC",
+                    symbol: "mUSDbC",
+                    addressesString: "MOONWELL_USDBC",
                     jrm: jrmConfigUSDC
                 });
 

--- a/test/proposals/Deploy4626Vaults.s.sol
+++ b/test/proposals/Deploy4626Vaults.s.sol
@@ -78,7 +78,7 @@ contract Deploy4626Vaults is Script, Compound4626Deploy, Test {
             assertEq(address(vault.asset()), addresses.getAddress("USDC"));
             assertEq(
                 address(vault.mToken()),
-                addresses.getAddress("MOONWELL_USDC")
+                addresses.getAddress("MOONWELL_USDBC")
             );
             assertEq(address(vault.comptroller()), unitroller);
             assertEq(vault.rewardRecipient(), rewardRecipient);

--- a/test/proposals/mainnetMTokensExample.json
+++ b/test/proposals/mainnetMTokensExample.json
@@ -9,8 +9,8 @@
         "priceFeedName": "USDC_ORACLE",
         "tokenAddressName": "USDC",
         "name": "Moonwell USDC",
-        "symbol": "mUSDC",
-        "addressesString": "MOONWELL_USDC",
+        "symbol": "mUSDbC",
+        "addressesString": "MOONWELL_USDBC",
         "jrm": {
             "baseRatePerYear": 0,
             "multiplierPerYear": 0.05e18,

--- a/test/proposals/mainnetRewardStreams.json
+++ b/test/proposals/mainnetRewardStreams.json
@@ -2,7 +2,7 @@
     {
         "borrowEmissionsPerSec": 1,
         "emissionToken": "0xFF8adeC2221f9f4D8dfbAFa6B9a297d17603493D",
-        "endTime": 1694210400,
+        "endTime": 1696629600,
         "mToken": "MOONWELL_USDBC",
         "owner": "EMISSIONS_ADMIN",
         "supplyEmissionPerSec": 0

--- a/test/proposals/mainnetRewardStreams.json
+++ b/test/proposals/mainnetRewardStreams.json
@@ -3,7 +3,7 @@
         "borrowEmissionsPerSec": 1,
         "emissionToken": "0xFF8adeC2221f9f4D8dfbAFa6B9a297d17603493D",
         "endTime": 1694210400,
-        "mToken": "MOONWELL_USDC",
+        "mToken": "MOONWELL_USDBC",
         "owner": "EMISSIONS_ADMIN",
         "supplyEmissionPerSec": 0
     },

--- a/test/proposals/mips/examples/mip-market-listing/MTokens.json
+++ b/test/proposals/mips/examples/mip-market-listing/MTokens.json
@@ -1,6 +1,6 @@
 [
     {
-        "addressesString": "MOONWELL_DAI",
+        "addressesString": "MOONWELL_USDBC",
         "supplyCap": 6000000e18,
         "borrowCap": 5000000e18,
         "collateralFactor": 0.8e18,

--- a/test/unit/HundredFinanceExploit.t.sol
+++ b/test/unit/HundredFinanceExploit.t.sol
@@ -26,7 +26,7 @@ contract HundredFinanceExploitTest is
     FaucetToken faucetToken;
     MErc20Immutable collateralToken;
     InterestRateModel irModel;
-    MErc20Immutable mUsdc;
+    MErc20Immutable mUSDbC;
     IERC20 usdc;
 
     address otherUser = vm.addr(1);
@@ -47,7 +47,7 @@ contract HundredFinanceExploitTest is
             addresses.getAddress("MOONWELL_WBTC")
         );
 
-        mUsdc = MErc20Immutable(addresses.getAddress("MOONWELL_USDC"));
+        mUSDbC = MErc20Immutable(addresses.getAddress("MOONWELL_USDBC"));
 
         vm.prank(addresses.getAddress("TEMPORAL_GOVERNOR"));
         oracle.setUnderlyingPrice(
@@ -58,8 +58,8 @@ contract HundredFinanceExploitTest is
         deal(address(usdc), otherUser, 1000e18);
 
         vm.startPrank(otherUser);
-        usdc.approve(address(mUsdc), 1000e6);
-        mUsdc.mint(1000e6);
+        usdc.approve(address(mUSDbC), 1000e6);
+        mUSDbC.mint(1000e6);
         vm.stopPrank();
 
         vm.label(address(this), "TEST CONTRACT");
@@ -93,7 +93,7 @@ contract HundredFinanceExploitTest is
         faucetToken.transfer(address(collateralToken), 500e8);
 
         // Go borrow all USDC in market
-        mUsdc.borrow(usdc.balanceOf(address(mUsdc)));
+        mUSDbC.borrow(usdc.balanceOf(address(mUSDbC)));
 
         // We now have a lot of liquidity here
         (, liquidity, shortfall) = comptroller.getAccountLiquidity(
@@ -164,7 +164,7 @@ contract HundredFinanceExploitTest is
         assertEq(shortfall, 0);
 
         // We can now borrow everything in the markets due to the massively inflated exchange rate
-        mUsdc.borrow(usdc.balanceOf(address(mUsdc)));
+        mUSDbC.borrow(usdc.balanceOf(address(mUSDbC)));
 
         // Now we can go call `redeemUnderlying` with everything in the market minus 1wei
         // which won't burn any mTokens but WILL transfer us the requested funds, not being


### PR DESCRIPTION
@ElliotFriedman I only did a global search and replace for `MOONWELL_USDC` to `MOONWELL_USDBC` and `mUSDC` to `mUSDbC`,  so I would appreciate a careful review to ensure this doesn't break tests. Thanks!