### PR TITLE
Add MIP-B11

### DIFF
--- a/proposals/MIPB11.json
+++ b/proposals/MIPB11.json
@@ -1,0 +1,42 @@
+{
+    "title": "MIP-B11: Gauntlet's BASE Recommendations",
+    "commands": [
+        {
+            "target": "{UNITROLLER}",
+            "values": "0",
+            "method": "_setCollateralFactor(address,uint256)",
+            "arguments": [
+                "{MOONWELL_wstETH}",
+                "0.75e18"
+            ],
+            "description": "Set collateral factor for wstETH to 75%"
+        },
+        {
+            "target": "{MOONWELL_DAI}",
+            "values": "0",
+            "method": "_setInterestRateModel(address)",
+            "arguments": [
+                "{JUMP_RATE_IRM_MOONWELL_DAI}"
+            ],
+            "description": "Set interest rate model for Moonwell DAI to updated rate model"
+        },
+        {
+            "target": "{MOONWELL_USDC}",
+            "values": "0",
+            "method": "_setInterestRateModel(address)",
+            "arguments": [
+                "{JUMP_RATE_IRM_MOONWELL_USDC}"
+            ],
+            "description": "Set interest rate model for Moonwell USDC to updated rate model"
+        },
+        {
+            "target": "{MOONWELL_USDBC}",
+            "values": "0",
+            "method": "_setInterestRateModel(address)",
+            "arguments": [
+                "{JUMP_RATE_IRM_MOONWELL_USDBC}"
+            ],
+            "description": "Set interest rate model for Moonwell USDbC to updated rate model"
+        }
+    ]
+}

--- a/src/proposals/mips/mip-b11/MIP-B11.md
+++ b/src/proposals/mips/mip-b11/MIP-B11.md
@@ -1,0 +1,33 @@
+# MIP-B11: Gauntlet's BASE Recommendations
+
+# Simple Summary
+
+### Risk Parameters
+
+A proposal to adjust 1 risk parameters:
+
+| Risk Parameter           | Current Value | Recommended Value |
+| ------------------------ | ------------- | ----------------- |
+| wstETH Collateral Factor | 75%           | 76%               |
+
+### IR Parameters
+
+A proposal to adjust 2 IR curves:
+
+| USDbC IR Parameters | Current | Recommended |
+| ------------------- | ------- | ----------- |
+| Base                | 0       | 0           |
+| Kink                | 0.8     | 0.7         |
+| Multiplier          | 0.045   | 0.057       |
+| Jump Multiplier     | 8.6     | 5.7         |
+
+| DAI and USDC IR Parameters | Current | Recommended |
+| -------------------------- | ------- | ----------- |
+| Base                       | 0       | 0           |
+| Kink                       | 0.8     | 0.8         |
+| Multiplier                 | 0.045   | 0.05        |
+| Jump Multiplier            | 8.6     | 8.6         |
+
+Our recommendation post is located in the forums with further analysis and supporting data.
+
+_By approving this proposal, you agree that any services provided by Gauntlet shall be governed by the terms of service available at gauntlet.network/tos._

