### PR TITLE
xwell wormhole executor migration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "lib/wormhole"]
 	path = lib/wormhole
 	url = https://github.com/wormhole-foundation/wormhole
+[submodule "lib/wormhole-solidity-sdk"]
+	path = lib/wormhole-solidity-sdk
+	url = https://github.com/wormhole-foundation/wormhole-solidity-sdk

--- a/chains/1.json
+++ b/chains/1.json
@@ -78,5 +78,25 @@
         "addr": "0x5B710010586C1b728B047c3E42473c700eeA4026",
         "isContract": true,
         "name": "BREAK_GLASS_GUARDIAN"
+    },
+    {
+        "addr": "0xF22F1c0A3a8Cb42F695601731974784C499C4EF3",
+        "isContract": true,
+        "name": "WORMHOLE_QUOTER_ROUTER"
+    },
+    {
+        "addr": "0x84EEe8dBa37C36947397E1E11251cA9A06Fc6F8a",
+        "isContract": true,
+        "name": "WORMHOLE_EXECUTOR"
+    },
+    {
+        "addr": "0xA25862D222Eb8343505c12d96e097e4332468D60",
+        "isContract": true,
+        "name": "WORMHOLE_QUOTER"
+    },
+    {
+        "addr": "0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B",
+        "name": "WORMHOLE_CORE",
+        "isContract": true
     }
 ]

--- a/chains/10.json
+++ b/chains/10.json
@@ -788,5 +788,20 @@
         "addr": "0x78Feb72aeA00B912ac45438e0764A02213266568",
         "isContract": true,
         "name": "STK_GOVTOKEN_IMPL_V2"
+    },
+    {
+        "addr": "0xa3B6551cCbB5Fe1dc33b71EE3590B1Df22ae75B3",
+        "isContract": true,
+        "name": "WORMHOLE_QUOTER_ROUTER"
+    },
+    {
+        "addr": "0x85B704501f6AE718205C0636260768C4e72ac3e7",
+        "isContract": true,
+        "name": "WORMHOLE_EXECUTOR"
+    },
+    {
+        "addr": "0xA25862D222Eb8343505c12d96e097e4332468D60",
+        "isContract": true,
+        "name": "WORMHOLE_QUOTER"
     }
 ]

--- a/chains/1284.json
+++ b/chains/1284.json
@@ -378,5 +378,10 @@
         "addr": "0xbaC3Dd6d0333ea14F957B7B0796bCD59e8771501",
         "isContract": true,
         "name": "STK_GOVTOKEN_IMPL_V2"
+    },
+    {
+        "addr": "0x85D06449C78064c2E02d787e9DC71716786F8D19",
+        "isContract": true,
+        "name": "WORMHOLE_EXECUTOR"
     }
 ]

--- a/chains/8453.json
+++ b/chains/8453.json
@@ -1418,5 +1418,20 @@
         "addr": "0xe2747A3f7dD8585eB04c7632a9561D9616454B29",
         "isContract": true,
         "name": "STK_GOVTOKEN_IMPL_V2"
+    },
+    {
+        "addr": "0x265fd0500a430d65d6D79Cd8707F24C048604658",
+        "isContract": true,
+        "name": "WORMHOLE_QUOTER_ROUTER"
+    },
+    {
+        "addr": "0x9E1936E91A4a5AE5A5F75fFc472D6cb8e93597ea",
+        "isContract": true,
+        "name": "WORMHOLE_EXECUTOR"
+    },
+    {
+        "addr": "0xA25862D222Eb8343505c12d96e097e4332468D60",
+        "isContract": true,
+        "name": "WORMHOLE_QUOTER"
     }
 ]

--- a/proposals/mips/mip-x48/mip-x48.sol
+++ b/proposals/mips/mip-x48/mip-x48.sol
@@ -1,0 +1,396 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+
+import "@forge-std/Test.sol";
+
+import {ProxyAdmin} from "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
+
+import {IWormhole} from "@protocol/wormhole/IWormhole.sol";
+import {xWELL} from "@protocol/xWELL/xWELL.sol";
+import {WormholeBridgeAdapter} from "@protocol/xWELL/WormholeBridgeAdapter.sol";
+
+import {HybridProposal} from "@proposals/proposalTypes/HybridProposal.sol";
+import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
+import {MOONBEAM_FORK_ID, BASE_FORK_ID, OPTIMISM_FORK_ID, MOONBEAM_WORMHOLE_CHAIN_ID, BASE_WORMHOLE_CHAIN_ID, OPTIMISM_WORMHOLE_CHAIN_ID, ChainIds} from "@utils/ChainIds.sol";
+import {ProposalActions} from "@proposals/utils/ProposalActions.sol";
+
+/// @title MIP-X48: Upgrade xWELL WormholeBridgeAdapter to Executor Framework
+/// @author Moonwell Contributors
+/// @notice Upgrades the WormholeBridgeAdapter proxy on Moonbeam, Base, and Optimism
+///         from the deprecated Standard Relayer to the new Wormhole Executor framework.
+///         Each proxy is upgraded via upgradeAndCall with initializeV3.
+///         Ethereum is handled separately via script/UpgradeWormholeBridgeAdapterEthereum.s.sol
+///         because the Ethereum xWELL deployment is owned by the deployer, not governance.
+contract mipx48 is HybridProposal {
+    using ProposalActions for *;
+    using ChainIds for uint256;
+
+    string public constant override name = "MIP-X48";
+
+    struct AdapterSnapshot {
+        address owner;
+        uint96 gasLimit;
+        address xERC20;
+        uint256 bufferCap;
+        uint256 buffer;
+    }
+
+    AdapterSnapshot public moonbeamBefore;
+    AdapterSnapshot public baseBefore;
+    AdapterSnapshot public optimismBefore;
+
+    constructor() {
+        bytes memory proposalDescription = abi.encodePacked(
+            vm.readFile("./proposals/mips/mip-x48/x48.md")
+        );
+        _setProposalDescription(proposalDescription);
+    }
+
+    function primaryForkId() public pure override returns (uint256) {
+        return MOONBEAM_FORK_ID;
+    }
+
+    function run() public override {
+        primaryForkId().createForksAndSelect();
+
+        Addresses addresses = new Addresses();
+        vm.makePersistent(address(addresses));
+
+        initProposal(addresses);
+
+        (, address deployerAddress, ) = vm.readCallers();
+
+        if (DO_DEPLOY) deploy(addresses, deployerAddress);
+        if (DO_AFTER_DEPLOY) afterDeploy(addresses, deployerAddress);
+
+        if (DO_BUILD) build(addresses);
+        if (DO_RUN) run(addresses, deployerAddress);
+        if (DO_TEARDOWN) teardown(addresses, deployerAddress);
+        if (DO_VALIDATE) {
+            validate(addresses, deployerAddress);
+            console.log("Validation completed for proposal ", this.name());
+        }
+        if (DO_PRINT) {
+            printProposalActionSteps();
+
+            addresses.removeAllRestrictions();
+            printCalldata(addresses);
+
+            _printAddressesChanges(addresses);
+        }
+    }
+
+    function deploy(Addresses addresses, address) public override {
+        /// ============ MOONBEAM ============
+        vm.selectFork(MOONBEAM_FORK_ID);
+        if (!addresses.isAddressSet("WORMHOLE_BRIDGE_ADAPTER_IMPL_V3")) {
+            vm.startBroadcast();
+            address impl = address(new WormholeBridgeAdapter());
+            vm.stopBroadcast();
+
+            require(
+                impl != address(0),
+                "MIP-X48: failed to deploy on Moonbeam"
+            );
+            addresses.addAddress("WORMHOLE_BRIDGE_ADAPTER_IMPL_V3", impl);
+        }
+
+        /// ============ BASE ============
+        vm.selectFork(BASE_FORK_ID);
+        if (!addresses.isAddressSet("WORMHOLE_BRIDGE_ADAPTER_IMPL_V3")) {
+            vm.startBroadcast();
+            address impl = address(new WormholeBridgeAdapter());
+            vm.stopBroadcast();
+
+            require(impl != address(0), "MIP-X48: failed to deploy on Base");
+            addresses.addAddress("WORMHOLE_BRIDGE_ADAPTER_IMPL_V3", impl);
+        }
+
+        /// ============ OPTIMISM ============
+        vm.selectFork(OPTIMISM_FORK_ID);
+        if (!addresses.isAddressSet("WORMHOLE_BRIDGE_ADAPTER_IMPL_V3")) {
+            vm.startBroadcast();
+            address impl = address(new WormholeBridgeAdapter());
+            vm.stopBroadcast();
+
+            require(
+                impl != address(0),
+                "MIP-X48: failed to deploy on Optimism"
+            );
+            addresses.addAddress("WORMHOLE_BRIDGE_ADAPTER_IMPL_V3", impl);
+        }
+
+        vm.selectFork(primaryForkId());
+    }
+
+    function build(Addresses addresses) public override {
+        /// ============ MOONBEAM ============
+        _pushAction(
+            addresses.getAddress("MOONBEAM_PROXY_ADMIN"),
+            abi.encodeWithSignature(
+                "upgradeAndCall(address,address,bytes)",
+                addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY"),
+                addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_IMPL_V3"),
+                abi.encodeWithSignature(
+                    "initializeV3(address,address,address,address,uint16)",
+                    addresses.getAddress("WORMHOLE_CORE"),
+                    addresses.getAddress("WORMHOLE_EXECUTOR"),
+                    address(0), /// no quoter router on Moonbeam
+                    address(0), /// no quoter on Moonbeam
+                    MOONBEAM_WORMHOLE_CHAIN_ID
+                )
+            ),
+            "Upgrade WormholeBridgeAdapter on Moonbeam to Executor framework"
+        );
+
+        /// ============ BASE ============
+        vm.selectFork(BASE_FORK_ID);
+        _pushAction(
+            addresses.getAddress("MRD_PROXY_ADMIN"),
+            abi.encodeWithSignature(
+                "upgradeAndCall(address,address,bytes)",
+                addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY"),
+                addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_IMPL_V3"),
+                abi.encodeWithSignature(
+                    "initializeV3(address,address,address,address,uint16)",
+                    addresses.getAddress("WORMHOLE_CORE"),
+                    addresses.getAddress("WORMHOLE_EXECUTOR"),
+                    addresses.getAddress("WORMHOLE_QUOTER_ROUTER"),
+                    addresses.getAddress("WORMHOLE_QUOTER"),
+                    BASE_WORMHOLE_CHAIN_ID
+                )
+            ),
+            "Upgrade WormholeBridgeAdapter on Base to Executor framework"
+        );
+
+        /// ============ OPTIMISM ============
+        vm.selectFork(OPTIMISM_FORK_ID);
+        _pushAction(
+            addresses.getAddress("MRD_PROXY_ADMIN"),
+            abi.encodeWithSignature(
+                "upgradeAndCall(address,address,bytes)",
+                addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY"),
+                addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_IMPL_V3"),
+                abi.encodeWithSignature(
+                    "initializeV3(address,address,address,address,uint16)",
+                    addresses.getAddress("WORMHOLE_CORE"),
+                    addresses.getAddress("WORMHOLE_EXECUTOR"),
+                    addresses.getAddress("WORMHOLE_QUOTER_ROUTER"),
+                    addresses.getAddress("WORMHOLE_QUOTER"),
+                    OPTIMISM_WORMHOLE_CHAIN_ID
+                )
+            ),
+            "Upgrade WormholeBridgeAdapter on Optimism to Executor framework"
+        );
+
+        vm.selectFork(primaryForkId());
+    }
+
+    function beforeSimulationHook(Addresses addresses) public override {
+        vm.selectFork(MOONBEAM_FORK_ID);
+        moonbeamBefore = _snapshotAdapter(addresses);
+
+        vm.selectFork(BASE_FORK_ID);
+        baseBefore = _snapshotAdapter(addresses);
+
+        vm.selectFork(OPTIMISM_FORK_ID);
+        optimismBefore = _snapshotAdapter(addresses);
+
+        vm.selectFork(primaryForkId());
+    }
+
+    function _snapshotAdapter(
+        Addresses addresses
+    ) internal view returns (AdapterSnapshot memory) {
+        address proxy = addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY");
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(proxy);
+        xWELL xwell = xWELL(addresses.getAddress("xWELL_PROXY"));
+
+        return
+            AdapterSnapshot({
+                owner: adapter.owner(),
+                gasLimit: adapter.gasLimit(),
+                xERC20: address(adapter.xERC20()),
+                bufferCap: xwell.bufferCap(proxy),
+                buffer: xwell.buffer(proxy)
+            });
+    }
+
+    function teardown(Addresses addresses, address) public pure override {}
+
+    function validate(Addresses addresses, address) public override {
+        vm.selectFork(MOONBEAM_FORK_ID);
+        _validateChainUpgrade(
+            addresses,
+            "MOONBEAM_PROXY_ADMIN",
+            addresses.getAddress("WORMHOLE_EXECUTOR"),
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            moonbeamBefore,
+            "Moonbeam"
+        );
+
+        vm.selectFork(BASE_FORK_ID);
+        _validateChainUpgrade(
+            addresses,
+            "MRD_PROXY_ADMIN",
+            addresses.getAddress("WORMHOLE_EXECUTOR"),
+            BASE_WORMHOLE_CHAIN_ID,
+            baseBefore,
+            "Base"
+        );
+
+        vm.selectFork(OPTIMISM_FORK_ID);
+        _validateChainUpgrade(
+            addresses,
+            "MRD_PROXY_ADMIN",
+            addresses.getAddress("WORMHOLE_EXECUTOR"),
+            OPTIMISM_WORMHOLE_CHAIN_ID,
+            optimismBefore,
+            "Optimism"
+        );
+
+        vm.selectFork(primaryForkId());
+    }
+
+    function _validateChainUpgrade(
+        Addresses addresses,
+        string memory proxyAdminName,
+        address expectedExecutor,
+        uint16 expectedWormholeChainId,
+        AdapterSnapshot memory before,
+        string memory chainName
+    ) internal {
+        address proxy = addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY");
+        address proxyAdmin = addresses.getAddress(proxyAdminName);
+        address expectedImpl = addresses.getAddress(
+            "WORMHOLE_BRIDGE_ADAPTER_IMPL_V3"
+        );
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(proxy);
+
+        /// 1. Verify implementation upgraded
+        assertEq(
+            _getProxyImplementation(proxyAdmin, proxy),
+            expectedImpl,
+            string.concat(chainName, ": implementation not upgraded")
+        );
+
+        /// 2. Verify initializeV3 state was set
+        assertEq(
+            address(adapter.coreBridge()),
+            addresses.getAddress("WORMHOLE_CORE"),
+            string.concat(chainName, ": coreBridge not set correctly")
+        );
+        assertEq(
+            address(adapter.executor()),
+            expectedExecutor,
+            string.concat(chainName, ": executor not set correctly")
+        );
+        assertEq(
+            adapter.wormholeChainId(),
+            expectedWormholeChainId,
+            string.concat(chainName, ": wormholeChainId not set correctly")
+        );
+
+        /// 3. Verify backwards-compat getter
+        assertEq(
+            address(adapter.wormholeRelayer()),
+            addresses.getAddress("WORMHOLE_CORE"),
+            string.concat(
+                chainName,
+                ": wormholeRelayer should return coreBridge"
+            )
+        );
+
+        /// 4. Verify storage preservation
+        assertEq(
+            adapter.owner(),
+            before.owner,
+            string.concat(chainName, ": owner changed after upgrade")
+        );
+        assertEq(
+            adapter.gasLimit(),
+            before.gasLimit,
+            string.concat(chainName, ": gasLimit changed after upgrade")
+        );
+        assertEq(
+            address(adapter.xERC20()),
+            before.xERC20,
+            string.concat(chainName, ": xERC20 changed after upgrade")
+        );
+
+        xWELL xwell = xWELL(addresses.getAddress("xWELL_PROXY"));
+        assertEq(
+            xwell.bufferCap(proxy),
+            before.bufferCap,
+            string.concat(chainName, ": bufferCap changed after upgrade")
+        );
+
+        /// 5. Verify trusted senders still configured for all peer chains
+        uint16[3] memory allChainIds = [
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            BASE_WORMHOLE_CHAIN_ID,
+            OPTIMISM_WORMHOLE_CHAIN_ID
+        ];
+        for (uint256 i = 0; i < allChainIds.length; i++) {
+            if (allChainIds[i] == expectedWormholeChainId) continue;
+            assertTrue(
+                adapter.isTrustedSender(allChainIds[i], address(adapter)),
+                string.concat(
+                    chainName,
+                    ": peer not trusted sender after upgrade"
+                )
+            );
+        }
+
+        /// 6. Verify target addresses still configured for all peer chains
+        for (uint256 i = 0; i < allChainIds.length; i++) {
+            if (allChainIds[i] == expectedWormholeChainId) continue;
+            assertEq(
+                adapter.targetAddress(allChainIds[i]),
+                address(adapter),
+                string.concat(chainName, ": target address not preserved")
+            );
+        }
+
+        /// 7. Verify initializeV3 cannot be called again
+        vm.expectRevert("Initializable: contract is already initialized");
+        adapter.initializeV3(
+            address(1),
+            address(1),
+            address(0),
+            address(0),
+            expectedWormholeChainId
+        );
+
+        /// 8. Verify initialize cannot be called again
+        vm.expectRevert("Initializable: contract is already initialized");
+        adapter.initialize(
+            address(1),
+            address(1),
+            address(1),
+            new uint16[](0),
+            new address[](0)
+        );
+
+        /// 9. Verify deprecated receiveWormholeMessages always reverts
+        vm.expectRevert("WormholeBridge: deprecated, use executeVAAv1");
+        adapter.receiveWormholeMessages(
+            "",
+            new bytes[](0),
+            bytes32(0),
+            0,
+            bytes32(0)
+        );
+    }
+
+    function _getProxyImplementation(
+        address proxyAdmin,
+        address proxy
+    ) internal view returns (address) {
+        (bool success, bytes memory data) = proxyAdmin.staticcall(
+            abi.encodeWithSignature("getProxyImplementation(address)", proxy)
+        );
+        require(success, "Failed to get proxy implementation");
+        return abi.decode(data, (address));
+    }
+}

