### PR TITLE
Fix/create morpho market

### DIFF
--- a/chains/8453.json
+++ b/chains/8453.json
@@ -1183,5 +1183,35 @@
         "addr": "0x71FBaD6c2200C8A5B89380f9B6bb8a35d411c852",
         "isContract": true,
         "name": "MORPHO_CHAINLINK_WELL_USD_ORACLE"
+    },
+    {
+        "addr": "0x4073bA1AF0bD159BF5c6F85D2FC9f43EEf43b02A",
+        "isContract": true,
+        "name": "CHAINLINK_MAMO_USD_ORACLE_IMPL"
+    },
+    {
+        "addr": "0xF4DCcaE864EDF2b218B40A950c4407C3383Dadb9",
+        "isContract": true,
+        "name": "CHAINLINK_MAMO_USD_ORACLE_PROXY"
+    },
+    {
+        "addr": "0x18d1325e8528E3ceafBf9a77F3bE3f76Fec42D5C",
+        "isContract": true,
+        "name": "MORPHO_CHAINLINK_MAMO_USD_ORACLE"
+    },
+    {
+        "addr": "0xFf37a7467a80EF462Ad5d73f67F619Ca2dbb2D4B",
+        "isContract": true,
+        "name": "CHAINLINK_stkWELL_USD_ORACLE_IMPL"
+    },
+    {
+        "addr": "0x593355Faef3075AF1b20Ca22FeDAbF6F3D2FD66C",
+        "isContract": true,
+        "name": "CHAINLINK_stkWELL_USD_ORACLE_PROXY"
+    },
+    {
+        "addr": "0xc842d95b9C35bf97842110408A8C501645Fb1722",
+        "isContract": true,
+        "name": "MORPHO_CHAINLINK_stkWELL_USD_ORACLE"
     }
 ]

--- a/script/templates/CreateMorphoMarket.s.sol
+++ b/script/templates/CreateMorphoMarket.s.sol
@@ -280,7 +280,7 @@ contract CreateMorphoMarket is Script, Test {
                 ""
             );
 
-            ChainlinkOracleProxy(logic).initialize(
+            ChainlinkOracleProxy(address(proxy)).initialize(
                 addresses.getAddress(ocfg.baseFeedName),
                 addresses.getAddress("TEMPORAL_GOVERNOR")
             );

--- a/script/templates/markets/meUSDC_MAMO_MARKET.json
+++ b/script/templates/markets/meUSDC_MAMO_MARKET.json
@@ -3,7 +3,7 @@
     "loanTokenName": "USDC",
     "collateralTokenName": "MAMO",
     "irmName": "MORPHO_ADAPTIVE_CURVE_IRM",
-    "lltv": 625000000000000000,
+    "lltv": 385000000000000000,
     "supplyCap": 1000000000000,
     "setSupplyQueue": true,
     "morphoBlueName": "MORPHO_BLUE",
@@ -15,7 +15,7 @@
         "quoteFeedName": "CHAINLINK_USDC_USD",
         "quoteFeedDecimals": 6
     },
-    "vaultDepositAssets": 1e6,
-    "collateralAmount": 40e18,
-    "borrowAssets": 9e5
+    "vaultDepositAssets": 1000000,
+    "collateralAmount": 50000000000000000000,
+    "borrowAssets": 900000
 }

--- a/script/templates/markets/meUSDC_WELL_MARKET.json
+++ b/script/templates/markets/meUSDC_WELL_MARKET.json
@@ -15,7 +15,7 @@
         "quoteFeedName": "CHAINLINK_USDC_USD",
         "quoteFeedDecimals": 6
     },
-    "vaultDepositAssets": 1e6,
-    "collateralAmount": 110e18,
-    "borrowAssets": 9e5
+    "vaultDepositAssets": 1000000,
+    "collateralAmount": 110000000000000000000,
+    "borrowAssets": 900000
 }

--- a/script/templates/markets/meUSDC_stkWELL_MARKET.json
+++ b/script/templates/markets/meUSDC_stkWELL_MARKET.json
@@ -3,19 +3,19 @@
     "loanTokenName": "USDC",
     "collateralTokenName": "STK_GOVTOKEN_PROXY",
     "irmName": "MORPHO_ADAPTIVE_CURVE_IRM",
-    "lltv": 385000000000000000,
+    "lltv": 625000000000000000,
     "supplyCap": 10000000000,
     "setSupplyQueue": true,
     "morphoBlueName": "MORPHO_BLUE",
     "oracle": {
-        "addressName": "MORPHO_CHAINLINK_WELL_USD_ORACLE",
-        "proxyAddressName": "CHAINLINK_WELL_USD_ORACLE",
+        "addressName": "MORPHO_CHAINLINK_stkWELL_USD_ORACLE",
+        "proxyAddressName": "CHAINLINK_stkWELL_USD_ORACLE",
         "baseFeedName": "CHAINLINK_WELL_USD",
         "baseFeedDecimals": 18,
         "quoteFeedName": "CHAINLINK_USDC_USD",
         "quoteFeedDecimals": 6
     },
-    "vaultDepositAssets": 1e6,
-    "collateralAmount": 110e18,
-    "borrowAssets": 9e5
+    "vaultDepositAssets": 1000000,
+    "collateralAmount": 110000000000000000000,
+    "borrowAssets": 900000
 }


### PR DESCRIPTION
**Oracle contract management and configuration:**

* Added new Chainlink oracle implementation and proxy contract addresses, as well as a proxy admin, to the `chains/8453.json` configuration file. The deprecated oracle entry was renamed for clarity. [[1]](diffhunk://#diff-9f37a29600467b6e34f3bd6ec9674e3e3db9c5b96c6dcc66edbc3d8cc9c3a46cL1130-R1130) [[2]](diffhunk://#diff-9f37a29600467b6e34f3bd6ec9674e3e3db9c5b96c6dcc66edbc3d8cc9c3a46cR1166-R1215)
* Refactored the `OracleConfig` struct in `CreateMorphoMarket.s.sol` to include a `proxyAddressName` field, enabling separation between logic and proxy contracts for oracles. [[1]](diffhunk://#diff-099fece2c30b779b7dcdba06be03e0dc2da12961afd3214fcf83ef1bd7806d78R40) [[2]](diffhunk://#diff-099fece2c30b779b7dcdba06be03e0dc2da12961afd3214fcf83ef1bd7806d78R114)
* Updated the oracle deployment logic in `CreateMorphoMarket.s.sol` to deploy and register proxy contracts and proxy admin only if they do not already exist, improving upgradability and avoiding redundant deployments.

**Market configuration updates:**

* Updated market JSON templates (`meUSDC_MAMO_MARKET.json`, `meUSDC_WELL_MARKET.json`, `meUSDC_stkWELL_MARKET.json`) to use the new oracle structure, referencing the correct logic and proxy names and adjusting market parameters for consistency. [[1]](diffhunk://#diff-6d0b3421442756ad0cefc9812198ee2ebeb57d191ff0b6431040eb91614b79c1L6-R19) [[2]](diffhunk://#diff-d598b6fe2f3851f6a86209c4af3be7e0c2233d6d544f21b2924d16823f9015a5L11-R20) [[3]](diffhunk://#diff-dadbabd915831fa33865f0e94d2f1792c3159090f6a3a8f925cd467f4957f77cL6-R19)

**Script improvements:**

* Added a call to `addresses.printAddresses()` in the deployment script for easier debugging and verification of deployed contract addresses.