--- a/src/proposals/mips/mip-b11/mip-b11.sol
+++ b/src/proposals/mips/mip-b11/mip-b11.sol
@@ -1,0 +1,185 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+
+import "@forge-std/Test.sol";
+
+import {MToken} from "@protocol/MToken.sol";
+import {Configs} from "@proposals/Configs.sol";
+import {Proposal} from "@proposals/proposalTypes/Proposal.sol";
+import {Addresses} from "@proposals/Addresses.sol";
+import {JumpRateModel} from "@protocol/IRModels/JumpRateModel.sol";
+import {TimelockProposal} from "@proposals/proposalTypes/TimelockProposal.sol";
+import {CrossChainProposal} from "@proposals/proposalTypes/CrossChainProposal.sol";
+import {Comptroller} from "@protocol/Comptroller.sol";
+
+contract mipb11 is Proposal, CrossChainProposal, Configs {
+    string public constant name = "MIP-b11";
+    uint256 public constant timestampsPerYear = 60 * 60 * 24 * 365;
+    uint256 public constant SCALE = 1e18;
+
+    uint256 public constant wstETH_NEW_CF = 0.76e18;
+
+    constructor() {
+        bytes memory proposalDescription = abi.encodePacked(
+            vm.readFile("./src/proposals/mips/mip-b11/MIP-B11.md")
+        );
+        _setProposalDescription(proposalDescription);
+    }
+
+    struct IRParams {
+        uint256 kink;
+        uint256 baseRatePerTimestamp;
+        uint256 multiplierPerTimestamp;
+        uint256 jumpMultiplierPerTimestamp;
+    }
+
+    function _validateJRM(
+        address jrmAddress,
+        address tokenAddress,
+        IRParams memory params
+    ) internal {
+        JumpRateModel jrm = JumpRateModel(jrmAddress);
+        assertEq(
+            address(MToken(tokenAddress).interestRateModel()),
+            address(jrm),
+            "interest rate model not set correctly"
+        );
+
+        assertEq(jrm.kink(), params.kink, "kink verification failed");
+        assertEq(
+            jrm.timestampsPerYear(),
+            timestampsPerYear,
+            "timestamps per year verifiacation failed"
+        );
+        assertEq(
+            jrm.baseRatePerTimestamp(),
+            (params.baseRatePerTimestamp * SCALE) / timestampsPerYear / SCALE,
+            "base rate per timestamp validation failed"
+        );
+        assertEq(
+            jrm.multiplierPerTimestamp(),
+            (params.multiplierPerTimestamp * SCALE) / timestampsPerYear / SCALE,
+            "multiplier per timestamp validation failed"
+        );
+        assertEq(
+            jrm.jumpMultiplierPerTimestamp(),
+            (params.jumpMultiplierPerTimestamp * SCALE) /
+                timestampsPerYear /
+                SCALE,
+            "jump multiplier per timestamp validation failed"
+        );
+    }
+
+    function _validateCF(
+        Addresses addresses,
+        address tokenAddress,
+        uint256 collateralFactor
+    ) internal {
+        address unitrollerAddress = addresses.getAddress("UNITROLLER");
+        Comptroller unitroller = Comptroller(unitrollerAddress);
+
+        (bool listed, uint256 collateralFactorMantissa) = unitroller.markets(
+            tokenAddress
+        );
+
+        assertTrue(listed);
+
+        assertEq(
+            collateralFactorMantissa,
+            collateralFactor,
+            "collateral factor validation failed"
+        );
+    }
+
+    function deploy(Addresses addresses, address) public override {}
+
+    function afterDeploy(Addresses addresses, address) public override {}
+
+    function afterDeploySetup(Addresses addresses) public override {}
+
+    function build(Addresses addresses) public override {
+        address unitrollerAddress = addresses.getAddress("UNITROLLER");
+
+        _pushCrossChainAction(
+            unitrollerAddress,
+            abi.encodeWithSignature(
+                "_setCollateralFactor(address,uint256)",
+                addresses.getAddress("MOONWELL_wstETH"),
+                wstETH_NEW_CF
+            ),
+            "Set collateral factor for Moonwell wstETH to updated collateral factor"
+        );
+
+        _pushCrossChainAction(
+            addresses.getAddress("MOONWELL_DAI"),
+            abi.encodeWithSignature(
+                "_setInterestRateModel(address)",
+                addresses.getAddress("JUMP_RATE_IRM_MOONWELL_DAI")
+            ),
+            "Set interest rate model for Moonwell DAI to updated rate model"
+        );
+
+        _pushCrossChainAction(
+            addresses.getAddress("MOONWELL_USDC"),
+            abi.encodeWithSignature(
+                "_setInterestRateModel(address)",
+                addresses.getAddress("JUMP_RATE_IRM_MOONWELL_USDC")
+            ),
+            "Set interest rate model for Moonwell USDC to updated rate model"
+        );
+
+        _pushCrossChainAction(
+            addresses.getAddress("MOONWELL_USDBC"),
+            abi.encodeWithSignature(
+                "_setInterestRateModel(address)",
+                addresses.getAddress("JUMP_RATE_IRM_MOONWELL_USDBC")
+            ),
+            "Set interest rate model for Moonwell USDBC to updated rate model"
+        );
+    }
+
+    function teardown(Addresses addresses, address) public pure override {}
+
+    /// @notice assert that the new interest rate model is set correctly
+    /// and that the interest rate model parameters are set correctly
+    function validate(Addresses addresses, address) public override {
+        _validateCF(
+            addresses,
+            addresses.getAddress("MOONWELL_wstETH"),
+            wstETH_NEW_CF
+        );
+
+        _validateJRM(
+            addresses.getAddress("JUMP_RATE_IRM_MOONWELL_USDBC"),
+            addresses.getAddress("MOONWELL_USDBC"),
+            IRParams({
+                baseRatePerTimestamp: 0,
+                kink: 0.7e18,
+                multiplierPerTimestamp: 0.057e18,
+                jumpMultiplierPerTimestamp: 5.7e18
+            })
+        );
+
+        _validateJRM(
+            addresses.getAddress("JUMP_RATE_IRM_MOONWELL_USDC"),
+            addresses.getAddress("MOONWELL_USDC"),
+            IRParams({
+                baseRatePerTimestamp: 0,
+                kink: 0.8e18,
+                multiplierPerTimestamp: 0.05e18,
+                jumpMultiplierPerTimestamp: 8.6e18
+            })
+        );
+
+        _validateJRM(
+            addresses.getAddress("JUMP_RATE_IRM_MOONWELL_DAI"),
+            addresses.getAddress("MOONWELL_DAI"),
+            IRParams({
+                baseRatePerTimestamp: 0,
+                kink: 0.8e18,
+                multiplierPerTimestamp: 0.05e18,
+                jumpMultiplierPerTimestamp: 8.6e18
+            })
+        );
+    }
+}