--- a/proposals/mips/mip-x48/x48.md
+++ b/proposals/mips/mip-x48/x48.md
@@ -1,0 +1,1 @@
+# MIP-X48: Upgrade xWELL WormholeBridgeAdapter to Executor Framework

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -3,6 +3,13 @@
         "envpath": "",
         "governor": "MultichainGovernor",
         "id": 0,
+        "path": "mip-x48.sol/mipx48.json",
+        "proposalType": "HybridProposal"
+    },
+    {
+        "envpath": "",
+        "governor": "MultichainGovernor",
+        "id": 0,
         "path": "mip-x47.sol/mipx47.json",
         "proposalType": "HybridProposal"
     },

--- a/remappings.txt
+++ b/remappings.txt
@@ -3,6 +3,8 @@
 @openzeppelin/=lib/openzeppelin-contracts/
 @openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/
 @wormhole/=lib/wormhole/ethereum/contracts/
+wormhole-sdk/=lib/wormhole-solidity-sdk/src/
+wormhole-solidity-sdk/=lib/wormhole-solidity-sdk/src/
 @protocol=src/
 @test=test/
 @proposals=proposals/

--- a/script/UpgradeWormholeBridgeAdapterEthereum.s.sol
+++ b/script/UpgradeWormholeBridgeAdapterEthereum.s.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+
+import {ITransparentUpgradeableProxy} from "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
+
+import {Script} from "@forge-std/Script.sol";
+import {console} from "@forge-std/console.sol";
+
+import {IWormhole} from "@protocol/wormhole/IWormhole.sol";
+import {WormholeBridgeAdapter} from "@protocol/xWELL/WormholeBridgeAdapter.sol";
+import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
+import {validateProxy} from "@proposals/utils/ProxyUtils.sol";
+import {ETHEREUM_CHAIN_ID, MOONBEAM_CHAIN_ID, BASE_CHAIN_ID, OPTIMISM_CHAIN_ID, MOONBEAM_WORMHOLE_CHAIN_ID, BASE_WORMHOLE_CHAIN_ID, OPTIMISM_WORMHOLE_CHAIN_ID, ETHEREUM_WORMHOLE_CHAIN_ID} from "@utils/ChainIds.sol";
+
+/*
+
+ Upgrade WormholeBridgeAdapter on Ethereum to Wormhole Executor framework.
+
+ The Ethereum xWELL deployment is owned by MOONWELL_DEPLOYER, not governance,
+ so this is a one-off deployer script (same pattern as DeployXWellEthereum.s.sol).
+
+ to simulate:
+     forge script script/UpgradeWormholeBridgeAdapterEthereum.s.sol:UpgradeWormholeBridgeAdapterEthereum \
+       -vvvv --rpc-url ethereum
+
+ to run:
+    forge script script/UpgradeWormholeBridgeAdapterEthereum.s.sol:UpgradeWormholeBridgeAdapterEthereum \
+      -vvvv --rpc-url ethereum --broadcast --etherscan-api-key ethereum --verify
+
+*/
+contract UpgradeWormholeBridgeAdapterEthereum is Script {
+    function run() public {
+        Addresses addresses = new Addresses();
+
+        require(
+            block.chainid == ETHEREUM_CHAIN_ID,
+            "This script must be run on Ethereum mainnet"
+        );
+
+        address proxyAdmin = addresses.getAddress("PROXY_ADMIN");
+        address adapterProxy = addresses.getAddress(
+            "WORMHOLE_BRIDGE_ADAPTER_PROXY"
+        );
+
+        // Snapshot pre-upgrade state
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(adapterProxy);
+        address ownerBefore = adapter.owner();
+        uint96 gasLimitBefore = adapter.gasLimit();
+        address xERC20Before = address(adapter.xERC20());
+
+        console.log("=== Pre-upgrade state ===");
+        console.log("  Owner:", ownerBefore);
+        console.log("  Gas limit:", uint256(gasLimitBefore));
+        console.log("  xERC20:", xERC20Before);
+        console.log("  Proxy:", adapterProxy);
+        console.log("  ProxyAdmin:", proxyAdmin);
+
+        vm.startBroadcast();
+
+        // Deploy new implementation
+        address newImpl = address(new WormholeBridgeAdapter());
+        console.log("  New implementation:", newImpl);
+
+        // Upgrade and initialize V3
+        ProxyAdmin(proxyAdmin).upgradeAndCall(
+            ITransparentUpgradeableProxy(adapterProxy),
+            newImpl,
+            abi.encodeWithSignature(
+                "initializeV3(address,address,address,address,uint16)",
+                addresses.getAddress("WORMHOLE_CORE"),
+                addresses.getAddress("WORMHOLE_EXECUTOR"),
+                addresses.getAddress("WORMHOLE_QUOTER_ROUTER"),
+                addresses.getAddress("WORMHOLE_QUOTER"),
+                ETHEREUM_WORMHOLE_CHAIN_ID
+            )
+        );
+
+        vm.stopBroadcast();
+
+        console.log("\n=== Upgrade Complete ===");
+
+        // Run validation
+        _validateUpgrade(
+            addresses,
+            adapterProxy,
+            proxyAdmin,
+            newImpl,
+            ownerBefore,
+            gasLimitBefore,
+            xERC20Before
+        );
+    }
+
+    function _validateUpgrade(
+        Addresses addresses,
+        address adapterProxy,
+        address proxyAdmin,
+        address expectedImpl,
+        address expectedOwner,
+        uint96 expectedGasLimit,
+        address expectedXERC20
+    ) internal view {
+        console.log("\n=== Running Validation ===");
+
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(adapterProxy);
+
+        // 1. Verify implementation upgraded
+        validateProxy(
+            vm,
+            adapterProxy,
+            expectedImpl,
+            proxyAdmin,
+            "Ethereum WORMHOLE_BRIDGE_ADAPTER_PROXY"
+        );
+
+        // 2. Verify initializeV3 state
+        require(
+            address(adapter.coreBridge()) ==
+                addresses.getAddress("WORMHOLE_CORE"),
+            "coreBridge not set correctly"
+        );
+        require(
+            address(adapter.executorQuoterRouter()) ==
+                addresses.getAddress("WORMHOLE_EXECUTOR"),
+            "executorQuoterRouter not set correctly"
+        );
+        require(
+            adapter.wormholeChainId() == ETHEREUM_WORMHOLE_CHAIN_ID,
+            "wormholeChainId not set correctly"
+        );
+
+        // 3. Verify backwards-compat getter
+        require(
+            address(adapter.wormholeRelayer()) ==
+                addresses.getAddress("WORMHOLE_CORE"),
+            "wormholeRelayer() should return coreBridge"
+        );
+
+        // 4. Verify storage preservation
+        require(
+            adapter.owner() == expectedOwner,
+            "owner changed after upgrade"
+        );
+        require(
+            adapter.gasLimit() == expectedGasLimit,
+            "gasLimit changed after upgrade"
+        );
+        require(
+            address(adapter.xERC20()) == expectedXERC20,
+            "xERC20 changed after upgrade"
+        );
+
+        // 5. Verify trusted senders still configured
+        require(
+            adapter.isTrustedSender(
+                MOONBEAM_WORMHOLE_CHAIN_ID,
+                addresses.getAddress(
+                    "WORMHOLE_BRIDGE_ADAPTER_PROXY",
+                    MOONBEAM_CHAIN_ID
+                )
+            ),
+            "Moonbeam adapter not trusted"
+        );
+        require(
+            adapter.isTrustedSender(
+                BASE_WORMHOLE_CHAIN_ID,
+                addresses.getAddress(
+                    "WORMHOLE_BRIDGE_ADAPTER_PROXY",
+                    BASE_CHAIN_ID
+                )
+            ),
+            "Base adapter not trusted"
+        );
+        require(
+            adapter.isTrustedSender(
+                OPTIMISM_WORMHOLE_CHAIN_ID,
+                addresses.getAddress(
+                    "WORMHOLE_BRIDGE_ADAPTER_PROXY",
+                    OPTIMISM_CHAIN_ID
+                )
+            ),
+            "Optimism adapter not trusted"
+        );
+
+        console.log("=== Validation Passed ===\n");
+    }
+}

--- a/src/wormhole/IExecutorQuoterRouter.sol
+++ b/src/wormhole/IExecutorQuoterRouter.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.19;
+
+/// @notice Local copy of Wormhole Executor interfaces.
+/// @dev The SDK's IExecutor.sol uses file-scoped events (Solidity ^0.8.22 feature)
+/// which is incompatible with our 0.8.19 pragma. This file contains only the
+/// interfaces we need, without file-scoped events.
+
+/// @notice Wormhole Executor interface for off-chain quote flow.
+/// The caller obtains a signed quote off-chain from the executor API and
+/// passes it when requesting execution.
+interface IExecutor {
+    function requestExecution(
+        uint16 dstChain,
+        bytes32 dstAddr,
+        address refundAddr,
+        bytes calldata signedQuote,
+        bytes calldata requestBytes,
+        bytes calldata relayInstructions
+    ) external payable;
+}
+
+/// @notice On-chain quoting + execution router for the Wormhole Executor framework.
+/// Available on chains with a deployed quoter (Base, Optimism, Ethereum).
+interface IExecutorQuoterRouter {
+    function quoteExecution(
+        uint16 dstChain,
+        bytes32 dstAddr,
+        address refundAddr,
+        address quoterAddr,
+        bytes calldata requestBytes,
+        bytes calldata relayInstructions
+    ) external view returns (uint256);
+
+    function requestExecution(
+        uint16 dstChain,
+        bytes32 dstAddr,
+        address refundAddr,
+        address quoterAddr,
+        bytes calldata requestBytes,
+        bytes calldata relayInstructions
+    ) external payable;
+}
+
+/// @notice Required interface for receiving MultiSig (V1) VAAs from the Executor
+interface IVaaV1Receiver {
+    function executeVAAv1(bytes memory multiSigVaa) external payable;
+}

