### PR TITLE
Add ParameterSetting helper contract to add utils for setting params.

### DIFF
--- a/src/proposals/utils/ParameterSetting.sol
+++ b/src/proposals/utils/ParameterSetting.sol
@@ -1,0 +1,32 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+import "@forge-std/Test.sol";
+
+import {Addresses} from "@proposals/Addresses.sol";
+import {CrossChainProposal} from "@proposals/proposalTypes/CrossChainProposal.sol";
+
+abstract contract ParameterSetting is CrossChainProposal {
+    function _setCollateralFactor(Addresses addresses, string memory asset, uint256 factor) internal {
+        address unitrollerAddress = addresses.getAddress("UNITROLLER");
+
+        _pushCrossChainAction(
+            unitrollerAddress,
+            abi.encodeWithSignature(
+                "_setCollateralFactor(address,uint256)",
+                addresses.getAddress(asset),
+                factor
+            ),
+            string.concat("Set collateral factor for ", asset)
+        );
+    }
+
+    function _setInterestRateModel(Addresses addresses, string memory asset, string memory rateModel) internal {
+        _pushCrossChainAction(
+            addresses.getAddress(asset),
+            abi.encodeWithSignature(
+                "_setInterestRateModel(address)",
+                addresses.getAddress(rateModel)
+            ),
+            string.concat("Set interest rate model for ", asset, " to ", rateModel)
+        );
+    }
+}


### PR DESCRIPTION
This is similar to `ParameterValidation.sol` and provides some basic helpers to make writing new MIPs even easier. Planning to use this in a quick generator we are writing that will enable generating MIP payload files for simple parameter update proposals.