--- a/src/proposals/utils/ParameterValidation.sol
+++ b/src/proposals/utils/ParameterValidation.sol
@@ -1,0 +1,79 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.19;
+
+import "@forge-std/Test.sol";
+
+import {Addresses} from "@proposals/Addresses.sol";
+import {JumpRateModel} from "@protocol/IRModels/JumpRateModel.sol";
+import {MToken} from "@protocol/MToken.sol";
+import {Comptroller} from "@protocol/Comptroller.sol";
+
+contract ParameterValidation is Test {
+    uint256 public constant timestampsPerYear = 60 * 60 * 24 * 365;
+    uint256 public constant SCALE = 1e18;
+
+    struct IRParams {
+        uint256 kink;
+        uint256 baseRatePerTimestamp;
+        uint256 multiplierPerTimestamp;
+        uint256 jumpMultiplierPerTimestamp;
+    }
+
+    function _validateJRM(
+        address jrmAddress,
+        address tokenAddress,
+        IRParams memory params
+    ) internal {
+        JumpRateModel jrm = JumpRateModel(jrmAddress);
+        assertEq(
+            address(MToken(tokenAddress).interestRateModel()),
+            address(jrm),
+            "interest rate model not set correctly"
+        );
+
+        assertEq(jrm.kink(), params.kink, "kink verification failed");
+        assertEq(
+            jrm.timestampsPerYear(),
+            timestampsPerYear,
+            "timestamps per year verifiacation failed"
+        );
+        assertEq(
+            jrm.baseRatePerTimestamp(),
+            (params.baseRatePerTimestamp * SCALE) / timestampsPerYear / SCALE,
+            "base rate per timestamp validation failed"
+        );
+        assertEq(
+            jrm.multiplierPerTimestamp(),
+            (params.multiplierPerTimestamp * SCALE) / timestampsPerYear / SCALE,
+            "multiplier per timestamp validation failed"
+        );
+        assertEq(
+            jrm.jumpMultiplierPerTimestamp(),
+            (params.jumpMultiplierPerTimestamp * SCALE) /
+                timestampsPerYear /
+                SCALE,
+            "jump multiplier per timestamp validation failed"
+        );
+    }
+
+    function _validateCF(
+        Addresses addresses,
+        address tokenAddress,
+        uint256 collateralFactor
+    ) internal {
+        address unitrollerAddress = addresses.getAddress("UNITROLLER");
+        Comptroller unitroller = Comptroller(unitrollerAddress);
+
+        (bool listed, uint256 collateralFactorMantissa) = unitroller.markets(
+            tokenAddress
+        );
+
+        assertTrue(listed);
+
+        assertEq(
+            collateralFactorMantissa,
+            collateralFactor,
+            "collateral factor validation failed"
+        );
+    }
+}

--- a/test/integration/SupplyBorrowCapsBaseLiveSystem.t.sol
+++ b/test/integration/SupplyBorrowCapsBaseLiveSystem.t.sol
@@ -12,11 +12,10 @@ import {Addresses} from "@proposals/Addresses.sol";
 import {Comptroller} from "@protocol/Comptroller.sol";
 import {mipb06 as mip} from "@proposals/mips/mip-b06/mip-b06.sol";
 import {TestProposals} from "@proposals/TestProposals.sol";