--- a/src/xWELL/AxelarBridgeAdapter.sol
+++ b/src/xWELL/AxelarBridgeAdapter.sol
@@ -278,6 +278,17 @@ contract AxelarBridgeAdapter is xERC20BridgeAdapter {
     //// ------------------------------------------------------------
     //// ------------------------------------------------------------
 
+    /// @notice off-chain quote bridge not supported on Axelar
+    function _bridgeOut(
+        address,
+        uint256,
+        uint256,
+        address,
+        bytes calldata
+    ) internal override {
+        revert("AxelarBridge: off-chain quote not supported");
+    }
+
     /// @notice bridge tokens from this chain to the dstChain
     /// @param user address burning tokens and funding the cross chain call
     /// @param dstChainId destination chain id

--- a/src/xWELL/WormholeBridgeAdapter.sol
+++ b/src/xWELL/WormholeBridgeAdapter.sol
@@ -2,14 +2,19 @@ pragma solidity 0.8.19;
 
 import {SafeCast} from "@openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
 
-import {IWormholeRelayer} from "@protocol/wormhole/IWormholeRelayer.sol";
-import {IWormholeReceiver} from "@protocol/wormhole/IWormholeReceiver.sol";
+import {IWormhole} from "@protocol/wormhole/IWormhole.sol";
+import {IExecutor, IExecutorQuoterRouter, IVaaV1Receiver} from "@protocol/wormhole/IExecutorQuoterRouter.sol";
 import {xERC20BridgeAdapter} from "@protocol/xWELL/xERC20BridgeAdapter.sol";
 import {WormholeTrustedSender} from "@protocol/governance/WormholeTrustedSender.sol";
 
-/// @notice Wormhole xERC20 Token Bridge adapter
+import {SequenceReplayProtectionLib} from "wormhole-sdk/libraries/ReplayProtection.sol";
+import {RequestLib} from "wormhole-sdk/Executor/Request.sol";
+import {RelayInstructionLib} from "wormhole-sdk/Executor/RelayInstruction.sol";
+import {toUniversalAddress} from "wormhole-sdk/Utils.sol";
+
+/// @notice Wormhole xERC20 Token Bridge adapter using the Executor framework
 contract WormholeBridgeAdapter is
-    IWormholeReceiver,
+    IVaaV1Receiver,
     xERC20BridgeAdapter,
     WormholeTrustedSender
 {
@@ -24,12 +29,13 @@ contract WormholeBridgeAdapter is
     /// @dev packing these variables into a single slot saves a
     /// COLD SLOAD on bridge out operations.
 
-    /// @notice gas limit for wormhole relayer, changeable incase gas prices change on external network
+    /// @notice gas limit for executor, changeable incase gas prices change on external network
     uint96 public gasLimit = 300_000;
 
-    /// @notice address of the wormhole relayer cannot be changed by owner
-    /// because the relayer contract is a proxy and should never change its address
-    IWormholeRelayer public wormholeRelayer;
+    /// @notice address of the wormhole core bridge contract
+    /// @dev was previously IWormholeRelayer wormholeRelayer in V1.
+    /// Storage layout is preserved since both are address types packed with uint96 gasLimit.
+    IWormhole internal _coreBridge;
 
     /// ---------------------------------------------------------
     /// ---------------------------------------------------------
@@ -37,12 +43,26 @@ contract WormholeBridgeAdapter is
     /// ---------------------------------------------------------
     /// ---------------------------------------------------------
 
-    /// @notice nonces that have already been processed
+    /// DEPRECATED: nonces that have already been processed (legacy Standard Relayer)
+    /// @dev kept for storage slot preservation. New replay protection uses
+    /// SequenceReplayProtectionLib which writes to deterministic storage slots.
     mapping(bytes32 => bool) public processedNonces;
 
     /// @notice chain id of the target chain to address for bridging
     /// starts off mapped to itself, but can be changed by governance
     mapping(uint16 => address) public targetAddress;
+
+    /// @notice address of the executor quoter router for onchain quoting and execution requests
+    IExecutorQuoterRouter public executorQuoterRouter;
+
+    /// @notice address of the quoter used for pricing execution
+    address public quoterAddress;
+
+    /// @notice this chain's wormhole chain ID, used for encoding execution requests
+    uint16 public wormholeChainId;
+
+    /// @notice Wormhole Executor for off-chain quote flow
+    IExecutor public executor;
 
     /// ---------------------------------------------------------
     /// ---------------------------------------------------------
@@ -97,7 +117,7 @@ contract WormholeBridgeAdapter is
         _transferOwnership(newOwner);
         _setxERC20(newxerc20);
 
-        wormholeRelayer = IWormholeRelayer(wormholeRelayerAddress);
+        _coreBridge = IWormhole(wormholeRelayerAddress); /// @dev storage slot repurposed in #initializeV3()
 
         /// initialize contract to trust this exact same address on an external chain
         /// @dev the external chain contracts MUST HAVE THE SAME ADDRESS on the external chain
@@ -122,13 +142,44 @@ contract WormholeBridgeAdapter is
         _transferOwnership(newOwner);
     }
 
+    /// @notice Migrate from Standard Relayer to Executor framework
+    /// @param _coreBridgeAddress Wormhole Core Bridge address
+    /// @param _executorAddress Executor address for off-chain quote flow
+    /// @param _executorQuoterRouterAddress Executor Quoter Router for on-chain quoting (address(0) if not available)
+    /// @param _quoterAddr on-chain quoter address for pricing execution (address(0) if not available)
+    /// @param _wormholeChainId this chain's Wormhole chain ID
+    function initializeV3(
+        address _coreBridgeAddress,
+        address _executorAddress,
+        address _executorQuoterRouterAddress,
+        address _quoterAddr,
+        uint16 _wormholeChainId
+    ) external reinitializer(3) {
+        require(
+            _coreBridgeAddress != address(0),
+            "WormholeBridge: zero core bridge"
+        );
+        require(
+            _executorAddress != address(0),
+            "WormholeBridge: zero executor"
+        );
+
+        _coreBridge = IWormhole(_coreBridgeAddress);
+        executor = IExecutor(_executorAddress);
+        executorQuoterRouter = IExecutorQuoterRouter(
+            _executorQuoterRouterAddress
+        );
+        quoterAddress = _quoterAddr;
+        wormholeChainId = _wormholeChainId;
+    }
+
     /// --------------------------------------------------------
     /// --------------------------------------------------------
     /// ---------------- Admin Only Functions ------------------
     /// --------------------------------------------------------
     /// --------------------------------------------------------
 
-    /// @notice set a gas limit for the relayer on the external chain
+    /// @notice set a gas limit for the executor on the external chain
     /// should only be called if there is a change in gas prices on the external chain
     /// @param newGasLimit new gas limit to set
     function setGasLimit(uint96 newGasLimit) external onlyOwner {
@@ -177,16 +228,52 @@ contract WormholeBridgeAdapter is
     /// --------------------------------------------------------
     /// --------------------------------------------------------
 
+    /// @notice Get the Wormhole core bridge address
+    function coreBridge() external view returns (IWormhole) {
+        return _coreBridge;
+    }
+
+    /// @notice Deprecated getter for backwards compatibility with scripts
+    /// @dev In V1 this was the Standard Relayer address. Now returns the core bridge address.
+    function wormholeRelayer() external view returns (address) {
+        return address(_coreBridge);
+    }
+
     /// @notice Estimate bridge cost to bridge out to a destination chain
+    /// @dev Uses the Executor onchain quoter. Returns 0 if the quote fails.
     /// @param dstChainId Destination chain id
     function bridgeCost(
         uint16 dstChainId
     ) public view returns (uint256 gasCost) {
-        (gasCost, ) = wormholeRelayer.quoteEVMDeliveryPrice(
-            dstChainId,
-            0,
-            gasLimit
+        if (address(executorQuoterRouter) == address(0)) {
+            return 0;
+        }
+
+        bytes memory relayInstructions = RelayInstructionLib.encodeGas(
+            uint128(gasLimit),
+            0
         );
+        bytes memory requestBytes = RequestLib.encodeVaaMultiSigRequest(
+            wormholeChainId,
+            toUniversalAddress(address(this)),
+            0
+        );
+        bytes32 peerAddr = toUniversalAddress(targetAddress[dstChainId]);
+
+        try
+            executorQuoterRouter.quoteExecution(
+                dstChainId,
+                peerAddr,
+                address(this),
+                quoterAddress,
+                requestBytes,
+                relayInstructions
+            )
+        returns (uint256 executorFee) {
+            gasCost = executorFee + _coreBridge.messageFee();
+        } catch {
+            gasCost = 0;
+        }
     }
 
     /// --------------------------------------------------------
@@ -195,10 +282,67 @@ contract WormholeBridgeAdapter is
     /// --------------------------------------------------------
     /// --------------------------------------------------------
 
-    /// @notice Bridge Out Funds to an external chain.
-    /// Callable by the users to bridge out their funds to an external chain.
-    /// If a user sends tokens to the token contract on the external chain,
-    /// that call will revert, and the tokens will be lost permanently.
+    /// @notice Bridge out using an off-chain signed quote from the Executor.
+    /// Burns xERC20 tokens, publishes a message via Wormhole Core Bridge, then
+    /// requests execution via the Executor with the signed quote.
+    /// @param user to send funds from, should be msg.sender in all cases
+    /// @param targetChain Destination chain id
+    /// @param amount Amount of xERC20 to bridge out
+    /// @param to Address to receive funds on destination chain
+    /// @param signedQuote Signed quote obtained off-chain from the executor API
+    function _bridgeOut(
+        address user,
+        uint256 targetChain,
+        uint256 amount,
+        address to,
+        bytes calldata signedQuote
+    ) internal override {
+        uint16 targetChainId = targetChain.toUint16();
+        require(
+            targetAddress[targetChainId] != address(0),
+            "WormholeBridge: invalid target chain"
+        );
+
+        /// user must burn xERC20 tokens first
+        _burnTokens(user, amount);
+
+        bytes memory payload = abi.encode(to, amount);
+
+        /// Step 1: Publish message via Core Bridge
+        uint256 messageFee = _coreBridge.messageFee();
+        uint64 sequence = _coreBridge.publishMessage{value: messageFee}(
+            0, // nonce
+            payload,
+            200 // finalized consistency level
+        );
+
+        /// Step 2: Request execution via Executor with off-chain signed quote
+        bytes memory requestBytes = RequestLib.encodeVaaMultiSigRequest(
+            wormholeChainId,
+            toUniversalAddress(address(this)),
+            sequence
+        );
+        bytes memory relayInstructions = RelayInstructionLib.encodeGas(
+            uint128(gasLimit),
+            0
+        );
+        bytes32 peerAddr = toUniversalAddress(targetAddress[targetChainId]);
+
+        executor.requestExecution{value: msg.value - messageFee}(
+            targetChainId,
+            peerAddr,
+            tx.origin,
+            signedQuote,
+            requestBytes,
+            relayInstructions
+        );
+
+        emit TokensSent(targetChainId, to, amount);
+    }
+
+    /// @notice Bridge Out Funds to an external chain using the Executor framework.
+    /// Burns xERC20 tokens, publishes a message via Wormhole Core Bridge, then
+    /// requests execution via the ExecutorQuoterRouter (on-chain quoting).
     /// @param user to send funds from, should be msg.sender in all cases
     /// @param targetChain Destination chain id
     /// @param amount Amount of xERC20 to bridge out
@@ -209,6 +353,10 @@ contract WormholeBridgeAdapter is
         uint256 amount,
         address to
     ) internal override {
+        require(
+            address(executorQuoterRouter) != address(0),
+            "WormholeBridge: onchain quoting not available, use bridge with signedQuote"
+        );
         uint16 targetChainId = targetChain.toUint16();
         uint256 cost = bridgeCost(targetChainId);
         require(msg.value == cost, "WormholeBridge: cost not equal to quote");
@@ -220,50 +368,82 @@ contract WormholeBridgeAdapter is
         /// user must burn xERC20 tokens first
         _burnTokens(user, amount);
 
-        wormholeRelayer.sendPayloadToEvm{value: cost}(
+        bytes memory payload = abi.encode(to, amount);
+
+        /// Step 1: Publish message via Core Bridge
+        uint256 messageFee = _coreBridge.messageFee();
+        uint64 sequence = _coreBridge.publishMessage{value: messageFee}(
+            0, // nonce
+            payload,
+            200 // finalized consistency level
+        );
+
+        /// Step 2: Request execution via Executor
+        bytes memory requestBytes = RequestLib.encodeVaaMultiSigRequest(
+            wormholeChainId,
+            toUniversalAddress(address(this)),
+            sequence
+        );
+        bytes memory relayInstructions = RelayInstructionLib.encodeGas(
+            uint128(gasLimit),
+            0
+        );
+        bytes32 peerAddr = toUniversalAddress(targetAddress[targetChainId]);
+
+        executorQuoterRouter.requestExecution{value: cost - messageFee}(
             targetChainId,
-            targetAddress[targetChainId],
-            abi.encode(to, amount), // payload
-            0, /// no receiver value allowed, only message passing
-            gasLimit
+            peerAddr,
+            tx.origin,
+            quoterAddress,
+            requestBytes,
+            relayInstructions
         );
 
         emit TokensSent(targetChainId, to, amount);
     }
 
-    /// @notice callable only by the wormhole relayer
-    /// @param payload the payload of the message, contains the to and amount
-    /// additional vaas, unused parameter
-    /// @param senderAddress the address of the sender on the source chain, bytes32 encoded
-    /// @param sourceChain the chain id of the source chain
-    /// @param nonce the unique message ID
-    function receiveWormholeMessages(
-        bytes memory payload,
-        bytes[] memory, // additionalVaas
-        bytes32 senderAddress,
-        uint16 sourceChain,
-        bytes32 nonce
-    ) external payable override {
+    /// @notice Receive and execute a Wormhole VAA. Anyone can submit a valid VAA.
+    /// The contract verifies the VAA via the Wormhole Core Bridge, checks that the
+    /// emitter is a trusted sender, and applies sequence-based replay protection.
+    /// @param encodedVaa the encoded VAA to process
+    function executeVAAv1(bytes memory encodedVaa) external payable override {
         require(msg.value == 0, "WormholeBridge: no value allowed");
+
+        (IWormhole.VM memory vm, bool valid, string memory reason) = _coreBridge
+            .parseAndVerifyVM(encodedVaa);
+        require(valid, reason);
+
         require(
-            msg.sender == address(wormholeRelayer),
-            "WormholeBridge: only relayer allowed"
-        );
-        require(
-            isTrustedSender(sourceChain, senderAddress),
+            isTrustedSender(vm.emitterChainId, vm.emitterAddress),
             "WormholeBridge: sender not trusted"
         );
-        require(
-            !processedNonces[nonce],
-            "WormholeBridge: message already processed"
+
+        /// Bitmap-based replay protection (deterministic storage slots, no mapping needed)
+        SequenceReplayProtectionLib.replayProtect(
+            vm.emitterChainId,
+            vm.emitterAddress,
+            vm.sequence
         );
 
-        processedNonces[nonce] = true;
-
-        // Parse the payload and do the corresponding actions!
-        (address to, uint256 amount) = abi.decode(payload, (address, uint256));
+        /// Parse the payload and do the corresponding actions!
+        (address to, uint256 amount) = abi.decode(
+            vm.payload,
+            (address, uint256)
+        );
 
         /// mint tokens and emit events
-        _bridgeIn(sourceChain, to, amount);
+        _bridgeIn(vm.emitterChainId, to, amount);
+    }
+
+    /// @notice DEPRECATED - Old Standard Relayer receive function
+    /// @dev Always reverts. Use executeVAAv1() instead.
+    function receiveWormholeMessages(
+        bytes memory,
+        bytes[] memory,
+        bytes32,
+        uint16,
+        bytes32
+    ) external payable {
+        revert("WormholeBridge: deprecated, use executeVAAv1");
     }
 }

--- a/src/xWELL/xERC20BridgeAdapter.sol
+++ b/src/xWELL/xERC20BridgeAdapter.sol
@@ -61,6 +61,22 @@ abstract contract xERC20BridgeAdapter is Ownable2StepUpgradeable {
         emit BridgedOut(dstChainId, msg.sender, to, amount);
     }
 
+    /// @notice Bridge out funds using an off-chain signed quote
+    /// @param dstChainId Destination chain id
+    /// @param amount Amount of xERC20 to bridge out
+    /// @param to Address to receive funds on destination chain
+    /// @param signedQuote Signed quote obtained off-chain from the executor API
+    function bridge(
+        uint16 dstChainId,
+        uint256 amount,
+        address to,
+        bytes calldata signedQuote
+    ) external payable virtual {
+        _bridgeOut(msg.sender, dstChainId, amount, to, signedQuote);
+
+        emit BridgedOut(dstChainId, msg.sender, to, amount);
+    }
+
     /// @notice set the xERC20 token
     /// @param newxerc20 address of the xERC20 token
     function _setxERC20(address newxerc20) internal {
@@ -101,5 +117,19 @@ abstract contract xERC20BridgeAdapter is Ownable2StepUpgradeable {
         uint256 dstChainId,
         uint256 amount,
         address to
+    ) internal virtual;
+
+    /// @notice bridge tokens from this chain to the dstChain using an off-chain signed quote
+    /// @param user address burning tokens and funding the cross chain call
+    /// @param dstChainId destination chain id
+    /// @param amount amount of tokens to bridge
+    /// @param to address to receive tokens on the destination chain
+    /// @param signedQuote signed quote obtained off-chain from the executor API
+    function _bridgeOut(
+        address user,
+        uint256 dstChainId,
+        uint256 amount,
+        address to,
+        bytes calldata signedQuote
     ) internal virtual;
 }

--- a/test/helper/BaseTest.t.sol
+++ b/test/helper/BaseTest.t.sol
@@ -15,6 +15,8 @@ import {WormholeBridgeAdapter} from "@protocol/xWELL/WormholeBridgeAdapter.sol";
 import {WormholeTrustedSender} from "@protocol/governance/WormholeTrustedSender.sol";
 import {BASE_WORMHOLE_CHAIN_ID} from "@utils/ChainIds.sol";
 import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
+import {MockCoreBridgeForAdapter} from "@test/mock/MockCoreBridgeForAdapter.sol";
+import {MockExecutorQuoterRouter} from "@test/mock/MockExecutorQuoterRouter.sol";
 
 contract BaseTest is xWELLDeploy, Test {
     /// @notice addresses contract, stores all addresses
@@ -57,7 +59,14 @@ contract BaseTest is xWELLDeploy, Test {
     address public pauseGuardian = address(1111111111);
 
     /// @notice wormhole relayer of the WormholeBridgeAdapter
+    /// @dev kept for backwards compatibility; now used as the initial core bridge address in initialize()
     address public wormholeRelayer = address(2222222222);
+
+    /// @notice mock core bridge for executor tests
+    MockCoreBridgeForAdapter public mockCoreBridge;
+
+    /// @notice mock executor quoter router for executor tests
+    MockExecutorQuoterRouter public mockExecutorQuoterRouter;
 
     /// @notice duration of the pause
     uint128 public pauseDuration = 10 days;
@@ -151,6 +160,20 @@ contract BaseTest is xWELLDeploy, Test {
             wormholeRelayer,
             chainIds,
             targets
+        );
+
+        /// deploy mocks for executor framework
+        mockCoreBridge = new MockCoreBridgeForAdapter();
+        mockCoreBridge.setChainId(chainId);
+        mockExecutorQuoterRouter = new MockExecutorQuoterRouter();
+
+        /// migrate to executor framework via initializeV3
+        wormholeBridgeAdapterProxy.initializeV3(
+            address(mockCoreBridge),
+            address(mockExecutorQuoterRouter), /// executor (off-chain quote)
+            address(mockExecutorQuoterRouter), /// executorQuoterRouter (on-chain quote)
+            address(0), /// quoter address (not needed for mock)
+            chainId
         );
 
         sigUtils = new SigUtils(xwellProxy.DOMAIN_SEPARATOR());

--- a/test/integration/xWELL/xWellExecutorIntegration.t.sol
+++ b/test/integration/xWELL/xWellExecutorIntegration.t.sol
@@ -1,0 +1,1269 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+
+import {IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {ITransparentUpgradeableProxy} from "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
+
+import "@forge-std/Test.sol";
+
+import {xWELL} from "@protocol/xWELL/xWELL.sol";
+import {IWormhole} from "@protocol/wormhole/IWormhole.sol";
+import {WormholeBridgeAdapter} from "@protocol/xWELL/WormholeBridgeAdapter.sol";
+import {IExecutor} from "@protocol/wormhole/IExecutorQuoterRouter.sol";
+import {PostProposalCheck} from "@test/integration/PostProposalCheck.sol";
+import {UpgradeWormholeBridgeAdapterEthereum} from "@script/UpgradeWormholeBridgeAdapterEthereum.s.sol";
+import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
+import {MOONBEAM_FORK_ID, BASE_FORK_ID, OPTIMISM_FORK_ID, ETHEREUM_FORK_ID, MOONBEAM_WORMHOLE_CHAIN_ID, BASE_WORMHOLE_CHAIN_ID, OPTIMISM_WORMHOLE_CHAIN_ID, ETHEREUM_WORMHOLE_CHAIN_ID} from "@utils/ChainIds.sol";
+
+/// @notice Integration test for xWELL WormholeBridgeAdapter after Executor migration.
+/// Inherits PostProposalCheck so mip-x48 runs in setUp(), upgrading the adapter on
+/// Moonbeam/Base/Optimism. Inherits UpgradeWormholeBridgeAdapterEthereum to conditionally
+/// upgrade the Ethereum adapter if V3 is not yet initialized on-chain.
+contract xWellExecutorIntegrationTest is
+    PostProposalCheck,
+    UpgradeWormholeBridgeAdapterEthereum
+{
+    /// Per-chain adapter addresses (resolved on respective forks)
+    address public adapterAddrMoonbeam;
+    address public adapterAddrBase;
+    address public adapterAddrOptimism;
+    address public adapterAddrEthereum;
+
+    /// Per-chain xWELL addresses
+    address public xwellAddrMoonbeam;
+    address public xwellAddrBase;
+    address public xwellAddrOptimism;
+    address public xwellAddrEthereum;
+
+    /// Per-chain core bridge addresses (read after V3 init)
+    address public coreBridgeMoonbeam;
+    address public coreBridgeBase;
+    address public coreBridgeOptimism;
+    address public coreBridgeEthereum;
+
+    /// Per-chain executor addresses (for off-chain quote mocking)
+    address public executorMoonbeam;
+    address public executorBase;
+    address public executorOptimism;
+    address public executorEthereum;
+
+    address user = address(0x123);
+    uint256 public constant startingWellAmount = 100_000 * 1e18;
+
+    event BridgedIn(
+        uint256 indexed srcChainId,
+        address indexed tokenReceiver,
+        uint256 amount
+    );
+
+    event TokensSent(
+        uint16 indexed dstChainId,
+        address indexed tokenReceiver,
+        uint256 amount
+    );
+
+    function setUp() public override {
+        super.setUp();
+
+        // Moonbeam
+        vm.selectFork(MOONBEAM_FORK_ID);
+        adapterAddrMoonbeam = addresses.getAddress(
+            "WORMHOLE_BRIDGE_ADAPTER_PROXY"
+        );
+        xwellAddrMoonbeam = addresses.getAddress("xWELL_PROXY");
+        coreBridgeMoonbeam = address(
+            WormholeBridgeAdapter(adapterAddrMoonbeam).coreBridge()
+        );
+        executorMoonbeam = address(
+            WormholeBridgeAdapter(adapterAddrMoonbeam).executor()
+        );
+
+        // Base
+        vm.selectFork(BASE_FORK_ID);
+        adapterAddrBase = addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY");
+        xwellAddrBase = addresses.getAddress("xWELL_PROXY");
+        coreBridgeBase = address(
+            WormholeBridgeAdapter(adapterAddrBase).coreBridge()
+        );
+        executorBase = address(
+            WormholeBridgeAdapter(adapterAddrBase).executor()
+        );
+
+        // Optimism
+        vm.selectFork(OPTIMISM_FORK_ID);
+        adapterAddrOptimism = addresses.getAddress(
+            "WORMHOLE_BRIDGE_ADAPTER_PROXY"
+        );
+        xwellAddrOptimism = addresses.getAddress("xWELL_PROXY");
+        coreBridgeOptimism = address(
+            WormholeBridgeAdapter(adapterAddrOptimism).coreBridge()
+        );
+        executorOptimism = address(
+            WormholeBridgeAdapter(adapterAddrOptimism).executor()
+        );
+
+        // Ethereum — upgrade if V3 not yet initialized
+        vm.selectFork(ETHEREUM_FORK_ID);
+        adapterAddrEthereum = addresses.getAddress(
+            "WORMHOLE_BRIDGE_ADAPTER_PROXY"
+        );
+        xwellAddrEthereum = addresses.getAddress("xWELL_PROXY");
+
+        /// Old impl doesn't have wormholeChainId(), so try/catch
+        try
+            WormholeBridgeAdapter(adapterAddrEthereum).wormholeChainId()
+        returns (uint16 chainId) {
+            if (chainId == 0) _upgradeEthereumAdapter();
+        } catch {
+            _upgradeEthereumAdapter();
+        }
+        coreBridgeEthereum = address(
+            WormholeBridgeAdapter(adapterAddrEthereum).coreBridge()
+        );
+        executorEthereum = address(
+            WormholeBridgeAdapter(adapterAddrEthereum).executor()
+        );
+    }
+
+    /// @notice Deploy new impl and upgradeAndCall on Ethereum fork
+    function _upgradeEthereumAdapter() internal {
+        address proxyAdmin = addresses.getAddress("PROXY_ADMIN");
+        address proxyAdminOwner = ProxyAdmin(proxyAdmin).owner();
+
+        vm.startPrank(proxyAdminOwner);
+        address newImpl = address(new WormholeBridgeAdapter());
+        ProxyAdmin(proxyAdmin).upgradeAndCall(
+            ITransparentUpgradeableProxy(adapterAddrEthereum),
+            newImpl,
+            abi.encodeWithSignature(
+                "initializeV3(address,address,address,address,uint16)",
+                addresses.getAddress("WORMHOLE_CORE"),
+                addresses.getAddress("WORMHOLE_EXECUTOR"),
+                address(0),
+                address(0),
+                ETHEREUM_WORMHOLE_CHAIN_ID
+            )
+        );
+        vm.stopPrank();
+    }
+
+    /// --------------------------------------------------------
+    /// ---------------------- Helpers -------------------------
+    /// --------------------------------------------------------
+
+    function _mockParseAndVerifyVM(
+        address coreBridgeAddr,
+        uint16 emitterChainId,
+        bytes32 emitterAddress,
+        uint64 sequence,
+        bytes memory payload
+    ) internal {
+        IWormhole.VM memory wormholeVm;
+        wormholeVm.emitterChainId = emitterChainId;
+        wormholeVm.emitterAddress = emitterAddress;
+        wormholeVm.sequence = sequence;
+        wormholeVm.payload = payload;
+        wormholeVm.consistencyLevel = 200;
+
+        vm.mockCall(
+            coreBridgeAddr,
+            abi.encodeWithSelector(IWormhole.parseAndVerifyVM.selector),
+            abi.encode(wormholeVm, true, "")
+        );
+    }
+
+    function _bridgeInViaVaa(
+        address adapterAddr,
+        address coreBridgeAddr,
+        address to,
+        uint256 amount,
+        uint64 sequence,
+        uint16 srcChainId
+    ) internal {
+        bytes32 emitterAddr = bytes32(uint256(uint160(adapterAddr)));
+        bytes memory payload = abi.encode(to, amount);
+
+        _mockParseAndVerifyVM(
+            coreBridgeAddr,
+            srcChainId,
+            emitterAddr,
+            sequence,
+            payload
+        );
+
+        WormholeBridgeAdapter(adapterAddr).executeVAAv1(abi.encode(sequence));
+        vm.clearMockedCalls();
+    }
+
+    /// @notice Mock the executor's requestExecution (off-chain quote overload)
+    /// so bridge-out with signedQuote succeeds on forks without a real signed quote.
+    function _mockExecutorRequestExecution(address executorAddr) internal {
+        vm.mockCall(
+            executorAddr,
+            abi.encodeWithSelector(IExecutor.requestExecution.selector),
+            abi.encode()
+        );
+    }
+
+    function _boundMintAmount(
+        address xwellAddr,
+        address adapterAddr,
+        uint256 mintAmount
+    ) internal view returns (uint256) {
+        uint256 buffer = xWELL(xwellAddr).buffer(adapterAddr);
+        return _bound(mintAmount, 1, buffer);
+    }
+
+    /// ========================================================
+    /// ================== Moonbeam Tests ======================
+    /// ========================================================
+
+    function testMoonbeamSetupAfterUpgrade() public {
+        vm.selectFork(MOONBEAM_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            adapterAddrMoonbeam
+        );
+
+        assertEq(
+            address(adapter.coreBridge()),
+            coreBridgeMoonbeam,
+            "Moonbeam: coreBridge not set"
+        );
+        assertTrue(
+            address(adapter.executor()) != address(0),
+            "Moonbeam: executor not set"
+        );
+        assertEq(
+            adapter.wormholeChainId(),
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            "Moonbeam: wormholeChainId not set"
+        );
+        assertEq(
+            address(adapter.wormholeRelayer()),
+            coreBridgeMoonbeam,
+            "Moonbeam: wormholeRelayer() should return coreBridge"
+        );
+        assertEq(
+            address(adapter.xERC20()),
+            xwellAddrMoonbeam,
+            "Moonbeam: xERC20 should be xWELL"
+        );
+        assertEq(adapter.gasLimit(), 300_000, "Moonbeam: gas limit changed");
+    }
+
+    function testMoonbeamReinitializeFails() public {
+        vm.selectFork(MOONBEAM_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            adapterAddrMoonbeam
+        );
+
+        vm.expectRevert("Initializable: contract is already initialized");
+        adapter.initializeV3(
+            address(1),
+            address(1),
+            address(0),
+            address(0),
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+    }
+
+    function testMoonbeamBridgeInSuccess() public {
+        vm.selectFork(MOONBEAM_FORK_ID);
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrMoonbeam,
+            adapterAddrMoonbeam,
+            startingWellAmount
+        );
+        uint256 startingBalance = xWELL(xwellAddrMoonbeam).balanceOf(user);
+
+        vm.expectEmit(true, true, true, true, adapterAddrMoonbeam);
+        emit BridgedIn(BASE_WORMHOLE_CHAIN_ID, user, mintAmount);
+
+        _bridgeInViaVaa(
+            adapterAddrMoonbeam,
+            coreBridgeMoonbeam,
+            user,
+            mintAmount,
+            0,
+            BASE_WORMHOLE_CHAIN_ID
+        );
+
+        assertEq(
+            xWELL(xwellAddrMoonbeam).balanceOf(user),
+            startingBalance + mintAmount,
+            "Moonbeam: user xWELL balance incorrect"
+        );
+    }
+
+    function testMoonbeamBridgeInReplayFails() public {
+        vm.selectFork(MOONBEAM_FORK_ID);
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrMoonbeam,
+            adapterAddrMoonbeam,
+            startingWellAmount / 2
+        );
+
+        _bridgeInViaVaa(
+            adapterAddrMoonbeam,
+            coreBridgeMoonbeam,
+            user,
+            mintAmount,
+            0,
+            BASE_WORMHOLE_CHAIN_ID
+        );
+
+        bytes32 emitterAddr = bytes32(uint256(uint160(adapterAddrMoonbeam)));
+        bytes memory payload = abi.encode(user, mintAmount);
+        _mockParseAndVerifyVM(
+            coreBridgeMoonbeam,
+            BASE_WORMHOLE_CHAIN_ID,
+            emitterAddr,
+            0,
+            payload
+        );
+
+        vm.expectRevert();
+        WormholeBridgeAdapter(adapterAddrMoonbeam).executeVAAv1(
+            abi.encode(uint64(0))
+        );
+        vm.clearMockedCalls();
+    }
+
+    function testMoonbeamBridgeInFailsUntrustedSender() public {
+        vm.selectFork(MOONBEAM_FORK_ID);
+
+        bytes32 untrustedEmitter = bytes32(uint256(uint160(address(0xdead))));
+        bytes memory payload = abi.encode(user, startingWellAmount);
+        _mockParseAndVerifyVM(
+            coreBridgeMoonbeam,
+            BASE_WORMHOLE_CHAIN_ID,
+            untrustedEmitter,
+            0,
+            payload
+        );
+
+        vm.expectRevert("WormholeBridge: sender not trusted");
+        WormholeBridgeAdapter(adapterAddrMoonbeam).executeVAAv1(
+            abi.encode(uint64(0))
+        );
+        vm.clearMockedCalls();
+    }
+
+    function testMoonbeamBridgeOutOffchainQuote() public {
+        vm.selectFork(MOONBEAM_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            adapterAddrMoonbeam
+        );
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrMoonbeam,
+            adapterAddrMoonbeam,
+            startingWellAmount
+        );
+        _bridgeInViaVaa(
+            adapterAddrMoonbeam,
+            coreBridgeMoonbeam,
+            user,
+            mintAmount,
+            0,
+            BASE_WORMHOLE_CHAIN_ID
+        );
+
+        uint256 bridgeOutAmount = mintAmount / 2;
+        uint256 startingBalance = xWELL(xwellAddrMoonbeam).balanceOf(user);
+
+        /// Mock the executor so it accepts the off-chain signed quote
+        _mockExecutorRequestExecution(executorMoonbeam);
+
+        uint256 messageFee = IWormhole(coreBridgeMoonbeam).messageFee();
+        uint256 totalCost = messageFee + 0.01 ether;
+        vm.deal(user, totalCost);
+        vm.startPrank(user);
+        xWELL(xwellAddrMoonbeam).approve(adapterAddrMoonbeam, bridgeOutAmount);
+
+        vm.expectEmit(true, true, true, true, adapterAddrMoonbeam);
+        emit TokensSent(BASE_WORMHOLE_CHAIN_ID, user, bridgeOutAmount);
+
+        adapter.bridge{value: totalCost}(
+            BASE_WORMHOLE_CHAIN_ID,
+            bridgeOutAmount,
+            user,
+            bytes("mock-signed-quote")
+        );
+        vm.stopPrank();
+        vm.clearMockedCalls();
+
+        assertEq(
+            xWELL(xwellAddrMoonbeam).balanceOf(user),
+            startingBalance - bridgeOutAmount,
+            "Moonbeam: balance incorrect after bridge out"
+        );
+    }
+
+    function testMoonbeamDeprecatedReceiveReverts() public {
+        vm.selectFork(MOONBEAM_FORK_ID);
+        vm.expectRevert("WormholeBridge: deprecated, use executeVAAv1");
+        WormholeBridgeAdapter(adapterAddrMoonbeam).receiveWormholeMessages(
+            "",
+            new bytes[](0),
+            bytes32(0),
+            0,
+            bytes32(0)
+        );
+    }
+
+    /// ========================================================
+    /// ===================== Base Tests =======================
+    /// ========================================================
+
+    function testBaseSetupAfterUpgrade() public {
+        vm.selectFork(BASE_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(adapterAddrBase);
+
+        assertEq(
+            address(adapter.coreBridge()),
+            coreBridgeBase,
+            "Base: coreBridge not set"
+        );
+        assertTrue(
+            address(adapter.executor()) != address(0),
+            "Base: executor not set"
+        );
+        assertEq(
+            adapter.wormholeChainId(),
+            BASE_WORMHOLE_CHAIN_ID,
+            "Base: wormholeChainId not set"
+        );
+        assertEq(
+            address(adapter.wormholeRelayer()),
+            coreBridgeBase,
+            "Base: wormholeRelayer() should return coreBridge"
+        );
+        assertEq(
+            address(adapter.xERC20()),
+            xwellAddrBase,
+            "Base: xERC20 should be xWELL"
+        );
+        assertEq(adapter.gasLimit(), 300_000, "Base: gas limit changed");
+    }
+
+    function testBaseReinitializeFails() public {
+        vm.selectFork(BASE_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(adapterAddrBase);
+
+        vm.expectRevert("Initializable: contract is already initialized");
+        adapter.initializeV3(
+            address(1),
+            address(1),
+            address(0),
+            address(0),
+            BASE_WORMHOLE_CHAIN_ID
+        );
+    }
+
+    function testBaseBridgeInSuccess() public {
+        vm.selectFork(BASE_FORK_ID);
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrBase,
+            adapterAddrBase,
+            startingWellAmount
+        );
+        uint256 startingBalance = xWELL(xwellAddrBase).balanceOf(user);
+
+        vm.expectEmit(true, true, true, true, adapterAddrBase);
+        emit BridgedIn(MOONBEAM_WORMHOLE_CHAIN_ID, user, mintAmount);
+
+        _bridgeInViaVaa(
+            adapterAddrBase,
+            coreBridgeBase,
+            user,
+            mintAmount,
+            0,
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+
+        assertEq(
+            xWELL(xwellAddrBase).balanceOf(user),
+            startingBalance + mintAmount,
+            "Base: user xWELL balance incorrect"
+        );
+    }
+
+    function testBaseBridgeInReplayFails() public {
+        vm.selectFork(BASE_FORK_ID);
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrBase,
+            adapterAddrBase,
+            startingWellAmount / 2
+        );
+
+        _bridgeInViaVaa(
+            adapterAddrBase,
+            coreBridgeBase,
+            user,
+            mintAmount,
+            0,
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+
+        bytes32 emitterAddr = bytes32(uint256(uint160(adapterAddrBase)));
+        bytes memory payload = abi.encode(user, mintAmount);
+        _mockParseAndVerifyVM(
+            coreBridgeBase,
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            emitterAddr,
+            0,
+            payload
+        );
+
+        vm.expectRevert();
+        WormholeBridgeAdapter(adapterAddrBase).executeVAAv1(
+            abi.encode(uint64(0))
+        );
+        vm.clearMockedCalls();
+    }
+
+    function testBaseBridgeInFailsUntrustedSender() public {
+        vm.selectFork(BASE_FORK_ID);
+
+        bytes32 untrustedEmitter = bytes32(uint256(uint160(address(0xdead))));
+        bytes memory payload = abi.encode(user, startingWellAmount);
+        _mockParseAndVerifyVM(
+            coreBridgeBase,
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            untrustedEmitter,
+            0,
+            payload
+        );
+
+        vm.expectRevert("WormholeBridge: sender not trusted");
+        WormholeBridgeAdapter(adapterAddrBase).executeVAAv1(
+            abi.encode(uint64(0))
+        );
+        vm.clearMockedCalls();
+    }
+
+    function testBaseBridgeOutOnchainQuote() public {
+        vm.selectFork(BASE_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(adapterAddrBase);
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrBase,
+            adapterAddrBase,
+            startingWellAmount
+        );
+        _bridgeInViaVaa(
+            adapterAddrBase,
+            coreBridgeBase,
+            user,
+            mintAmount,
+            0,
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+
+        uint256 cost = adapter.bridgeCost(MOONBEAM_WORMHOLE_CHAIN_ID);
+        if (cost == 0) return; /// quoter not live on fork
+
+        uint256 bridgeOutAmount = mintAmount / 2;
+        uint256 startingBalance = xWELL(xwellAddrBase).balanceOf(user);
+
+        vm.deal(user, cost);
+        vm.startPrank(user);
+        xWELL(xwellAddrBase).approve(adapterAddrBase, bridgeOutAmount);
+
+        vm.expectEmit(true, true, true, true, adapterAddrBase);
+        emit TokensSent(MOONBEAM_WORMHOLE_CHAIN_ID, user, bridgeOutAmount);
+
+        adapter.bridge{value: cost}(
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            bridgeOutAmount,
+            user
+        );
+        vm.stopPrank();
+
+        assertEq(
+            xWELL(xwellAddrBase).balanceOf(user),
+            startingBalance - bridgeOutAmount,
+            "Base: balance incorrect after on-chain bridge out"
+        );
+    }
+
+    function testBaseBridgeOutOffchainQuote() public {
+        vm.selectFork(BASE_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(adapterAddrBase);
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrBase,
+            adapterAddrBase,
+            startingWellAmount
+        );
+        _bridgeInViaVaa(
+            adapterAddrBase,
+            coreBridgeBase,
+            user,
+            mintAmount,
+            1,
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+
+        uint256 bridgeOutAmount = mintAmount / 2;
+        uint256 startingBalance = xWELL(xwellAddrBase).balanceOf(user);
+
+        _mockExecutorRequestExecution(executorBase);
+
+        uint256 messageFee = IWormhole(coreBridgeBase).messageFee();
+        uint256 totalCost = messageFee + 0.01 ether;
+        vm.deal(user, totalCost);
+        vm.startPrank(user);
+        xWELL(xwellAddrBase).approve(adapterAddrBase, bridgeOutAmount);
+
+        vm.expectEmit(true, true, true, true, adapterAddrBase);
+        emit TokensSent(MOONBEAM_WORMHOLE_CHAIN_ID, user, bridgeOutAmount);
+
+        adapter.bridge{value: totalCost}(
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            bridgeOutAmount,
+            user,
+            bytes("mock-signed-quote")
+        );
+        vm.stopPrank();
+        vm.clearMockedCalls();
+
+        assertEq(
+            xWELL(xwellAddrBase).balanceOf(user),
+            startingBalance - bridgeOutAmount,
+            "Base: balance incorrect after off-chain bridge out"
+        );
+    }
+
+    function testBaseDeprecatedReceiveReverts() public {
+        vm.selectFork(BASE_FORK_ID);
+        vm.expectRevert("WormholeBridge: deprecated, use executeVAAv1");
+        WormholeBridgeAdapter(adapterAddrBase).receiveWormholeMessages(
+            "",
+            new bytes[](0),
+            bytes32(0),
+            0,
+            bytes32(0)
+        );
+    }
+
+    /// ========================================================
+    /// ================== Optimism Tests ======================
+    /// ========================================================
+
+    function testOptimismSetupAfterUpgrade() public {
+        vm.selectFork(OPTIMISM_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            adapterAddrOptimism
+        );
+
+        assertEq(
+            address(adapter.coreBridge()),
+            coreBridgeOptimism,
+            "Optimism: coreBridge not set"
+        );
+        assertTrue(
+            address(adapter.executor()) != address(0),
+            "Optimism: executor not set"
+        );
+        assertEq(
+            adapter.wormholeChainId(),
+            OPTIMISM_WORMHOLE_CHAIN_ID,
+            "Optimism: wormholeChainId not set"
+        );
+        assertEq(
+            address(adapter.wormholeRelayer()),
+            coreBridgeOptimism,
+            "Optimism: wormholeRelayer() should return coreBridge"
+        );
+        assertEq(
+            address(adapter.xERC20()),
+            xwellAddrOptimism,
+            "Optimism: xERC20 should be xWELL"
+        );
+        assertEq(adapter.gasLimit(), 300_000, "Optimism: gas limit changed");
+    }
+
+    function testOptimismReinitializeFails() public {
+        vm.selectFork(OPTIMISM_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            adapterAddrOptimism
+        );
+
+        vm.expectRevert("Initializable: contract is already initialized");
+        adapter.initializeV3(
+            address(1),
+            address(1),
+            address(0),
+            address(0),
+            OPTIMISM_WORMHOLE_CHAIN_ID
+        );
+    }
+
+    function testOptimismBridgeInSuccess() public {
+        vm.selectFork(OPTIMISM_FORK_ID);
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrOptimism,
+            adapterAddrOptimism,
+            startingWellAmount
+        );
+        uint256 startingBalance = xWELL(xwellAddrOptimism).balanceOf(user);
+
+        vm.expectEmit(true, true, true, true, adapterAddrOptimism);
+        emit BridgedIn(MOONBEAM_WORMHOLE_CHAIN_ID, user, mintAmount);
+
+        _bridgeInViaVaa(
+            adapterAddrOptimism,
+            coreBridgeOptimism,
+            user,
+            mintAmount,
+            0,
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+
+        assertEq(
+            xWELL(xwellAddrOptimism).balanceOf(user),
+            startingBalance + mintAmount,
+            "Optimism: user xWELL balance incorrect"
+        );
+    }
+
+    function testOptimismBridgeInReplayFails() public {
+        vm.selectFork(OPTIMISM_FORK_ID);
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrOptimism,
+            adapterAddrOptimism,
+            startingWellAmount / 2
+        );
+
+        _bridgeInViaVaa(
+            adapterAddrOptimism,
+            coreBridgeOptimism,
+            user,
+            mintAmount,
+            0,
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+
+        bytes32 emitterAddr = bytes32(uint256(uint160(adapterAddrOptimism)));
+        bytes memory payload = abi.encode(user, mintAmount);
+        _mockParseAndVerifyVM(
+            coreBridgeOptimism,
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            emitterAddr,
+            0,
+            payload
+        );
+
+        vm.expectRevert();
+        WormholeBridgeAdapter(adapterAddrOptimism).executeVAAv1(
+            abi.encode(uint64(0))
+        );
+        vm.clearMockedCalls();
+    }
+
+    function testOptimismBridgeInFailsUntrustedSender() public {
+        vm.selectFork(OPTIMISM_FORK_ID);
+
+        bytes32 untrustedEmitter = bytes32(uint256(uint160(address(0xdead))));
+        bytes memory payload = abi.encode(user, startingWellAmount);
+        _mockParseAndVerifyVM(
+            coreBridgeOptimism,
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            untrustedEmitter,
+            0,
+            payload
+        );
+
+        vm.expectRevert("WormholeBridge: sender not trusted");
+        WormholeBridgeAdapter(adapterAddrOptimism).executeVAAv1(
+            abi.encode(uint64(0))
+        );
+        vm.clearMockedCalls();
+    }
+
+    function testOptimismBridgeOutOnchainQuote() public {
+        vm.selectFork(OPTIMISM_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            adapterAddrOptimism
+        );
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrOptimism,
+            adapterAddrOptimism,
+            startingWellAmount
+        );
+        _bridgeInViaVaa(
+            adapterAddrOptimism,
+            coreBridgeOptimism,
+            user,
+            mintAmount,
+            0,
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+
+        uint256 cost = adapter.bridgeCost(MOONBEAM_WORMHOLE_CHAIN_ID);
+        if (cost == 0) return; /// quoter not live on fork
+
+        uint256 bridgeOutAmount = mintAmount / 2;
+        uint256 startingBalance = xWELL(xwellAddrOptimism).balanceOf(user);
+
+        vm.deal(user, cost);
+        vm.startPrank(user);
+        xWELL(xwellAddrOptimism).approve(adapterAddrOptimism, bridgeOutAmount);
+
+        vm.expectEmit(true, true, true, true, adapterAddrOptimism);
+        emit TokensSent(MOONBEAM_WORMHOLE_CHAIN_ID, user, bridgeOutAmount);
+
+        adapter.bridge{value: cost}(
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            bridgeOutAmount,
+            user
+        );
+        vm.stopPrank();
+
+        assertEq(
+            xWELL(xwellAddrOptimism).balanceOf(user),
+            startingBalance - bridgeOutAmount,
+            "Optimism: balance incorrect after on-chain bridge out"
+        );
+    }
+
+    function testOptimismBridgeOutOffchainQuote() public {
+        vm.selectFork(OPTIMISM_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            adapterAddrOptimism
+        );
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrOptimism,
+            adapterAddrOptimism,
+            startingWellAmount
+        );
+        _bridgeInViaVaa(
+            adapterAddrOptimism,
+            coreBridgeOptimism,
+            user,
+            mintAmount,
+            1,
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+
+        uint256 bridgeOutAmount = mintAmount / 2;
+        uint256 startingBalance = xWELL(xwellAddrOptimism).balanceOf(user);
+
+        _mockExecutorRequestExecution(executorOptimism);
+
+        uint256 messageFee = IWormhole(coreBridgeOptimism).messageFee();
+        uint256 totalCost = messageFee + 0.01 ether;
+        vm.deal(user, totalCost);
+        vm.startPrank(user);
+        xWELL(xwellAddrOptimism).approve(adapterAddrOptimism, bridgeOutAmount);
+
+        vm.expectEmit(true, true, true, true, adapterAddrOptimism);
+        emit TokensSent(MOONBEAM_WORMHOLE_CHAIN_ID, user, bridgeOutAmount);
+
+        adapter.bridge{value: totalCost}(
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            bridgeOutAmount,
+            user,
+            bytes("mock-signed-quote")
+        );
+        vm.stopPrank();
+        vm.clearMockedCalls();
+
+        assertEq(
+            xWELL(xwellAddrOptimism).balanceOf(user),
+            startingBalance - bridgeOutAmount,
+            "Optimism: balance incorrect after off-chain bridge out"
+        );
+    }
+
+    function testOptimismDeprecatedReceiveReverts() public {
+        vm.selectFork(OPTIMISM_FORK_ID);
+        vm.expectRevert("WormholeBridge: deprecated, use executeVAAv1");
+        WormholeBridgeAdapter(adapterAddrOptimism).receiveWormholeMessages(
+            "",
+            new bytes[](0),
+            bytes32(0),
+            0,
+            bytes32(0)
+        );
+    }
+
+    /// ========================================================
+    /// ================== Ethereum Tests ======================
+    /// ========================================================
+
+    function testEthereumSetupAfterUpgrade() public {
+        vm.selectFork(ETHEREUM_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            adapterAddrEthereum
+        );
+
+        assertEq(
+            address(adapter.coreBridge()),
+            addresses.getAddress("WORMHOLE_CORE"),
+            "Ethereum: coreBridge not set"
+        );
+        assertEq(
+            address(adapter.executor()),
+            addresses.getAddress("WORMHOLE_EXECUTOR"),
+            "Ethereum: executor not set"
+        );
+        assertEq(
+            adapter.wormholeChainId(),
+            ETHEREUM_WORMHOLE_CHAIN_ID,
+            "Ethereum: wormholeChainId not set"
+        );
+        assertEq(
+            address(adapter.wormholeRelayer()),
+            addresses.getAddress("WORMHOLE_CORE"),
+            "Ethereum: wormholeRelayer() should return coreBridge"
+        );
+        assertEq(
+            address(adapter.xERC20()),
+            xwellAddrEthereum,
+            "Ethereum: xERC20 should be xWELL"
+        );
+        assertEq(adapter.gasLimit(), 300_000, "Ethereum: gas limit changed");
+    }
+
+    function testEthereumReinitializeFails() public {
+        vm.selectFork(ETHEREUM_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            adapterAddrEthereum
+        );
+
+        vm.expectRevert("Initializable: contract is already initialized");
+        adapter.initializeV3(
+            address(1),
+            address(1),
+            address(0),
+            address(0),
+            ETHEREUM_WORMHOLE_CHAIN_ID
+        );
+    }
+
+    function testEthereumBridgeInSuccess() public {
+        vm.selectFork(ETHEREUM_FORK_ID);
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrEthereum,
+            adapterAddrEthereum,
+            startingWellAmount
+        );
+        uint256 startingBalance = xWELL(xwellAddrEthereum).balanceOf(user);
+
+        vm.expectEmit(true, true, true, true, adapterAddrEthereum);
+        emit BridgedIn(MOONBEAM_WORMHOLE_CHAIN_ID, user, mintAmount);
+
+        _bridgeInViaVaa(
+            adapterAddrEthereum,
+            coreBridgeEthereum,
+            user,
+            mintAmount,
+            0,
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+
+        assertEq(
+            xWELL(xwellAddrEthereum).balanceOf(user),
+            startingBalance + mintAmount,
+            "Ethereum: user xWELL balance incorrect"
+        );
+    }
+
+    function testEthereumBridgeInReplayFails() public {
+        vm.selectFork(ETHEREUM_FORK_ID);
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrEthereum,
+            adapterAddrEthereum,
+            startingWellAmount / 2
+        );
+
+        _bridgeInViaVaa(
+            adapterAddrEthereum,
+            coreBridgeEthereum,
+            user,
+            mintAmount,
+            0,
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+
+        bytes32 emitterAddr = bytes32(uint256(uint160(adapterAddrEthereum)));
+        bytes memory payload = abi.encode(user, mintAmount);
+        _mockParseAndVerifyVM(
+            coreBridgeEthereum,
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            emitterAddr,
+            0,
+            payload
+        );
+
+        vm.expectRevert();
+        WormholeBridgeAdapter(adapterAddrEthereum).executeVAAv1(
+            abi.encode(uint64(0))
+        );
+        vm.clearMockedCalls();
+    }
+
+    function testEthereumBridgeInFailsUntrustedSender() public {
+        vm.selectFork(ETHEREUM_FORK_ID);
+
+        bytes32 untrustedEmitter = bytes32(uint256(uint160(address(0xdead))));
+        bytes memory payload = abi.encode(user, startingWellAmount);
+        _mockParseAndVerifyVM(
+            coreBridgeEthereum,
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            untrustedEmitter,
+            0,
+            payload
+        );
+
+        vm.expectRevert("WormholeBridge: sender not trusted");
+        WormholeBridgeAdapter(adapterAddrEthereum).executeVAAv1(
+            abi.encode(uint64(0))
+        );
+        vm.clearMockedCalls();
+    }
+
+    function testEthereumBridgeOutOnchainQuote() public {
+        vm.selectFork(ETHEREUM_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            adapterAddrEthereum
+        );
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrEthereum,
+            adapterAddrEthereum,
+            startingWellAmount
+        );
+        _bridgeInViaVaa(
+            adapterAddrEthereum,
+            coreBridgeEthereum,
+            user,
+            mintAmount,
+            0,
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+
+        uint256 cost = adapter.bridgeCost(MOONBEAM_WORMHOLE_CHAIN_ID);
+        if (cost == 0) return; /// quoter not live on fork
+
+        uint256 bridgeOutAmount = mintAmount / 2;
+        uint256 startingBalance = xWELL(xwellAddrEthereum).balanceOf(user);
+
+        vm.deal(user, cost);
+        vm.startPrank(user);
+        xWELL(xwellAddrEthereum).approve(adapterAddrEthereum, bridgeOutAmount);
+
+        vm.expectEmit(true, true, true, true, adapterAddrEthereum);
+        emit TokensSent(MOONBEAM_WORMHOLE_CHAIN_ID, user, bridgeOutAmount);
+
+        adapter.bridge{value: cost}(
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            bridgeOutAmount,
+            user
+        );
+        vm.stopPrank();
+
+        assertEq(
+            xWELL(xwellAddrEthereum).balanceOf(user),
+            startingBalance - bridgeOutAmount,
+            "Ethereum: balance incorrect after on-chain bridge out"
+        );
+    }
+
+    function testEthereumBridgeOutOffchainQuote() public {
+        vm.selectFork(ETHEREUM_FORK_ID);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            adapterAddrEthereum
+        );
+
+        uint256 mintAmount = _boundMintAmount(
+            xwellAddrEthereum,
+            adapterAddrEthereum,
+            startingWellAmount
+        );
+        _bridgeInViaVaa(
+            adapterAddrEthereum,
+            coreBridgeEthereum,
+            user,
+            mintAmount,
+            1,
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+
+        uint256 bridgeOutAmount = mintAmount / 2;
+        uint256 startingBalance = xWELL(xwellAddrEthereum).balanceOf(user);
+
+        _mockExecutorRequestExecution(executorEthereum);
+
+        uint256 messageFee = IWormhole(coreBridgeEthereum).messageFee();
+        uint256 totalCost = messageFee + 0.01 ether;
+        vm.deal(user, totalCost);
+        vm.startPrank(user);
+        xWELL(xwellAddrEthereum).approve(adapterAddrEthereum, bridgeOutAmount);
+
+        vm.expectEmit(true, true, true, true, adapterAddrEthereum);
+        emit TokensSent(MOONBEAM_WORMHOLE_CHAIN_ID, user, bridgeOutAmount);
+
+        adapter.bridge{value: totalCost}(
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            bridgeOutAmount,
+            user,
+            bytes("mock-signed-quote")
+        );
+        vm.stopPrank();
+        vm.clearMockedCalls();
+
+        assertEq(
+            xWELL(xwellAddrEthereum).balanceOf(user),
+            startingBalance - bridgeOutAmount,
+            "Ethereum: balance incorrect after off-chain bridge out"
+        );
+    }
+
+    function testEthereumDeprecatedReceiveReverts() public {
+        vm.selectFork(ETHEREUM_FORK_ID);
+        vm.expectRevert("WormholeBridge: deprecated, use executeVAAv1");
+        WormholeBridgeAdapter(adapterAddrEthereum).receiveWormholeMessages(
+            "",
+            new bytes[](0),
+            bytes32(0),
+            0,
+            bytes32(0)
+        );
+    }
+
+    /// ========================================================
+    /// ============= Cross-Chain Consistency Tests ============
+    /// ========================================================
+
+    function testAllChainsV3Initialized() public {
+        vm.selectFork(MOONBEAM_FORK_ID);
+        assertEq(
+            WormholeBridgeAdapter(adapterAddrMoonbeam).wormholeChainId(),
+            MOONBEAM_WORMHOLE_CHAIN_ID,
+            "Moonbeam V3 not initialized"
+        );
+
+        vm.selectFork(BASE_FORK_ID);
+        assertEq(
+            WormholeBridgeAdapter(adapterAddrBase).wormholeChainId(),
+            BASE_WORMHOLE_CHAIN_ID,
+            "Base V3 not initialized"
+        );
+
+        vm.selectFork(OPTIMISM_FORK_ID);
+        assertEq(
+            WormholeBridgeAdapter(adapterAddrOptimism).wormholeChainId(),
+            OPTIMISM_WORMHOLE_CHAIN_ID,
+            "Optimism V3 not initialized"
+        );
+
+        vm.selectFork(ETHEREUM_FORK_ID);
+        assertEq(
+            WormholeBridgeAdapter(adapterAddrEthereum).wormholeChainId(),
+            ETHEREUM_WORMHOLE_CHAIN_ID,
+            "Ethereum V3 not initialized"
+        );
+    }
+
+    function testAllChainsBridgeCostDoesNotRevert() public view {
+        /// bridgeCost uses try/catch so it should never revert,
+        /// even if the executor quoter is not live on the fork.
+        WormholeBridgeAdapter(adapterAddrMoonbeam).bridgeCost(
+            BASE_WORMHOLE_CHAIN_ID
+        );
+        WormholeBridgeAdapter(adapterAddrBase).bridgeCost(
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+        WormholeBridgeAdapter(adapterAddrOptimism).bridgeCost(
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+        WormholeBridgeAdapter(adapterAddrEthereum).bridgeCost(
+            MOONBEAM_WORMHOLE_CHAIN_ID
+        );
+    }
+
+    function testBridgeInFailsWithValueAllChains() public {
+        vm.selectFork(MOONBEAM_FORK_ID);
+        vm.deal(address(this), 1 ether);
+        vm.expectRevert("WormholeBridge: no value allowed");
+        WormholeBridgeAdapter(adapterAddrMoonbeam).executeVAAv1{value: 1}(
+            bytes("")
+        );
+
+        vm.selectFork(BASE_FORK_ID);
+        vm.deal(address(this), 1 ether);
+        vm.expectRevert("WormholeBridge: no value allowed");
+        WormholeBridgeAdapter(adapterAddrBase).executeVAAv1{value: 1}(
+            bytes("")
+        );
+
+        vm.selectFork(OPTIMISM_FORK_ID);
+        vm.deal(address(this), 1 ether);
+        vm.expectRevert("WormholeBridge: no value allowed");
+        WormholeBridgeAdapter(adapterAddrOptimism).executeVAAv1{value: 1}(
+            bytes("")
+        );
+
+        vm.selectFork(ETHEREUM_FORK_ID);
+        vm.deal(address(this), 1 ether);
+        vm.expectRevert("WormholeBridge: no value allowed");
+        WormholeBridgeAdapter(adapterAddrEthereum).executeVAAv1{value: 1}(
+            bytes("")
+        );
+    }
+
+    function testBridgeOutFailsInvalidTargetAllChains() public {
+        uint16 invalidChainId = 999;
+
+        vm.selectFork(MOONBEAM_FORK_ID);
+        vm.expectRevert("WormholeBridge: invalid target chain");
+        WormholeBridgeAdapter(adapterAddrMoonbeam).bridge{value: 0}(
+            invalidChainId,
+            1e18,
+            user,
+            bytes("")
+        );
+
+        vm.selectFork(BASE_FORK_ID);
+        vm.expectRevert("WormholeBridge: invalid target chain");
+        WormholeBridgeAdapter(adapterAddrBase).bridge{value: 0}(
+            invalidChainId,
+            1e18,
+            user,
+            bytes("")
+        );
+
+        vm.selectFork(OPTIMISM_FORK_ID);
+        vm.expectRevert("WormholeBridge: invalid target chain");
+        WormholeBridgeAdapter(adapterAddrOptimism).bridge{value: 0}(
+            invalidChainId,
+            1e18,
+            user,
+            bytes("")
+        );
+
+        vm.selectFork(ETHEREUM_FORK_ID);
+        vm.expectRevert("WormholeBridge: invalid target chain");
+        WormholeBridgeAdapter(adapterAddrEthereum).bridge{value: 0}(
+            invalidChainId,
+            1e18,
+            user,
+            bytes("")
+        );
+    }
+}

--- a/test/mock/MockCoreBridgeForAdapter.sol
+++ b/test/mock/MockCoreBridgeForAdapter.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.19;
+
+import {IWormhole} from "@protocol/wormhole/IWormhole.sol";
+
+/// @notice Mock Wormhole Core Bridge for xWELL WormholeBridgeAdapter tests.
+/// Combines publishMessage + parseAndVerifyVM + messageFee + chainId.
+contract MockCoreBridgeForAdapter {
+    bool public valid = true;
+    string public reason = "";
+    uint16 public mockChainId;
+    uint256 public mockMessageFee;
+    uint64 public nextSequence;
+
+    /// @notice storage for configuring parseAndVerifyVM response
+    uint16 public vmEmitterChainId;
+    bytes32 public vmEmitterAddress;
+    uint64 public vmSequence;
+    bytes public vmPayload;
+
+    function setValid(bool _valid, string memory _reason) external {
+        valid = _valid;
+        reason = _reason;
+    }
+
+    function setChainId(uint16 _chainId) external {
+        mockChainId = _chainId;
+    }
+
+    function setMessageFee(uint256 _fee) external {
+        mockMessageFee = _fee;
+    }
+
+    /// @notice Configure what parseAndVerifyVM will return
+    function setVmData(
+        uint16 _emitterChainId,
+        bytes32 _emitterAddress,
+        uint64 _sequence,
+        bytes memory _payload
+    ) external {
+        vmEmitterChainId = _emitterChainId;
+        vmEmitterAddress = _emitterAddress;
+        vmSequence = _sequence;
+        vmPayload = _payload;
+    }
+
+    function chainId() external view returns (uint16) {
+        return mockChainId;
+    }
+
+    function messageFee() external view returns (uint256) {
+        return mockMessageFee;
+    }
+
+    function publishMessage(
+        uint32,
+        bytes memory,
+        uint8
+    ) external payable returns (uint64 sequence) {
+        sequence = nextSequence;
+        nextSequence++;
+    }
+
+    function parseAndVerifyVM(
+        bytes calldata
+    )
+        external
+        view
+        returns (IWormhole.VM memory vm, bool _valid, string memory _reason)
+    {
+        vm.emitterChainId = vmEmitterChainId;
+        vm.emitterAddress = vmEmitterAddress;
+        vm.sequence = vmSequence;
+        vm.payload = vmPayload;
+        vm.consistencyLevel = 200;
+
+        _valid = valid;
+        _reason = reason;
+    }
+}

--- a/test/mock/MockExecutorQuoterRouter.sol
+++ b/test/mock/MockExecutorQuoterRouter.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.19;
+
+/// @notice Mock ExecutorQuoterRouter for xWELL WormholeBridgeAdapter tests.
+contract MockExecutorQuoterRouter {
+    uint256 public mockQuote;
+    uint256 public lastRequestValue;
+    uint16 public lastDstChain;
+    uint256 public requestCount;
+
+    function setQuote(uint256 _quote) external {
+        mockQuote = _quote;
+    }
+
+    function quoteExecution(
+        uint16,
+        bytes32,
+        address,
+        address,
+        bytes calldata,
+        bytes calldata
+    ) external view returns (uint256) {
+        return mockQuote;
+    }
+
+    /// @notice On-chain quoting requestExecution (IExecutorQuoterRouter)
+    function requestExecution(
+        uint16 dstChain,
+        bytes32,
+        address,
+        address,
+        bytes calldata,
+        bytes calldata
+    ) external payable {
+        lastRequestValue = msg.value;
+        lastDstChain = dstChain;
+        requestCount++;
+    }
+
+    /// @notice Off-chain quoting requestExecution (IExecutor)
+    function requestExecution(
+        uint16 dstChain,
+        bytes32,
+        address,
+        bytes calldata,
+        bytes calldata,
+        bytes calldata
+    ) external payable {
+        lastRequestValue = msg.value;
+        lastDstChain = dstChain;
+        requestCount++;
+    }
+}

--- a/test/unit/WormholeBridgeAdapter.t.sol
+++ b/test/unit/WormholeBridgeAdapter.t.sol
@@ -6,13 +6,12 @@ import "@forge-std/Test.sol";
 
 import "@test/helper/BaseTest.t.sol";
 
-import {Address} from "@utils/Address.sol";
-import {MockWormholeReceiver} from "@test/mock/MockWormholeReceiver.sol";
+import {IWormhole} from "@protocol/wormhole/IWormhole.sol";
 import {WormholeTrustedSender} from "@protocol/governance/WormholeTrustedSender.sol";
+import {MockCoreBridgeForAdapter} from "@test/mock/MockCoreBridgeForAdapter.sol";
+import {MockExecutorQuoterRouter} from "@test/mock/MockExecutorQuoterRouter.sol";
 
 contract WormholeBridgeAdapterUnitTest is BaseTest {
-    using Address for address;
-
     /// xerc20 bridge adapter events
 
     /// @notice emitted when tokens are bridged out
@@ -70,44 +69,89 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
     /// @notice amount of tokens to mint
     uint256 amount;
 
-    /// relayer gas cost
-    uint256 public constant gasCost = 0.00001 * 1 ether;
-
-    /// mock wormhole receiver
-    MockWormholeReceiver receiver;
-
     function setUp() public override {
         super.setUp();
         to = address(999999999999999);
         amount = 100 * 1e18;
-        receiver = new MockWormholeReceiver();
-        uint256 codeSize;
-        assembly {
-            codeSize := extcodesize(sload(receiver.slot))
-        }
-
-        bytes memory runtimeBytecode = new bytes(codeSize);
-
-        assembly {
-            extcodecopy(
-                sload(receiver.slot),
-                add(runtimeBytecode, 0x20),
-                0,
-                codeSize
-            )
-        }
-
-        /// set the wormhole relayer address to have the
-        /// runtime bytecode of the mock wormhole relayer
-        vm.etch(wormholeRelayer, runtimeBytecode);
     }
+
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ------------------- Helper Functions -------------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+
+    /// @notice Set up mock core bridge to return a valid VAA with given params
+    /// @param emitterChainId the chain the message was emitted from
+    /// @param emitterAddress the address that emitted the message (bytes32)
+    /// @param sequence the VAA sequence number
+    /// @param payload the VAA payload
+    /// @return encodedVaa fake encoded VAA bytes (just used as passthrough to mock)
+    function _setupVaa(
+        uint16 emitterChainId,
+        bytes32 emitterAddress,
+        uint64 sequence,
+        bytes memory payload
+    ) internal returns (bytes memory encodedVaa) {
+        mockCoreBridge.setVmData(
+            emitterChainId,
+            emitterAddress,
+            sequence,
+            payload
+        );
+        /// The actual bytes don't matter — the mock ignores them and returns preset data
+        encodedVaa = abi.encode(
+            "mock-vaa",
+            emitterChainId,
+            emitterAddress,
+            sequence
+        );
+    }
+
+    /// @notice Bridge in tokens via executeVAAv1 using a valid VAA from the trusted adapter
+    /// @param sequence the VAA sequence number (each call must use a unique sequence)
+    function _bridgeInViaVaa(uint64 sequence) internal {
+        bytes32 emitterAddr = bytes32(
+            uint256(uint160(address(wormholeBridgeAdapterProxy)))
+        );
+        bytes memory payload = abi.encode(to, amount);
+        bytes memory encodedVaa = _setupVaa(
+            chainId,
+            emitterAddr,
+            sequence,
+            payload
+        );
+
+        wormholeBridgeAdapterProxy.executeVAAv1(encodedVaa);
+    }
+
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// -------------------- Setup Tests -----------------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
 
     function testSetup() public view {
         assertEq(wormholeBridgeAdapterProxy.owner(), owner, "invalid owner");
         assertEq(
             address(wormholeBridgeAdapterProxy.wormholeRelayer()),
-            wormholeRelayer,
-            "invalid wormhole relayer"
+            address(mockCoreBridge),
+            "invalid wormhole relayer / core bridge"
+        );
+        assertEq(
+            address(wormholeBridgeAdapterProxy.coreBridge()),
+            address(mockCoreBridge),
+            "invalid core bridge"
+        );
+        assertEq(
+            address(wormholeBridgeAdapterProxy.executorQuoterRouter()),
+            address(mockExecutorQuoterRouter),
+            "invalid executor quoter router"
+        );
+        assertEq(
+            wormholeBridgeAdapterProxy.wormholeChainId(),
+            chainId,
+            "invalid wormhole chain id"
         );
         assertTrue(
             wormholeBridgeAdapterProxy.isTrustedSender(
@@ -135,16 +179,6 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
             xwellProxy.bufferCap(address(wormholeBridgeAdapterProxy)),
             externalChainBufferCap,
             "incorrect buffer cap for wormhole bridge adapter"
-        );
-        assertEq(
-            MockWormholeReceiver(wormholeRelayer).price(),
-            0,
-            "price not zero"
-        );
-        assertEq(
-            MockWormholeReceiver(wormholeRelayer).nonce(),
-            0,
-            "nonce not zero"
         );
     }
 
@@ -174,7 +208,22 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         );
     }
 
-    /// ACL failure tests
+    function testInitializeV3FailsAlreadyInitialized() public {
+        vm.expectRevert("Initializable: contract is already initialized");
+        wormholeBridgeAdapterProxy.initializeV3(
+            address(mockCoreBridge),
+            address(mockExecutorQuoterRouter),
+            address(mockExecutorQuoterRouter),
+            address(0),
+            chainId
+        );
+    }
+
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ------------------- ACL Failure Tests ------------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
 
     function testSetGasLimitNonOwnerFails() public {
         vm.expectRevert("Ownable: caller is not the owner");
@@ -202,7 +251,11 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         );
     }
 
-    /// ACL success tests
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ------------------- ACL Success Tests ------------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
 
     function testSetGasLimitOwnerSucceeds(uint96 newGasLimit) public {
         uint96 oldGasLimit = wormholeBridgeAdapterProxy.gasLimit();
@@ -329,7 +382,12 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         );
     }
 
-    /// initialization
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// --------------- Initialization Tests -------------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+
     function testInitializeFailsArrayLengthMismatch() public {
         ProxyAdmin admin = new ProxyAdmin();
         (, , , , address wormholeAdapterProxy, ) = deployMoonbeamSystem(
@@ -350,66 +408,75 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         );
     }
 
-    /// receiveWormholeMessages failure tests
-    /// value
-    function testReceiveWormholeMessageFailsWithValue() public {
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ----------- executeVAAv1 Failure Tests -----------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+
+    /// msg.value must be 0
+    function testExecuteVAAv1FailsWithValue() public {
         vm.deal(address(this), 100);
         vm.expectRevert("WormholeBridge: no value allowed");
-        wormholeBridgeAdapterProxy.receiveWormholeMessages{value: 100}(
-            "",
-            new bytes[](0),
-            address(this).toBytes(),
-            chainId,
-            bytes32(type(uint256).max)
-        );
+        wormholeBridgeAdapterProxy.executeVAAv1{value: 100}(bytes("fake-vaa"));
     }
 
-    /// not relayer address
-    function testReceiveWormholeMessageFailsNotRelayer() public {
-        vm.expectRevert("WormholeBridge: only relayer allowed");
-        wormholeBridgeAdapterProxy.receiveWormholeMessages{value: 0}(
-            "",
-            new bytes[](0),
-            address(this).toBytes(),
-            chainId,
-            bytes32(type(uint256).max)
-        );
+    /// invalid VAA (core bridge returns valid=false)
+    function testExecuteVAAv1FailsInvalidVaa() public {
+        mockCoreBridge.setValid(false, "bad signature");
+        bytes memory encodedVaa = bytes("invalid-vaa");
+
+        vm.expectRevert("bad signature");
+        wormholeBridgeAdapterProxy.executeVAAv1(encodedVaa);
     }
 
-    /// already processed
-
-    function testAlreadyProcessedMessageReplayFails(bytes32 nonce) public {
-        testReceiveWormholeMessageSucceeds(nonce);
-
-        vm.prank(wormholeRelayer);
-        vm.expectRevert("WormholeBridge: message already processed");
-        wormholeBridgeAdapterProxy.receiveWormholeMessages{value: 0}(
-            abi.encode(to, amount),
-            new bytes[](0),
-            address(wormholeBridgeAdapterProxy).toBytes(),
+    /// untrusted sender
+    function testExecuteVAAv1FailsUntrustedSender() public {
+        bytes32 untrustedEmitter = bytes32(uint256(uint160(address(0xdead))));
+        bytes memory payload = abi.encode(to, amount);
+        bytes memory encodedVaa = _setupVaa(
             chainId,
-            nonce
+            untrustedEmitter,
+            0,
+            payload
         );
-    }
 
-    /// not trusted sender from external chain
-    function testReceiveWormholeMessageFailsNotTrustedExternalChain() public {
         vm.expectRevert("WormholeBridge: sender not trusted");
-        vm.prank(wormholeRelayer);
-        wormholeBridgeAdapterProxy.receiveWormholeMessages{value: 0}(
-            "",
-            new bytes[](0),
-            address(this).toBytes(),
-            chainId,
-            bytes32(type(uint256).max)
-        );
+        wormholeBridgeAdapterProxy.executeVAAv1(encodedVaa);
     }
 
-    function testReceiveWormholeMessageSucceeds(bytes32 nonce) public {
+    /// replay — same sequence number
+    function testExecuteVAAv1FailsReplay() public {
+        /// first call succeeds
+        _bridgeInViaVaa(0);
+
+        /// second call with same sequence should fail
+        bytes32 emitterAddr = bytes32(
+            uint256(uint160(address(wormholeBridgeAdapterProxy)))
+        );
+        bytes memory payload = abi.encode(to, amount);
+        bytes memory encodedVaa = _setupVaa(chainId, emitterAddr, 0, payload);
+
+        vm.expectRevert();
+        wormholeBridgeAdapterProxy.executeVAAv1(encodedVaa);
+    }
+
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ----------- executeVAAv1 Success Tests -----------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+
+    function testExecuteVAAv1Succeeds() public {
         uint256 startingBalance = xwellProxy.balanceOf(to);
         uint256 startingTotalSupply = xwellProxy.totalSupply();
 
-        vm.prank(wormholeRelayer);
+        bytes32 emitterAddr = bytes32(
+            uint256(uint160(address(wormholeBridgeAdapterProxy)))
+        );
+        bytes memory payload = abi.encode(to, amount);
+        bytes memory encodedVaa = _setupVaa(chainId, emitterAddr, 0, payload);
+
         vm.expectEmit(
             true,
             true,
@@ -418,13 +485,7 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
             address(wormholeBridgeAdapterProxy)
         );
         emit BridgedIn(chainId, to, amount);
-        wormholeBridgeAdapterProxy.receiveWormholeMessages{value: 0}(
-            abi.encode(to, amount),
-            new bytes[](0),
-            address(wormholeBridgeAdapterProxy).toBytes(),
-            chainId,
-            nonce
-        );
+        wormholeBridgeAdapterProxy.executeVAAv1(encodedVaa);
 
         assertEq(
             xwellProxy.balanceOf(to) - startingBalance,
@@ -436,38 +497,72 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
             amount,
             "incorrect total supply increase"
         );
-        assertTrue(
-            wormholeBridgeAdapterProxy.processedNonces(nonce),
-            "nonce not used"
+    }
+
+    function testExecuteVAAv1SucceedsMultipleSequences() public {
+        uint256 startingBalance = xwellProxy.balanceOf(to);
+
+        _bridgeInViaVaa(0);
+        _bridgeInViaVaa(1);
+        _bridgeInViaVaa(2);
+
+        assertEq(
+            xwellProxy.balanceOf(to) - startingBalance,
+            amount * 3,
+            "incorrect total amount received after 3 bridge-ins"
         );
     }
 
     /// bridge in, test not enough rate limit
-    function testBridgeInFailsRateLimitExhausted(bytes32 nonce) public {
+    function testBridgeInFailsRateLimitExhausted() public {
         amount = xwellProxy.buffer(address(wormholeBridgeAdapterProxy));
-        unchecked {
-            testReceiveWormholeMessageSucceeds(bytes32(uint256(nonce) + 1));
-        }
-        amount = 1;
+        _bridgeInViaVaa(0);
 
-        vm.prank(wormholeRelayer);
+        amount = 1;
+        bytes32 emitterAddr = bytes32(
+            uint256(uint160(address(wormholeBridgeAdapterProxy)))
+        );
+        bytes memory payload = abi.encode(to, amount);
+        bytes memory encodedVaa = _setupVaa(chainId, emitterAddr, 1, payload);
+
         vm.expectRevert("RateLimited: rate limit hit");
-        wormholeBridgeAdapterProxy.receiveWormholeMessages{value: 0}(
-            abi.encode(to, amount),
+        wormholeBridgeAdapterProxy.executeVAAv1(encodedVaa);
+    }
+
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ---------- Deprecated receiveWormholeMessages ----------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+
+    function testReceiveWormholeMessagesAlwaysReverts() public {
+        vm.expectRevert("WormholeBridge: deprecated, use executeVAAv1");
+        wormholeBridgeAdapterProxy.receiveWormholeMessages(
+            "",
             new bytes[](0),
-            address(wormholeBridgeAdapterProxy).toBytes(),
-            chainId,
-            nonce
+            bytes32(0),
+            0,
+            bytes32(0)
         );
     }
 
-    /// bridge out tests:
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ------------------- Bridge Out Tests -------------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
 
     /// incorrect cost
     function testBridgeOutFailsIncorrectCost() public {
-        vm.deal(address(this), 1);
+        /// set a non-zero quote so msg.value mismatch triggers
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        vm.deal(address(this), cost + 1);
+
         vm.expectRevert("WormholeBridge: cost not equal to quote");
-        wormholeBridgeAdapterProxy.bridge{value: 1}(chainId, amount, to);
+        wormholeBridgeAdapterProxy.bridge{value: cost + 1}(chainId, amount, to);
     }
 
     /// incorrect target chain
@@ -500,7 +595,7 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         amount = externalChainBufferCap / 2;
         to = address(this);
 
-        testReceiveWormholeMessageSucceeds(bytes32(uint256(1)));
+        _bridgeInViaVaa(0);
 
         amount = externalChainBufferCap;
         xwellProxy.approve(address(wormholeBridgeAdapterProxy), amount);
@@ -513,7 +608,7 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         amount = externalChainBufferCap / 2;
         to = address(this);
 
-        testReceiveWormholeMessageSucceeds(bytes32(uint256(1)));
+        _bridgeInViaVaa(0);
 
         amount = externalChainBufferCap;
 
@@ -529,5 +624,29 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         );
         emit TokensSent(chainId, to, amount);
         wormholeBridgeAdapterProxy.bridge{value: 0}(chainId, amount, to);
+    }
+
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ------------------- Bridge Cost Tests ------------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+
+    function testBridgeCostReturnsQuotePlusMessageFee() public {
+        mockExecutorQuoterRouter.setQuote(0.01 ether);
+        mockCoreBridge.setMessageFee(0.001 ether);
+
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        assertEq(
+            cost,
+            0.011 ether,
+            "bridge cost should be quote + message fee"
+        );
+    }
+
+    function testBridgeCostReturnsZeroWhenQuoteFails() public {
+        /// quote will revert since targetAddress for chainId+1 is zero
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId + 1);
+        assertEq(cost, 0, "bridge cost should be 0 for unknown chain");
     }
 }

--- a/test/unit/WormholeUnwrapperAdapter.t.sol
+++ b/test/unit/WormholeUnwrapperAdapter.t.sol
@@ -4,14 +4,12 @@ import "@forge-std/Test.sol";
 
 import "@test/helper/BaseTest.t.sol";
 
-import {MockWormholeReceiver} from "@test/mock/MockWormholeReceiver.sol";
 import {WormholeUnwrapperAdapter} from "@protocol/xWELL/WormholeUnwrapperAdapter.sol";
-import {Address} from "@utils/Address.sol";
 import {WormholeTrustedSender} from "@protocol/governance/WormholeTrustedSender.sol";
+import {MockCoreBridgeForAdapter} from "@test/mock/MockCoreBridgeForAdapter.sol";
+import {MockExecutorQuoterRouter} from "@test/mock/MockExecutorQuoterRouter.sol";
 
 contract WormholeUnwrapperAdapterUnitTest is BaseTest {
-    using Address for address;
-
     /// xerc20 bridge adapter events
 
     /// @notice emitted when tokens are bridged out
@@ -69,12 +67,6 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
     /// @notice amount of tokens to mint
     uint256 public amount;
 
-    /// relayer gas cost
-    uint256 public immutable gasCost = 0.00001 * 1 ether;
-
-    /// mock wormhole receiver
-    MockWormholeReceiver public receiver;
-
     /// wormhole bridge unwrapper adapter logic contract
     WormholeUnwrapperAdapter unwrapper;
 
@@ -82,28 +74,6 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
         super.setUp();
         to = address(999999999999999);
         amount = 100 * 1e18;
-        receiver = new MockWormholeReceiver();
-        uint256 codeSize;
-        assembly {
-            codeSize := extcodesize(sload(receiver.slot))
-        }
-
-        bytes memory runtimeBytecode = new bytes(codeSize);
-
-        assembly {
-            extcodecopy(
-                sload(receiver.slot),
-                add(runtimeBytecode, 0x20),
-                0,
-                codeSize
-            )
-        }
-
-        /// set the wormhole relayer address to have the
-        /// runtime bytecode of the mock wormhole relayer
-        vm.etch(wormholeRelayer, runtimeBytecode);
-
-        testSetup();
 
         unwrapper = new WormholeUnwrapperAdapter();
 
@@ -117,6 +87,56 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
             .setLockbox(address(xerc20Lockbox));
         deal(address(well), address(xerc20Lockbox), 5_000_000_000 * 1e18);
     }
+
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ------------------- Helper Functions -------------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+
+    /// @notice Set up mock core bridge to return a valid VAA with given params
+    function _setupVaa(
+        uint16 emitterChainId,
+        bytes32 emitterAddress,
+        uint64 sequence,
+        bytes memory payload
+    ) internal returns (bytes memory encodedVaa) {
+        mockCoreBridge.setVmData(
+            emitterChainId,
+            emitterAddress,
+            sequence,
+            payload
+        );
+        /// The actual bytes don't matter — the mock ignores them and returns preset data
+        encodedVaa = abi.encode(
+            "mock-vaa",
+            emitterChainId,
+            emitterAddress,
+            sequence
+        );
+    }
+
+    /// @notice Bridge in tokens via executeVAAv1 using a valid VAA from the trusted adapter
+    function _bridgeInViaVaa(uint64 sequence) internal {
+        bytes32 emitterAddr = bytes32(
+            uint256(uint160(address(wormholeBridgeAdapterProxy)))
+        );
+        bytes memory payload = abi.encode(to, amount);
+        bytes memory encodedVaa = _setupVaa(
+            chainId,
+            emitterAddr,
+            sequence,
+            payload
+        );
+
+        wormholeBridgeAdapterProxy.executeVAAv1(encodedVaa);
+    }
+
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ------------------- Lockbox Tests ----------------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
 
     function testOwnerCannotSetLockboxIfAlreadySet() public {
         vm.prank(owner);
@@ -138,12 +158,28 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
             .setLockbox(address(xerc20Lockbox));
     }
 
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// -------------------- Setup Tests -----------------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+
     function testSetup() public view {
         assertEq(wormholeBridgeAdapterProxy.owner(), owner, "invalid owner");
         assertEq(
             address(wormholeBridgeAdapterProxy.wormholeRelayer()),
-            wormholeRelayer,
-            "invalid wormhole relayer"
+            address(mockCoreBridge),
+            "invalid wormhole relayer / core bridge"
+        );
+        assertEq(
+            address(wormholeBridgeAdapterProxy.coreBridge()),
+            address(mockCoreBridge),
+            "invalid core bridge"
+        );
+        assertEq(
+            address(wormholeBridgeAdapterProxy.executorQuoterRouter()),
+            address(mockExecutorQuoterRouter),
+            "invalid executor quoter router"
         );
         assertTrue(
             wormholeBridgeAdapterProxy.isTrustedSender(
@@ -171,16 +207,6 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
             xwellProxy.bufferCap(address(wormholeBridgeAdapterProxy)),
             externalChainBufferCap,
             "incorrect buffer cap for wormhole bridge adapter"
-        );
-        assertEq(
-            MockWormholeReceiver(wormholeRelayer).price(),
-            0,
-            "price not zero"
-        );
-        assertEq(
-            MockWormholeReceiver(wormholeRelayer).nonce(),
-            0,
-            "nonce not zero"
         );
     }
 
@@ -210,7 +236,11 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
         );
     }
 
-    /// ACL failure tests
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ------------------- ACL Failure Tests ------------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
 
     function testSetGasLimitNonOwnerFails() public {
         vm.expectRevert("Ownable: caller is not the owner");
@@ -238,7 +268,11 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
         );
     }
 
-    /// ACL success tests
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ------------------- ACL Success Tests ------------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
 
     function testSetGasLimitOwnerSucceeds(uint96 newGasLimit) public {
         uint96 oldGasLimit = wormholeBridgeAdapterProxy.gasLimit();
@@ -365,66 +399,68 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
         );
     }
 
-    /// receiveWormholeMessages failure tests
-    /// value
-    function testReceiveWormholeMessageFailsWithValue() public {
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ----------- executeVAAv1 Tests (Unwrapper) -------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+
+    /// msg.value must be 0
+    function testExecuteVAAv1FailsWithValue() public {
         vm.deal(address(this), 100);
         vm.expectRevert("WormholeBridge: no value allowed");
-        wormholeBridgeAdapterProxy.receiveWormholeMessages{value: 100}(
-            "",
-            new bytes[](0),
-            address(this).toBytes(),
-            chainId,
-            bytes32(type(uint256).max)
-        );
+        wormholeBridgeAdapterProxy.executeVAAv1{value: 100}(bytes("fake-vaa"));
     }
 
-    /// not relayer address
-    function testReceiveWormholeMessageFailsNotRelayer() public {
-        vm.expectRevert("WormholeBridge: only relayer allowed");
-        wormholeBridgeAdapterProxy.receiveWormholeMessages{value: 0}(
-            "",
-            new bytes[](0),
-            address(this).toBytes(),
-            chainId,
-            bytes32(type(uint256).max)
-        );
+    /// invalid VAA
+    function testExecuteVAAv1FailsInvalidVaa() public {
+        mockCoreBridge.setValid(false, "bad signature");
+        vm.expectRevert("bad signature");
+        wormholeBridgeAdapterProxy.executeVAAv1(bytes("invalid-vaa"));
     }
 
-    /// already processed
-
-    function testAlreadyProcessedMessageReplayFails(bytes32 nonce) public {
-        testReceiveWormholeMessageSucceeds(nonce);
-
-        vm.prank(wormholeRelayer);
-        vm.expectRevert("WormholeBridge: message already processed");
-        wormholeBridgeAdapterProxy.receiveWormholeMessages{value: 0}(
-            abi.encode(to, amount),
-            new bytes[](0),
-            address(wormholeBridgeAdapterProxy).toBytes(),
+    /// untrusted sender
+    function testExecuteVAAv1FailsUntrustedSender() public {
+        bytes32 untrustedEmitter = bytes32(uint256(uint160(address(0xdead))));
+        bytes memory payload = abi.encode(to, amount);
+        bytes memory encodedVaa = _setupVaa(
             chainId,
-            nonce
+            untrustedEmitter,
+            0,
+            payload
         );
-    }
 
-    /// not trusted sender from external chain
-    function testReceiveWormholeMessageFailsNotTrustedExternalChain() public {
         vm.expectRevert("WormholeBridge: sender not trusted");
-        vm.prank(wormholeRelayer);
-        wormholeBridgeAdapterProxy.receiveWormholeMessages{value: 0}(
-            "",
-            new bytes[](0),
-            address(this).toBytes(),
-            chainId,
-            bytes32(type(uint256).max)
-        );
+        wormholeBridgeAdapterProxy.executeVAAv1(encodedVaa);
     }
 
-    function testReceiveWormholeMessageSucceeds(bytes32 nonce) public {
-        uint256 startingBalance = well.balanceOf(to);
+    /// replay — same sequence number
+    function testExecuteVAAv1FailsReplay() public {
+        _bridgeInViaVaa(0);
+
+        bytes32 emitterAddr = bytes32(
+            uint256(uint160(address(wormholeBridgeAdapterProxy)))
+        );
+        bytes memory payload = abi.encode(to, amount);
+        bytes memory encodedVaa = _setupVaa(chainId, emitterAddr, 0, payload);
+
+        vm.expectRevert();
+        wormholeBridgeAdapterProxy.executeVAAv1(encodedVaa);
+    }
+
+    /// @notice Test that executeVAAv1 succeeds and delivers WELL (not xWELL)
+    /// because the unwrapper adapter mints xWELL then burns via lockbox to give WELL
+    function testExecuteVAAv1SucceedsUnwrapsToWell() public {
+        uint256 startingWellBalance = well.balanceOf(to);
         uint256 startingTotalSupply = xwellProxy.totalSupply();
 
-        vm.prank(wormholeRelayer);
+        bytes32 emitterAddr = bytes32(
+            uint256(uint160(address(wormholeBridgeAdapterProxy)))
+        );
+        bytes memory payload = abi.encode(to, amount);
+        bytes memory encodedVaa = _setupVaa(chainId, emitterAddr, 0, payload);
+
+        /// The BridgedIn event emits with the adapter address as the intermediate receiver
         vm.expectEmit(
             true,
             true,
@@ -435,61 +471,75 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
         emit BridgedIn(chainId, address(wormholeBridgeAdapterProxy), amount);
 
         uint256 startingGas = gasleft();
-
-        wormholeBridgeAdapterProxy.receiveWormholeMessages{value: 0}(
-            abi.encode(to, amount),
-            new bytes[](0),
-            address(wormholeBridgeAdapterProxy).toBytes(),
-            chainId,
-            nonce
-        );
-
+        wormholeBridgeAdapterProxy.executeVAAv1(encodedVaa);
         uint256 endingGas = gasleft();
 
         console.log("gas used: ", startingGas - endingGas);
 
+        /// User receives WELL tokens (not xWELL) because the unwrapper adapter
+        /// mints xWELL to itself, then burns via lockbox, sending WELL to the user
         assertEq(
-            well.balanceOf(to) - startingBalance,
+            well.balanceOf(to) - startingWellBalance,
             amount,
-            "incorrect amount received"
+            "incorrect WELL amount received"
         );
+        /// Total supply should not change (mint + burn cancel out)
         assertEq(
             xwellProxy.totalSupply(),
             startingTotalSupply,
             "total supply changed"
         );
-        assertTrue(
-            wormholeBridgeAdapterProxy.processedNonces(nonce),
-            "nonce not used"
-        );
     }
 
     /// bridge in, test not enough rate limit
-    function testBridgeInFailsRateLimitExhausted(bytes32 nonce) public {
+    function testBridgeInFailsRateLimitExhausted() public {
         amount = xwellProxy.buffer(address(wormholeBridgeAdapterProxy));
-        unchecked {
-            testReceiveWormholeMessageSucceeds(bytes32(uint256(nonce) + 1));
-        }
-        amount = 1;
+        _bridgeInViaVaa(0);
 
-        vm.prank(wormholeRelayer);
+        amount = 1;
+        bytes32 emitterAddr = bytes32(
+            uint256(uint160(address(wormholeBridgeAdapterProxy)))
+        );
+        bytes memory payload = abi.encode(to, amount);
+        bytes memory encodedVaa = _setupVaa(chainId, emitterAddr, 1, payload);
+
         vm.expectRevert("RateLimited: rate limit hit");
-        wormholeBridgeAdapterProxy.receiveWormholeMessages{value: 0}(
-            abi.encode(to, amount),
+        wormholeBridgeAdapterProxy.executeVAAv1(encodedVaa);
+    }
+
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ---------- Deprecated receiveWormholeMessages ----------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+
+    function testReceiveWormholeMessagesAlwaysReverts() public {
+        vm.expectRevert("WormholeBridge: deprecated, use executeVAAv1");
+        wormholeBridgeAdapterProxy.receiveWormholeMessages(
+            "",
             new bytes[](0),
-            address(wormholeBridgeAdapterProxy).toBytes(),
-            chainId,
-            nonce
+            bytes32(0),
+            0,
+            bytes32(0)
         );
     }
 
-    /// bridge out tests:
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
+    /// ------------------- Bridge Out Tests -------------------
+    /// --------------------------------------------------------
+    /// --------------------------------------------------------
 
     /// incorrect cost
     function testBridgeOutFailsIncorrectCost() public {
-        vm.deal(address(this), 1);
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        vm.deal(address(this), cost + 1);
+
         vm.expectRevert("WormholeBridge: cost not equal to quote");
-        wormholeBridgeAdapterProxy.bridge{value: 1}(chainId, amount, to);
+        wormholeBridgeAdapterProxy.bridge{value: cost + 1}(chainId, amount, to);
     }
 
     /// incorrect target chain
@@ -522,7 +572,7 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
         amount = externalChainBufferCap / 2;
         to = address(this);
 
-        testReceiveWormholeMessageSucceeds(bytes32(uint256(1)));
+        _bridgeInViaVaa(0);
 
         amount = externalChainBufferCap;
         xwellProxy.approve(address(wormholeBridgeAdapterProxy), amount);
@@ -535,7 +585,7 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
         amount = externalChainBufferCap / 2;
         to = address(this);
 
-        testReceiveWormholeMessageSucceeds(bytes32(uint256(1)));
+        _bridgeInViaVaa(0);
 
         amount = externalChainBufferCap;
 


### PR DESCRIPTION
## changes
- `xWELL` / `WormholeBridgeAdapter` updated to use wormhole executor
- new `bridge()` function to accept offchain quote (needed for moonbeam)
- proposal script to upgrade xwell on base / op / moonbeam
- foundry script to upgrade xwell on ethereum (deployer as owner)

## todo
- [ ] look into "unreachable code" warning on `xERC20BridgeAdapter`
- [ ] swap+bump mip numbers with governor proposal (consider rebasing this branch on main)