+import {PostProposalCheck} from "@test/integration/PostProposalCheck.sol";
 
-contract SupplyBorrowCapsLiveSystemBaseTest is Test, Configs {
+contract SupplyBorrowCapsLiveSystemBaseTest is PostProposalCheck, Configs {
     Comptroller comptroller;
-    TestProposals proposals;
-    Addresses addresses;
     MErc20 mUSDbC;
     MErc20 mWeth;
     MErc20 mcbEth;
@@ -30,23 +29,9 @@ contract SupplyBorrowCapsLiveSystemBaseTest is Test, Configs {
     /// @notice max mint amt for cbEth market
     uint256 public constant maxMintAmountcbEth = 5_000e18;
 
-    function setUp() public {
-        address[] memory mips = new address[](1);
-        mips[0] = address(new mip());
+    function setUp() public override {
+        super.setUp();
 
-        proposals = new TestProposals(mips);
-        proposals.setUp();
-        proposals.testProposals(
-            false,
-            false,
-            false,
-            true,
-            true,
-            true,
-            false,
-            true
-        ); /// only build, run and validate
-        addresses = proposals.addresses();
         comptroller = Comptroller(addresses.getAddress("UNITROLLER"));
         mUSDbC = MErc20(addresses.getAddress("MOONWELL_USDBC"));
         mWeth = MErc20(addresses.getAddress("MOONWELL_WETH"));
@@ -95,7 +80,6 @@ contract SupplyBorrowCapsLiveSystemBaseTest is Test, Configs {
 
         deal(underlying, address(this), mintAmount);
 
-        console.log("mintAmount: ", mintAmount);
         IERC20(underlying).approve(address(mcbEth), mintAmount);
         mcbEth.mint(mintAmount);
 
@@ -111,7 +95,7 @@ contract SupplyBorrowCapsLiveSystemBaseTest is Test, Configs {
     function testBorrowingOverBorrowCapFailsWeth() public {
         uint256 mintAmount = _getMaxSupplyAmount(
             addresses.getAddress("MOONWELL_WETH")
-        );
+        ) - 1e18;
         uint256 borrowAmount = _getMaxBorrowAmount(
             addresses.getAddress("MOONWELL_WETH")
         );

--- a/test/integration/wstETHIntegration.t.sol
+++ b/test/integration/wstETHIntegration.t.sol
@@ -146,8 +146,8 @@ contract wstETHLiveSystemBaseTest is Test, PostProposalCheck {
         assertApproxEqRel(
             liquidity,
             (mintAmount * price * collateralFactor) / 1e36, /// trim off both the CF and Chainlink Price feed extra precision
-            1e9,
-            "liquidity not within .0000001% of given CF"
+            1e14,
+            "liquidity not within 0.01% of given CF"
         );
         assertEq(shortfall, 0, "Incorrect shortfall");
 

--- a/utils/Addresses.json
+++ b/utils/Addresses.json
@@ -370,7 +370,7 @@
         "name": "MTOKEN_IMPLEMENTATION"
     },
     {
-        "addr": "0x492dcEF1fc5253413fC5576B9522840a1A774DCe",
+        "addr": "0xF22c8255eA615b3Da6CA5CF5aeCc8956bfF07Aa8",
         "chainId": 8453,
         "name": "JUMP_RATE_IRM_MOONWELL_USDBC"
     },
@@ -380,7 +380,7 @@
         "name": "MOONWELL_DAI"
     },
     {
-        "addr": "0x492dcEF1fc5253413fC5576B9522840a1A774DCe",
+        "addr": "0x32f3A6134590fc2d9440663d35a2F0a6265F04c4",
         "chainId": 8453,
         "name": "JUMP_RATE_IRM_MOONWELL_DAI"
     },
@@ -390,7 +390,7 @@
         "name": "MOONWELL_USDBC"
     },
     {
-        "addr": "0x492dcEF1fc5253413fC5576B9522840a1A774DCe",
+        "addr": "0x32f3A6134590fc2d9440663d35a2F0a6265F04c4",
         "chainId": 8453,
         "name": "JUMP_RATE_IRM_MOONWELL_USDC"
     },


### PR DESCRIPTION
Included `proposals/MIPB11.json` for sake of example, but ended up implementing using `mip-b11.sol` since we wanted to include the extra validation of the JRM parameters.

Aside, would you accept moving `_validateCF` and `_validateJRM` into `CrossChainProposal`? We could also add more validation functions for other parameters.