### PR TITLE
add: mip-x53 xwell adapter correct gas limit and quoter router address

### DIFF
--- a/chains/1.json
+++ b/chains/1.json
@@ -95,6 +95,11 @@
         "name": "WORMHOLE_QUOTER"
     },
     {
+        "addr": "0xa54008017941EcE968623a0Dd8Ee907E2b133596",
+        "isContract": false,
+        "name": "WORMHOLE_QUOTER_SIGNER"
+    },
+    {
         "addr": "0x2dc66C40bb15F0470e40508B43cD64D0b4F57180",
         "isContract": true,
         "name": "WORMHOLE_BRIDGE_ADAPTER_IMPL_V2"

--- a/chains/10.json
+++ b/chains/10.json
@@ -260,6 +260,11 @@
         "name": "WORMHOLE_QUOTER"
     },
     {
+        "addr": "0xa54008017941EcE968623a0Dd8Ee907E2b133596",
+        "isContract": false,
+        "name": "WORMHOLE_QUOTER_SIGNER"
+    },
+    {
         "addr": "0x27428DD2d3DD32A4D7f7C497eAaa23130d894911",
         "isContract": true,
         "name": "WORMHOLE_BRIDGE_RELAYER_PROXY"

--- a/chains/10.json
+++ b/chains/10.json
@@ -843,5 +843,10 @@
         "addr": "0xa8A334ffaba129C07Df4740001ceE7c0D838ddB9",
         "isContract": true,
         "name": "WORMHOLE_BRIDGE_ADAPTER_IMPL_V5"
+    },
+    {
+        "addr": "0xb46b3856f87305Aa76DC59349de0b518368e318b",
+        "isContract": true,
+        "name": "WORMHOLE_BRIDGE_ADAPTER_IMPL_V6"
     }
 ]

--- a/chains/1284.json
+++ b/chains/1284.json
@@ -175,7 +175,7 @@
         "isContract": true
     },
     {
-        "addr": "0xb84543e036054E2cD5394A9D99fa701Eef666df4",
+        "addr": "0x78c504b6c0ea2adbf6a58b208c9888f3692db169",
         "name": "xWELL_ROUTER",
         "isContract": true
     },

--- a/chains/8453.json
+++ b/chains/8453.json
@@ -1528,5 +1528,10 @@
         "addr": "0x78Feb72aeA00B912ac45438e0764A02213266568",
         "isContract": true,
         "name": "WORMHOLE_BRIDGE_ADAPTER_IMPL_V5"
+    },
+    {
+        "addr": "0x2481BFB0DfA54Dc155011eF2E90ADAB9556b8D99",
+        "isContract": true,
+        "name": "WORMHOLE_BRIDGE_ADAPTER_IMPL_V6"
     }
 ]

--- a/chains/8453.json
+++ b/chains/8453.json
@@ -130,6 +130,11 @@
         "name": "WORMHOLE_QUOTER"
     },
     {
+        "addr": "0xa54008017941EcE968623a0Dd8Ee907E2b133596",
+        "isContract": false,
+        "name": "WORMHOLE_QUOTER_SIGNER"
+    },
+    {
         "addr": "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA",
         "name": "USDBC",
         "isContract": true

--- a/foundry.toml
+++ b/foundry.toml
@@ -53,7 +53,7 @@ opSepolia = { endpoint= "${OP_SEPOLIA_RPC_URL}", retries = 2, retry_backoff = 10
 [etherscan]
 #optimism = { key = "${BASESCAN_API_KEY}", url= "https://api.etherscan.io/v2/api?chainid=10" }
 #moonriver = { key = "${MOONRIVER_API_KEY}", url= "https://api-moonriver.moonscan.io/api" }
-#moonbeam = { key = "${BASESCAN_API_KEY}", url= "https://api.etherscan.io/v2/api?chainid=1284" }
+#moonbeam = { key = "${ETHERSCAN_API_KEY}", url= "https://api.etherscan.io/v2/api?chainid=1284" }
 #moonbase = { key = "${MOONBEAM_API_KEY}", url= "https://api-moonbase.moonscan.io/api" }
 #goerli = { key = "${ETHERSCAN_API_KEY}", url= "https://api-goerli.etherscan.io/api" }
 #sepolia = { key = "${ETHERSCAN_API_KEY}", url= "https://api-sepolia.etherscan.io/api" }

--- a/proposals/hooks/BridgeValidationHook.sol
+++ b/proposals/hooks/BridgeValidationHook.sol
@@ -10,8 +10,9 @@ import {ProposalAction} from "@proposals/proposalTypes/IProposal.sol";
 ///      the actual bridge cost returned by router.bridgeCost(destinationChain)
 abstract contract BridgeValidationHook {
     /// @notice Function selector for bridgeToRecipient(address,uint256,uint16)
+    /// @dev Hardcoded selector to disambiguate from the signed-quote overload
     bytes4 private constant BRIDGE_TO_RECIPIENT_SELECTOR =
-        xWELLRouter.bridgeToRecipient.selector;
+        bytes4(keccak256("bridgeToRecipient(address,uint256,uint16)"));
 
     /// @notice Minimum multiplier for bridge cost (4x)
     uint256 private constant MIN_BRIDGE_COST_MULTIPLIER = 4;

--- a/proposals/mips/mip-x53/mip-x53.sol
+++ b/proposals/mips/mip-x53/mip-x53.sol
@@ -100,6 +100,16 @@ contract mipx53 is HybridProposal {
 
     function build(Addresses addresses) public override {
         /// -------------------------------------------------------
+        /// Moonbeam: setGasLimit
+        /// -------------------------------------------------------
+
+        _pushAction(
+            addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY"),
+            abi.encodeWithSignature("setGasLimit(uint96)", NEW_GAS_LIMIT),
+            "Bump executor gas limit on Moonbeam WormholeBridgeAdapter to 700k"
+        );
+
+        /// -------------------------------------------------------
         /// Base: upgrade impl, then setQuoterAddress + setGasLimit
         /// -------------------------------------------------------
 
@@ -159,6 +169,16 @@ contract mipx53 is HybridProposal {
     function teardown(Addresses addresses, address) public pure override {}
 
     function validate(Addresses addresses, address) public override {
+        // Moonbeam
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY")
+        );
+        assertEq(
+            adapter.gasLimit(),
+            NEW_GAS_LIMIT,
+            "Moonbeam: gasLimit not bumped to 700k"
+        );
+
         vm.selectFork(BASE_FORK_ID);
         _validateAdapterV6(addresses, "Base", _BASE_DST_WH_ID);
 

--- a/proposals/mips/mip-x53/mip-x53.sol
+++ b/proposals/mips/mip-x53/mip-x53.sol
@@ -1,0 +1,282 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+
+import "@forge-std/Test.sol";
+
+import {ITransparentUpgradeableProxy} from "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
+import {IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+import {WormholeBridgeAdapter} from "@protocol/xWELL/WormholeBridgeAdapter.sol";
+import {HybridProposal} from "@proposals/proposalTypes/HybridProposal.sol";
+import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
+import {MOONBEAM_FORK_ID, BASE_FORK_ID, OPTIMISM_FORK_ID, BASE_WORMHOLE_CHAIN_ID, OPTIMISM_WORMHOLE_CHAIN_ID, ChainIds} from "@utils/ChainIds.sol";
+import {ProposalActions} from "@proposals/utils/ProposalActions.sol";
+
+/// @title MIP-X53: Fix WormholeBridgeAdapter quoterAddress on Base + Optimism
+/// @notice Upgrades the WormholeBridgeAdapter on Base and Optimism to a fresh
+///         V6 implementation, then calls `setQuoterAddress` to point the
+///         on-chain quoter at the off-chain quoter operator's signer EOA
+///         (`WORMHOLE_QUOTER_SIGNER`) and `setGasLimit` to bump the executor
+///         gas limit to 700k.
+contract mipx53 is HybridProposal {
+    using ProposalActions for *;
+    using ChainIds for uint256;
+
+    string public constant override name = "MIP-X53";
+
+    /// @notice destination chain used for the validation bridge() call.
+    /// On Base we bridge to OP; on OP we bridge to Base.
+    uint16 internal constant _BASE_DST_WH_ID = OPTIMISM_WORMHOLE_CHAIN_ID;
+    uint16 internal constant _OP_DST_WH_ID = BASE_WORMHOLE_CHAIN_ID;
+
+    /// @notice mocked-user bridge amount used in `validate()`
+    uint256 internal constant BRIDGE_AMOUNT = 1e18;
+
+    uint96 internal constant NEW_GAS_LIMIT = 700_000;
+
+    constructor() {
+        bytes memory proposalDescription = abi.encodePacked(
+            vm.readFile("./proposals/mips/mip-x53/x53.md")
+        );
+        _setProposalDescription(proposalDescription);
+    }
+
+    function run() public override {
+        primaryForkId().createForksAndSelect();
+
+        Addresses addresses = new Addresses();
+        vm.makePersistent(address(addresses));
+
+        initProposal(addresses);
+
+        (, address deployerAddress, ) = vm.readCallers();
+
+        if (DO_DEPLOY) deploy(addresses, deployerAddress);
+        if (DO_AFTER_DEPLOY) afterDeploy(addresses, deployerAddress);
+
+        if (DO_BUILD) build(addresses);
+        if (DO_RUN) simulate(addresses, deployerAddress);
+        if (DO_TEARDOWN) teardown(addresses, deployerAddress);
+        if (DO_VALIDATE) {
+            validate(addresses, deployerAddress);
+            console.log("Validation completed for proposal ", this.name());
+        }
+        if (DO_PRINT) {
+            printProposalActionSteps();
+
+            addresses.removeAllRestrictions();
+            printCalldata(addresses);
+
+            _printAddressesChanges(addresses);
+        }
+    }
+
+    function primaryForkId() public pure override returns (uint256) {
+        return MOONBEAM_FORK_ID;
+    }
+
+    /// @notice Deploy a fresh V6 implementation on Base and Optimism. Same
+    ///         logic as V5 plus the new `setQuoterAddress` setter.
+    function deploy(Addresses addresses, address) public override {
+        vm.selectFork(BASE_FORK_ID);
+        if (!addresses.isAddressSet("WORMHOLE_BRIDGE_ADAPTER_IMPL_V6")) {
+            vm.startBroadcast();
+            address impl = address(new WormholeBridgeAdapter());
+            vm.stopBroadcast();
+            addresses.addAddress("WORMHOLE_BRIDGE_ADAPTER_IMPL_V6", impl);
+        }
+
+        vm.selectFork(OPTIMISM_FORK_ID);
+        if (!addresses.isAddressSet("WORMHOLE_BRIDGE_ADAPTER_IMPL_V6")) {
+            vm.startBroadcast();
+            address impl = address(new WormholeBridgeAdapter());
+            vm.stopBroadcast();
+            addresses.addAddress("WORMHOLE_BRIDGE_ADAPTER_IMPL_V6", impl);
+        }
+
+        vm.selectFork(primaryForkId());
+    }
+
+    function build(Addresses addresses) public override {
+        /// -------------------------------------------------------
+        /// Base: upgrade impl, then setQuoterAddress + setGasLimit
+        /// -------------------------------------------------------
+
+        vm.selectFork(BASE_FORK_ID);
+        _pushAction(
+            addresses.getAddress("MRD_PROXY_ADMIN"),
+            abi.encodeWithSignature(
+                "upgrade(address,address)",
+                addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY"),
+                addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_IMPL_V6")
+            ),
+            "Upgrade WormholeBridgeAdapter on Base to V6 impl"
+        );
+        _pushAction(
+            addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY"),
+            abi.encodeWithSignature(
+                "setQuoterAddress(address)",
+                addresses.getAddress("WORMHOLE_QUOTER_SIGNER")
+            ),
+            "Set quoter signer EOA on Base WormholeBridgeAdapter"
+        );
+        _pushAction(
+            addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY"),
+            abi.encodeWithSignature("setGasLimit(uint96)", NEW_GAS_LIMIT),
+            "Bump executor gas limit on Base WormholeBridgeAdapter to 700k"
+        );
+
+        /// -------------------------------------------------------
+        /// Optimism: upgrade impl, then setQuoterAddress + setGasLimit
+        /// -------------------------------------------------------
+
+        vm.selectFork(OPTIMISM_FORK_ID);
+        _pushAction(
+            addresses.getAddress("MRD_PROXY_ADMIN"),
+            abi.encodeWithSignature(
+                "upgrade(address,address)",
+                addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY"),
+                addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_IMPL_V6")
+            ),
+            "Upgrade WormholeBridgeAdapter on Optimism to V6 impl"
+        );
+        _pushAction(
+            addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY"),
+            abi.encodeWithSignature(
+                "setQuoterAddress(address)",
+                addresses.getAddress("WORMHOLE_QUOTER_SIGNER")
+            ),
+            "Set quoter signer EOA on Optimism WormholeBridgeAdapter"
+        );
+        _pushAction(
+            addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY"),
+            abi.encodeWithSignature("setGasLimit(uint96)", NEW_GAS_LIMIT),
+            "Bump executor gas limit on Optimism WormholeBridgeAdapter to 700k"
+        );
+    }
+
+    function teardown(Addresses addresses, address) public pure override {}
+
+    function validate(Addresses addresses, address) public override {
+        vm.selectFork(BASE_FORK_ID);
+        _validateAdapterV6(addresses, "Base", _BASE_DST_WH_ID);
+
+        vm.selectFork(OPTIMISM_FORK_ID);
+        _validateAdapterV6(addresses, "Optimism", _OP_DST_WH_ID);
+
+        vm.selectFork(primaryForkId());
+    }
+
+    /// @notice Per-chain validation: storage state, bridgeCost > 0, and a
+    ///         mocked-user bridge() call that hits the live executor router.
+    function _validateAdapterV6(
+        Addresses addresses,
+        string memory chainName,
+        uint16 dstWormholeId
+    ) internal {
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY")
+        );
+
+        /// 1. Implementation upgraded
+        address proxyAdmin = addresses.getAddress("MRD_PROXY_ADMIN");
+        address actualImpl = ProxyAdmin(proxyAdmin).getProxyImplementation(
+            ITransparentUpgradeableProxy(address(adapter))
+        );
+        assertEq(
+            actualImpl,
+            addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_IMPL_V6"),
+            string.concat(chainName, ": adapter not upgraded to V6")
+        );
+
+        /// 2. quoterAddress storage now points at the signer EOA
+        assertEq(
+            adapter.quoterAddress(),
+            addresses.getAddress("WORMHOLE_QUOTER_SIGNER"),
+            string.concat(chainName, ": quoterAddress not set to signer")
+        );
+
+        /// 3. V5 state preserved (router, executor, wormhole, gas limit)
+        assertEq(
+            address(adapter.executorQuoterRouter()),
+            addresses.getAddress("WORMHOLE_QUOTER_ROUTER"),
+            string.concat(chainName, ": executorQuoterRouter changed")
+        );
+        assertEq(
+            address(adapter.executor()),
+            addresses.getAddress("WORMHOLE_EXECUTOR"),
+            string.concat(chainName, ": executor changed")
+        );
+        assertTrue(
+            address(adapter.wormhole()) != address(0),
+            string.concat(chainName, ": wormhole core not set")
+        );
+        assertEq(
+            adapter.gasLimit(),
+            NEW_GAS_LIMIT,
+            string.concat(chainName, ": gasLimit not bumped to 700k")
+        );
+
+        /// 4. bridgeCost(dst) returns a real positive quote now
+        uint256 cost = adapter.bridgeCost(dstWormholeId);
+        assertGt(
+            cost,
+            0,
+            string.concat(chainName, ": bridgeCost returned 0 after V6 fix")
+        );
+
+        /// 5. Mocked-user bridge: end-to-end against the live executor router.
+        ///    Pattern mirrors test/integration/xWELL/WormholeBridgeAdapterIntegration.t.sol#testBridgeOutAfterUpgrade.
+        _runMockedUserBridge(
+            addresses,
+            adapter,
+            chainName,
+            dstWormholeId,
+            cost
+        );
+    }
+
+    /// @notice Funds a synthetic user with xWELL + ETH and exercises the
+    ///         on-chain-quote bridge() overload. After the V6 fix this must
+    ///         not revert; tokens must burn and totalSupply must drop.
+    function _runMockedUserBridge(
+        Addresses addresses,
+        WormholeBridgeAdapter adapter,
+        string memory chainName,
+        uint16 dstWormholeId,
+        uint256 cost
+    ) internal {
+        address user = address(0xBEEF);
+        IERC20 xWell = IERC20(addresses.getAddress("xWELL_PROXY"));
+
+        /// Mint synthetic xWELL balance to user (`deal` writes balance + totalSupply)
+        deal(address(xWell), user, BRIDGE_AMOUNT, true);
+
+        /// Fund user with exactly the on-chain quote
+        vm.deal(user, cost);
+
+        uint256 userBalanceBefore = xWell.balanceOf(user);
+        uint256 totalSupplyBefore = xWell.totalSupply();
+
+        vm.startPrank(user);
+        xWell.approve(address(adapter), BRIDGE_AMOUNT);
+        adapter.bridge{value: cost}(
+            uint256(dstWormholeId),
+            BRIDGE_AMOUNT,
+            user
+        );
+        vm.stopPrank();
+
+        assertEq(
+            userBalanceBefore - xWell.balanceOf(user),
+            BRIDGE_AMOUNT,
+            string.concat(chainName, ": user xWELL not burned by bridge()")
+        );
+        assertEq(
+            totalSupplyBefore - xWell.totalSupply(),
+            BRIDGE_AMOUNT,
+            string.concat(chainName, ": xWELL totalSupply not reduced")
+        );
+    }
+}

--- a/proposals/mips/mip-x53/x53.md
+++ b/proposals/mips/mip-x53/x53.md
@@ -1,72 +1,52 @@
-# MIP-X53: Fix `WormholeBridgeAdapter.quoterAddress` on Base + Optimism
+## MIP-X53: Update xWELL Wormhole Executor Quoter Configuration
 
-## Summary
+### Summary
 
-Calls a new `initializeV6(address)` on the WormholeBridgeAdapter proxies on Base
-and Optimism, overwriting `quoterAddress` storage with the off-chain quoter
-operator's signer EOA (`0xa54008017941EcE968623a0Dd8Ee907E2b133596`, registered
-as `WORMHOLE_QUOTER_SIGNER`).
+This proposal upgrades the xWELL Wormhole adapter implementation to resolve
+configuration issues identified after MIP-X52. The new implementation adds a
+setter for the Wormhole Executor quoter address and updates the quoter
+configuration to use the EOA address required by Wormhole’s current
+implementation pattern.
 
-## Background
+### Background
 
-MIP-X52 migrated the adapter to the Wormhole Executor framework
-(`initializeV5`). The `quoterAddress` slot was set to the on-chain
-`ExecutorQuoter` contract address (`WORMHOLE_QUOTER`). Per the
-[Wormhole Executor on-chain quoting design](https://github.com/wormholelabs-xyz/example-messaging-executor/blob/main/design/02_On_Chain_Quotes.md),
-`ExecutorQuoterRouter.quoterContract[]` is keyed by the off-chain quoter
-operator's signer (recovered from a signed governance blob), not by the on-chain
-contract. Concretely on Base:
+MIP-X52 upgraded the xWELL Wormhole adapter contract to the new Wormhole
+Executor pattern, replacing the prior relayer and `processVAA` flow.
 
-| Lookup                                               | Value           |
-| ---------------------------------------------------- | --------------- |
-| `Router.quoterContract[0xa54008…3596]` (signer)      | `0xA25862…8D60` |
-| `Router.quoterContract[0xA25862…8D60]` (current val) | `address(0)`    |
+After deployment, two issues were identified:
 
-When the adapter calls `Router.quoteExecution(..., quoterAddr=0xA25862…)`, the
-router resolves the (empty) mapping entry to `address(0)` and reverts inside
-`0.requestQuote(...)`. The adapter's `try/catch` swallows it, making
-`bridgeCost()` silently return `0`. Any user calling
-`bridge(uint256,uint256,address)` (the on-chain-quote overload) reverts because
-`msg.value == 0` doesn't match the (non-zero) intended fee, and the bridge-out
-path is effectively unreachable through that overload.
+1. The executor receiving endpoint on Moonbeam consumes more than double the gas
+   used by the prior implementation, 10% more on other chains.
+2. Wormhole documentation and example source code contain discrepancies
+   regarding which address should be used as the quoter, specifically whether
+   the quoter should be a contract address or an EOA.
 
-## Fix
+The first issue can be addressed through the existing gas configuration setter.
+The second issue requires a new setter, since the current implementation does
+not include a way to update the quoter address.
 
-A new one-shot reinitializer `initializeV6(address)` overwrites slot 159 with
-the signer EOA. It does not change the storage layout (no new variables) and
-only takes effect on chains where V5 was already applied.
+### Proposal
 
-## Scope
+This proposal authorizes the following actions:
 
-- **Base**: `upgradeAndCall` to V6 with `initializeV6(WORMHOLE_QUOTER_SIGNER)`.
-- **Optimism**: same.
-- **Moonbeam**: not affected (`executorQuoterRouter == address(0)`).
-- **Ethereum**: handled by the deployer-owned script
-  `script/UpgradeWormholeAdapterEthereumV6.s.sol` (xWELL on Ethereum is owned by
-  `MOONWELL_DEPLOYER`, not by governance).
+1. Deploy a new xWELL Wormhole adapter implementation that includes a setter for
+   the quoter address.
+2. Upgrade the existing xWELL Wormhole adapter proxy to the new implementation.
+3. Call the new setter to update the quoter address to the appropriate EOA.
+4. Use the existing setter to update gas configuration for the executor
+   receiving endpoint.
 
-## Verification (in `validate()`)
+Proposal script validations confirm that `bridgeCost()` returns a positive
+value, as expected by the onchain bridge function when passing `msg.value`.
 
-For Base and Optimism:
+### Rationale
 
-1. Implementation address points at the freshly deployed V6 logic.
-2. `quoterAddress() == WORMHOLE_QUOTER_SIGNER`.
-3. V5 state preserved: `executorQuoterRouter`, `executor`, `wormhole`,
-   `gasLimit` unchanged.
-4. `initializeV6` is one-shot — re-call reverts with
-   `Initializable: contract is already initialized`.
-5. `bridgeCost(dst)` is **strictly positive** (Base→OP and OP→Base).
-6. End-to-end bridge: a synthetic user is funded with 1e18 xWELL and exactly
-   `bridgeCost` ETH; calling `bridge(uint256,uint256,address)` burns the user's
-   xWELL, decreases `xWELL.totalSupply()`, and the call goes through to the live
-   `ExecutorQuoterRouter` and `Executor` contracts on the fork.
+This upgrade improves the reliability of xWELL bridging after the migration to
+Wormhole Executor.
 
-## Risk
+### Voting Options
 
-- Storage layout: V6 adds no new variables; slot 159 (`quoterAddress`) was
-  already declared in V5. No layout drift.
-- Reachability: `initializeV6` is gated by `reinitializer(6)` and a non-zero
-  `executorQuoterRouter` check, so it cannot be called on Moonbeam (whose
-  `executorQuoterRouter` is `address(0)`).
-- Reversibility: a future reinitializer at a higher version can override the
-  slot again if needed.
+- **For:** Approve the implementation upgrade, quoter address update, gas and
+  configuration update.
+- **Against:** Do not approve the upgrade or configuration changes.
+- **Abstain:** Participate in the vote without expressing support or opposition.

--- a/proposals/mips/mip-x53/x53.md
+++ b/proposals/mips/mip-x53/x53.md
@@ -1,0 +1,72 @@
+# MIP-X53: Fix `WormholeBridgeAdapter.quoterAddress` on Base + Optimism
+
+## Summary
+
+Calls a new `initializeV6(address)` on the WormholeBridgeAdapter proxies on Base
+and Optimism, overwriting `quoterAddress` storage with the off-chain quoter
+operator's signer EOA (`0xa54008017941EcE968623a0Dd8Ee907E2b133596`, registered
+as `WORMHOLE_QUOTER_SIGNER`).
+
+## Background
+
+MIP-X52 migrated the adapter to the Wormhole Executor framework
+(`initializeV5`). The `quoterAddress` slot was set to the on-chain
+`ExecutorQuoter` contract address (`WORMHOLE_QUOTER`). Per the
+[Wormhole Executor on-chain quoting design](https://github.com/wormholelabs-xyz/example-messaging-executor/blob/main/design/02_On_Chain_Quotes.md),
+`ExecutorQuoterRouter.quoterContract[]` is keyed by the off-chain quoter
+operator's signer (recovered from a signed governance blob), not by the on-chain
+contract. Concretely on Base:
+
+| Lookup                                               | Value           |
+| ---------------------------------------------------- | --------------- |
+| `Router.quoterContract[0xa54008…3596]` (signer)      | `0xA25862…8D60` |
+| `Router.quoterContract[0xA25862…8D60]` (current val) | `address(0)`    |
+
+When the adapter calls `Router.quoteExecution(..., quoterAddr=0xA25862…)`, the
+router resolves the (empty) mapping entry to `address(0)` and reverts inside
+`0.requestQuote(...)`. The adapter's `try/catch` swallows it, making
+`bridgeCost()` silently return `0`. Any user calling
+`bridge(uint256,uint256,address)` (the on-chain-quote overload) reverts because
+`msg.value == 0` doesn't match the (non-zero) intended fee, and the bridge-out
+path is effectively unreachable through that overload.
+
+## Fix
+
+A new one-shot reinitializer `initializeV6(address)` overwrites slot 159 with
+the signer EOA. It does not change the storage layout (no new variables) and
+only takes effect on chains where V5 was already applied.
+
+## Scope
+
+- **Base**: `upgradeAndCall` to V6 with `initializeV6(WORMHOLE_QUOTER_SIGNER)`.
+- **Optimism**: same.
+- **Moonbeam**: not affected (`executorQuoterRouter == address(0)`).
+- **Ethereum**: handled by the deployer-owned script
+  `script/UpgradeWormholeAdapterEthereumV6.s.sol` (xWELL on Ethereum is owned by
+  `MOONWELL_DEPLOYER`, not by governance).
+
+## Verification (in `validate()`)
+
+For Base and Optimism:
+
+1. Implementation address points at the freshly deployed V6 logic.
+2. `quoterAddress() == WORMHOLE_QUOTER_SIGNER`.
+3. V5 state preserved: `executorQuoterRouter`, `executor`, `wormhole`,
+   `gasLimit` unchanged.
+4. `initializeV6` is one-shot — re-call reverts with
+   `Initializable: contract is already initialized`.
+5. `bridgeCost(dst)` is **strictly positive** (Base→OP and OP→Base).
+6. End-to-end bridge: a synthetic user is funded with 1e18 xWELL and exactly
+   `bridgeCost` ETH; calling `bridge(uint256,uint256,address)` burns the user's
+   xWELL, decreases `xWELL.totalSupply()`, and the call goes through to the live
+   `ExecutorQuoterRouter` and `Executor` contracts on the fork.
+
+## Risk
+
+- Storage layout: V6 adds no new variables; slot 159 (`quoterAddress`) was
+  already declared in V5. No layout drift.
+- Reachability: `initializeV6` is gated by `reinitializer(6)` and a non-zero
+  `executorQuoterRouter` check, so it cannot be called on Moonbeam (whose
+  `executorQuoterRouter` is `address(0)`).
+- Reversibility: a future reinitializer at a higher version can override the
+  slot again if needed.

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -2,6 +2,13 @@
     {
         "envpath": "",
         "governor": "MultichainGovernor",
+        "id": 0,
+        "path": "mip-x53.sol/mipx53.json",
+        "proposalType": "HybridProposal"
+    },
+    {
+        "envpath": "",
+        "governor": "MultichainGovernor",
         "id": 161,
         "path": "mip-x52.sol/mipx52.json",
         "proposalType": "HybridProposal"

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -2,7 +2,7 @@
     {
         "envpath": "",
         "governor": "MultichainGovernor",
-        "id": 0,
+        "id": 162,
         "path": "mip-x53.sol/mipx53.json",
         "proposalType": "HybridProposal"
     },

--- a/script/UpgradeWormholeAdapterEthereum.s.sol
+++ b/script/UpgradeWormholeAdapterEthereum.s.sol
@@ -7,21 +7,24 @@ import {ProxyAdmin} from "@openzeppelin-contracts/contracts/proxy/transparent/Pr
 import {Script} from "@forge-std/Script.sol";
 import {console} from "@forge-std/console.sol";
 
-import {IWormhole} from "@protocol/wormhole/IWormhole.sol";
 import {WormholeBridgeAdapter} from "@protocol/xWELL/WormholeBridgeAdapter.sol";
 import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
 import {validateProxy} from "@proposals/utils/ProxyUtils.sol";
-import {ETHEREUM_CHAIN_ID, MOONBEAM_CHAIN_ID, BASE_CHAIN_ID, OPTIMISM_CHAIN_ID, MOONBEAM_WORMHOLE_CHAIN_ID, BASE_WORMHOLE_CHAIN_ID, OPTIMISM_WORMHOLE_CHAIN_ID, ETHEREUM_WORMHOLE_CHAIN_ID} from "@utils/ChainIds.sol";
+import {ETHEREUM_CHAIN_ID, MOONBEAM_CHAIN_ID, BASE_CHAIN_ID, OPTIMISM_CHAIN_ID, MOONBEAM_WORMHOLE_CHAIN_ID, BASE_WORMHOLE_CHAIN_ID, OPTIMISM_WORMHOLE_CHAIN_ID} from "@utils/ChainIds.sol";
 
 /*
 
- Upgrade WormholeBridgeAdapter on Ethereum to Wormhole Executor framework (V4).
+ Upgrade WormholeBridgeAdapter on Ethereum to V6.
 
- The adapter already has V3 (wormhole core bridge) set from the processVAA migration.
- This V4 upgrade adds executor, quoter router, quoter, and wormhole chain ID.
+ V5 (Wormhole Executor framework) was previously applied via this same script.
+ V5 stored the on-chain Quoter contract in the `quoterAddress` slot, but the
+ ExecutorQuoterRouter resolves `quoterContract[]` by the off-chain operator's
+ signer EOA — so `bridgeCost()` silently returns 0. V6 overwrites the slot
+ with `WORMHOLE_QUOTER_SIGNER` and re-validates end-to-end.
 
  The Ethereum xWELL deployment is owned by MOONWELL_DEPLOYER, not governance,
  so this is a one-off deployer script (same pattern as DeployXWellEthereum.s.sol).
+ Base + Optimism are upgraded in lockstep via the governance MIP `mip-x53`.
 
  to simulate:
      forge script script/UpgradeWormholeAdapterEthereum.s.sol:UpgradeWormholeAdapterEthereum \
@@ -33,6 +36,10 @@ import {ETHEREUM_CHAIN_ID, MOONBEAM_CHAIN_ID, BASE_CHAIN_ID, OPTIMISM_CHAIN_ID, 
 
 */
 contract UpgradeWormholeAdapterEthereum is Script {
+    /// @notice new executor gas limit applied via `setGasLimit` after the
+    ///         V6 upgrade. Mirrors the `mip-x53` bump on Base + Optimism.
+    uint96 internal constant NEW_GAS_LIMIT = 700_000;
+
     function run() public {
         Addresses addresses = new Addresses();
 
@@ -45,40 +52,47 @@ contract UpgradeWormholeAdapterEthereum is Script {
         address adapterProxy = addresses.getAddress(
             "WORMHOLE_BRIDGE_ADAPTER_PROXY"
         );
+        address quoterSigner = addresses.getAddress("WORMHOLE_QUOTER_SIGNER");
 
-        // Snapshot pre-upgrade state
+        // Snapshot pre-upgrade state we expect to preserve through V6
         WormholeBridgeAdapter adapter = WormholeBridgeAdapter(adapterProxy);
         address ownerBefore = adapter.owner();
         uint96 gasLimitBefore = adapter.gasLimit();
         address xERC20Before = address(adapter.xERC20());
         address wormholeBefore = address(adapter.wormhole());
+        address routerBefore = address(adapter.executorQuoterRouter());
+        address executorBefore = address(adapter.executor());
+        address quoterBefore = adapter.quoterAddress();
 
         console.log("=== Pre-upgrade state ===");
-        console.log("  Owner:", ownerBefore);
-        console.log("  Gas limit:", uint256(gasLimitBefore));
-        console.log("  xERC20:", xERC20Before);
-        console.log("  Wormhole (V3):", wormholeBefore);
-        console.log("  Proxy:", adapterProxy);
-        console.log("  ProxyAdmin:", proxyAdmin);
+        console.log("  Adapter proxy   :", adapterProxy);
+        console.log("  ProxyAdmin      :", proxyAdmin);
+        console.log("  Owner           :", ownerBefore);
+        console.log("  Gas limit       :", uint256(gasLimitBefore));
+        console.log("  Target gas limit:", uint256(NEW_GAS_LIMIT));
+        console.log("  xERC20          :", xERC20Before);
+        console.log("  Wormhole core   :", wormholeBefore);
+        console.log("  Quoter router   :", routerBefore);
+        console.log("  Executor        :", executorBefore);
+        console.log("  quoterAddress   :", quoterBefore, "(broken value)");
+        console.log("  Target signer   :", quoterSigner);
 
         vm.startBroadcast();
 
-        // Deploy new implementation
+        // Deploy new V6 implementation
         address newImpl = address(new WormholeBridgeAdapter());
         console.log("  New implementation:", newImpl);
 
-        // Upgrade and initialize V5 (executor framework)
-        // V3 (wormhole core bridge) is already set on-chain
-        ProxyAdmin(proxyAdmin).upgradeAndCall(
+        // Plain upgrade then call setQuoterAddress + setGasLimit on the proxy.
+        // The new V6 implementation exposes setQuoterAddress so we can fix the
+        // broken slot without a one-shot reinitializer; we bump the gas limit
+        // in the same script to keep Ethereum aligned with mip-x53 on Base+OP.
+        ProxyAdmin(proxyAdmin).upgrade(
             ITransparentUpgradeableProxy(adapterProxy),
-            newImpl,
-            abi.encodeWithSignature(
-                "initializeV5(address,address,address)",
-                addresses.getAddress("WORMHOLE_EXECUTOR"),
-                addresses.getAddress("WORMHOLE_QUOTER_ROUTER"),
-                addresses.getAddress("WORMHOLE_QUOTER")
-            )
+            newImpl
         );
+        adapter.setQuoterAddress(quoterSigner);
+        adapter.setGasLimit(NEW_GAS_LIMIT);
 
         vm.stopBroadcast();
 
@@ -90,10 +104,12 @@ contract UpgradeWormholeAdapterEthereum is Script {
             adapterProxy,
             proxyAdmin,
             newImpl,
+            quoterSigner,
             ownerBefore,
-            gasLimitBefore,
             xERC20Before,
-            wormholeBefore
+            wormholeBefore,
+            routerBefore,
+            executorBefore
         );
     }
 
@@ -102,16 +118,18 @@ contract UpgradeWormholeAdapterEthereum is Script {
         address adapterProxy,
         address proxyAdmin,
         address expectedImpl,
+        address expectedSigner,
         address expectedOwner,
-        uint96 expectedGasLimit,
         address expectedXERC20,
-        address expectedWormhole
-    ) internal view {
+        address expectedWormhole,
+        address expectedRouter,
+        address expectedExecutor
+    ) internal {
         console.log("\n=== Running Validation ===");
 
         WormholeBridgeAdapter adapter = WormholeBridgeAdapter(adapterProxy);
 
-        // 1. Verify implementation upgraded
+        // 1. Implementation upgraded
         validateProxy(
             vm,
             adapterProxy,
@@ -120,38 +138,39 @@ contract UpgradeWormholeAdapterEthereum is Script {
             "Ethereum WORMHOLE_BRIDGE_ADAPTER_PROXY"
         );
 
-        // 2. Verify V3 state preserved (wormhole core bridge)
+        // 2. quoterAddress now points at the off-chain signer
+        require(
+            adapter.quoterAddress() == expectedSigner,
+            "quoterAddress not updated to signer"
+        );
+
+        // 3. Pre-V6 state preserved
         require(
             address(adapter.wormhole()) == expectedWormhole,
             "wormhole core bridge changed after upgrade"
         );
-
-        // 3. Verify V4 state (executor framework)
         require(
-            address(adapter.executor()) ==
-                addresses.getAddress("WORMHOLE_EXECUTOR"),
-            "executor not set correctly"
+            address(adapter.executor()) == expectedExecutor,
+            "executor changed after upgrade"
         );
         require(
-            address(adapter.executorQuoterRouter()) ==
-                addresses.getAddress("WORMHOLE_QUOTER_ROUTER"),
-            "executorQuoterRouter not set correctly"
+            address(adapter.executorQuoterRouter()) == expectedRouter,
+            "executorQuoterRouter changed after upgrade"
         );
-        // 4. Verify storage preservation
         require(
             adapter.owner() == expectedOwner,
             "owner changed after upgrade"
         );
         require(
-            adapter.gasLimit() == expectedGasLimit,
-            "gasLimit changed after upgrade"
+            adapter.gasLimit() == NEW_GAS_LIMIT,
+            "gasLimit not bumped to 700k"
         );
         require(
             address(adapter.xERC20()) == expectedXERC20,
             "xERC20 changed after upgrade"
         );
 
-        // 5. Verify trusted senders still configured
+        // 4. Trusted senders still configured
         require(
             adapter.isTrustedSender(
                 MOONBEAM_WORMHOLE_CHAIN_ID,
@@ -182,6 +201,11 @@ contract UpgradeWormholeAdapterEthereum is Script {
             ),
             "Optimism adapter not trusted"
         );
+
+        // 5. bridgeCost(Base) is strictly positive after the V6 fix
+        uint256 cost = adapter.bridgeCost(BASE_WORMHOLE_CHAIN_ID);
+        console.log("  bridgeCost(Base):", cost);
+        require(cost > 0, "bridgeCost still 0 after V6 fix");
 
         console.log("=== Validation Passed ===\n");
     }

--- a/src/xWELL/WormholeBridgeAdapter.sol
+++ b/src/xWELL/WormholeBridgeAdapter.sol
@@ -125,6 +125,11 @@ contract WormholeBridgeAdapter is
     /// @param newGasLimit new gas limit
     event GasLimitUpdated(uint96 oldGasLimit, uint96 newGasLimit);
 
+    /// @notice emitted when the onchain quoter address is updated
+    /// @param oldQuoter old quoter
+    /// @param newQuoter new quoter
+    event QuoterAddressUpdated(address oldQuoter, address newQuoter);
+
     /// ---------------------------------------------------------
     /// ---------------------------------------------------------
     /// ---------------------- INITIALIZE -----------------------
@@ -226,6 +231,16 @@ contract WormholeBridgeAdapter is
         gasLimit = newGasLimit;
 
         emit GasLimitUpdated(oldGasLimit, newGasLimit);
+    }
+
+    /// @notice set the off-chain quoter operator's signer EOA used by the
+    /// Executor Quoter Router to price executions
+    /// @param newQuoterAddress new quoter signer address
+    function setQuoterAddress(address newQuoterAddress) external onlyOwner {
+        address oldQuoterAddress = quoterAddress;
+        quoterAddress = newQuoterAddress;
+
+        emit QuoterAddressUpdated(oldQuoterAddress, newQuoterAddress);
     }
 
     /// @notice remove trusted senders from external chains

--- a/src/xWELL/xWELLRouter.sol
+++ b/src/xWELL/xWELLRouter.sol
@@ -166,8 +166,7 @@ contract xWELLRouter {
 
     /// @notice helper function to bridge WELL to xWELL on the specified chain
     /// using an off-chain signed quote. The executor fee is priced off-chain
-    /// so the router forwards the entire msg.value to the adapter and refunds
-    /// any leftover to the sender.
+    /// so the router forwards the entire msg.value to the adapter.
     /// @param to address to receive the xWELL
     /// @param amount amount of WELL to bridge
     /// @param wormholeChainId chain id to send xWELL to

--- a/src/xWELL/xWELLRouter.sol
+++ b/src/xWELL/xWELLRouter.sol
@@ -201,13 +201,6 @@ contract xWELLRouter {
             signedQuote
         );
 
-        if (address(this).balance != 0) {
-            (bool success, ) = msg.sender.call{value: address(this).balance}(
-                ""
-            );
-            require(success, "xWELLRouter: failed to refund excess GLMR");
-        }
-
         emit BridgeOutSuccess(to, wormholeChainId, amount);
     }
 }

--- a/src/xWELL/xWELLRouter.sol
+++ b/src/xWELL/xWELLRouter.sol
@@ -87,6 +87,35 @@ contract xWELLRouter {
         _bridgeToChain(to, amount, wormholeChainId);
     }
 
+    /// @notice bridge WELL to xWELL on the specified chain using an
+    /// off-chain signed quote from the Wormhole Executor
+    /// receiver address to receive the xWELL is msg.sender
+    /// @param amount amount of WELL to bridge
+    /// @param wormholeChainId chain id to send xWELL to
+    /// @param signedQuote signed quote obtained off-chain from the executor API
+    function bridgeToSender(
+        uint256 amount,
+        uint16 wormholeChainId,
+        bytes calldata signedQuote
+    ) external payable {
+        _bridgeToChain(msg.sender, amount, wormholeChainId, signedQuote);
+    }
+
+    /// @notice bridge WELL to xWELL on the specified chain using an
+    /// off-chain signed quote from the Wormhole Executor
+    /// @param to address to receive the xWELL
+    /// @param amount amount of WELL to bridge
+    /// @param wormholeChainId chain id to send xWELL to
+    /// @param signedQuote signed quote obtained off-chain from the executor API
+    function bridgeToRecipient(
+        address to,
+        uint256 amount,
+        uint16 wormholeChainId,
+        bytes calldata signedQuote
+    ) external payable {
+        _bridgeToChain(to, amount, wormholeChainId, signedQuote);
+    }
+
     /// @notice helper function to bridge WELL to xWELL on the specified chain
     /// @param to address to receive the xWELL
     /// @param amount amount of WELL to bridge
@@ -123,6 +152,53 @@ contract xWELLRouter {
             wormholeChainId,
             xwellAmount,
             to
+        );
+
+        if (address(this).balance != 0) {
+            (bool success, ) = msg.sender.call{value: address(this).balance}(
+                ""
+            );
+            require(success, "xWELLRouter: failed to refund excess GLMR");
+        }
+
+        emit BridgeOutSuccess(to, wormholeChainId, amount);
+    }
+
+    /// @notice helper function to bridge WELL to xWELL on the specified chain
+    /// using an off-chain signed quote. The executor fee is priced off-chain
+    /// so the router forwards the entire msg.value to the adapter and refunds
+    /// any leftover to the sender.
+    /// @param to address to receive the xWELL
+    /// @param amount amount of WELL to bridge
+    /// @param wormholeChainId chain id to send xWELL to
+    /// @param signedQuote signed quote obtained off-chain from the executor API
+    function _bridgeToChain(
+        address to,
+        uint256 amount,
+        uint16 wormholeChainId,
+        bytes calldata signedQuote
+    ) private {
+        /// transfer WELL to this contract from the sender
+        well.safeTransferFrom(msg.sender, address(this), amount);
+
+        /// approve the lockbox to spend the WELL
+        well.approve(address(lockbox), amount);
+
+        /// deposit the WELL into the lockbox, which credits the router contract the xWELL
+        lockbox.deposit(amount);
+
+        /// get the amount of xWELL credited to the lockbox
+        uint256 xwellAmount = xwell.balanceOf(address(this));
+
+        /// approve the wormhole bridge to spend the xWELL
+        xwell.approve(address(wormholeBridge), xwellAmount);
+
+        /// bridge the xWELL to the destination chain using the off-chain signed quote
+        wormholeBridge.bridge{value: msg.value}(
+            wormholeChainId,
+            xwellAmount,
+            to,
+            signedQuote
         );
 
         if (address(this).balance != 0) {

--- a/test/integration/xWELL/DeployxWellBaseIntegration.t.sol
+++ b/test/integration/xWELL/DeployxWellBaseIntegration.t.sol
@@ -52,44 +52,21 @@ contract xWellIntegrationTest is Test {
         _upgradeAdapterToV5();
     }
 
-    /// @notice Deploy V5 impl and upgrade via proxy admin
+    /// @notice Deploy a fresh impl and swap it onto the proxy. The live
+    ///         proxy on Base/Optimism is already V5-initialized after
+    ///         mip-x52, so we use plain `upgrade()` (no init data) to avoid
+    ///         "Initializable: contract is already initialized".
     function _upgradeAdapterToV5() internal {
         address proxyAdmin = addresses.getAddress("MRD_PROXY_ADMIN");
         address proxy = addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY");
 
         WormholeBridgeAdapter newImpl = new WormholeBridgeAdapter();
 
-        /// Try to get executor addresses — they may or may not be in chain config
-        address executorAddr;
-        address quoterRouterAddr;
-        address quoterAddr;
-        try addresses.getAddress("WORMHOLE_EXECUTOR") returns (address a) {
-            executorAddr = a;
-        } catch {
-            executorAddr = address(new MockExecutorQuoterRouter());
-        }
-        try addresses.getAddress("WORMHOLE_QUOTER_ROUTER") returns (address a) {
-            quoterRouterAddr = a;
-        } catch {
-            quoterRouterAddr = address(new MockExecutorQuoterRouter());
-        }
-        try addresses.getAddress("WORMHOLE_QUOTER") returns (address a) {
-            quoterAddr = a;
-        } catch {
-            quoterAddr = address(new MockExecutorQuoterRouter());
-        }
-
         address proxyAdminOwner = ProxyAdmin(proxyAdmin).owner();
         vm.prank(proxyAdminOwner);
-        ProxyAdmin(proxyAdmin).upgradeAndCall(
+        ProxyAdmin(proxyAdmin).upgrade(
             ITransparentUpgradeableProxy(proxy),
-            address(newImpl),
-            abi.encodeWithSignature(
-                "initializeV5(address,address,address)",
-                executorAddr,
-                quoterRouterAddr,
-                quoterAddr
-            )
+            address(newImpl)
         );
     }
 

--- a/test/integration/xWELL/WormholeBridgeAdapterIntegration.t.sol
+++ b/test/integration/xWELL/WormholeBridgeAdapterIntegration.t.sol
@@ -291,6 +291,79 @@ contract WormholeBridgeAdapterIntegrationTest is PostProposalCheck {
     }
 
     // ---------------------------------------------------------------
+    // On-chain quote bridge tests (the bridge(uint256,uint256,address)
+    // overload). After mip-x53 fixes quoterAddress on Base + Optimism,
+    // bridgeCost > 0 and the on-chain-quote path becomes usable. Moonbeam
+    // has no on-chain quoter — the path always reverts up front there.
+    // ---------------------------------------------------------------
+
+    function testBridgeOnchainQuoteFailsZeroValue() public {
+        address user = address(0xBEEF);
+        uint256 amount = 1e18;
+        deal(address(xwellProxy), user, amount);
+
+        vm.startPrank(user);
+        xwellProxy.approve(address(adapter), amount);
+
+        if (block.chainid == MOONBEAM_CHAIN_ID) {
+            vm.expectRevert(
+                "WormholeBridge: onchain quoting not available, use bridge with signedQuote"
+            );
+        } else {
+            vm.expectRevert("WormholeBridge: cost not equal to quote");
+        }
+        adapter.bridge{value: 0}(uint256(sourceWormholeChainId), amount, user);
+        vm.stopPrank();
+    }
+
+    function testBridgeOnchainQuoteSucceeds() public {
+        if (block.chainid == MOONBEAM_CHAIN_ID) {
+            // Moonbeam has no on-chain quoter — covered by the failure test
+            return;
+        }
+
+        address user = address(0xBEEF);
+        uint256 amount = 1e18;
+        deal(address(xwellProxy), user, amount);
+
+        // Etch a mock router onto the live ExecutorQuoterRouter so
+        // requestExecution succeeds without going to the real Wormhole network.
+        address routerAddr = address(adapter.executorQuoterRouter());
+        MockExecutorQuoterRouter mockRouter = new MockExecutorQuoterRouter();
+        vm.etch(routerAddr, address(mockRouter).code);
+        // Force a non-zero quote so the require(msg.value == cost) path runs
+        MockExecutorQuoterRouter(routerAddr).setQuote(0.001 ether);
+
+        uint256 cost = adapter.bridgeCost(sourceWormholeChainId);
+        assertGt(cost, 0, "expected non-zero on-chain quote post-mip-x53");
+
+        vm.deal(user, cost);
+
+        uint256 supplyBefore = xwellProxy.totalSupply();
+        uint256 balanceBefore = xwellProxy.balanceOf(user);
+
+        vm.startPrank(user);
+        xwellProxy.approve(address(adapter), amount);
+        adapter.bridge{value: cost}(
+            uint256(sourceWormholeChainId),
+            amount,
+            user
+        );
+        vm.stopPrank();
+
+        assertEq(
+            balanceBefore - xwellProxy.balanceOf(user),
+            amount,
+            "user xWELL not burned"
+        );
+        assertEq(
+            supplyBefore - xwellProxy.totalSupply(),
+            amount,
+            "totalSupply did not drop"
+        );
+    }
+
+    // ---------------------------------------------------------------
     // Test 9: Wormhole core rejection propagates through executeVAAv1
     // ---------------------------------------------------------------
 

--- a/test/integration/xWELL/WormholeBridgeAdapterIntegration.t.sol
+++ b/test/integration/xWELL/WormholeBridgeAdapterIntegration.t.sol
@@ -79,8 +79,16 @@ contract WormholeBridgeAdapterIntegrationTest is PostProposalCheck {
     // ---------------------------------------------------------------
 
     function testUpgradePreservesExistingState() public view {
-        /// gasLimit is still 300_000
-        assertEq(adapter.gasLimit(), 300_000, "gasLimit changed after upgrade");
+        /// gasLimit was bumped to 700_000 on Base + Optimism by mip-x53;
+        /// Moonbeam is untouched and stays at 300_000.
+        uint96 expectedGasLimit = block.chainid == MOONBEAM_CHAIN_ID
+            ? 300_000
+            : 700_000;
+        assertEq(
+            adapter.gasLimit(),
+            expectedGasLimit,
+            "gasLimit not at expected value after upgrade"
+        );
 
         /// wormhole() returns the core bridge address
         assertEq(
@@ -300,15 +308,24 @@ contract WormholeBridgeAdapterIntegrationTest is PostProposalCheck {
     }
 
     // ---------------------------------------------------------------
-    // Test 10: bridgeCost returns 0 when no executorQuoterRouter
+    // Test 10: bridgeCost is 0 on Moonbeam (no quoter) and >0 elsewhere
     // ---------------------------------------------------------------
 
-    function testBridgeCostReturnsZeroGracefully() public view {
-        /// If executorQuoterRouter is not set (e.g. Moonbeam), bridgeCost returns 0
-        /// On chains with a quoter, it returns the executor quote + message fee
+    function testBridgeCostMatchesQuoterConfig() public view {
         uint256 cost = adapter.bridgeCost(sourceWormholeChainId);
-        /// Either 0 (no quoter / quote fails) or some value — just ensure no revert
-        assertTrue(cost >= 0, "bridgeCost should not revert");
+        if (block.chainid == MOONBEAM_CHAIN_ID) {
+            /// Moonbeam has no on-chain quoter — must always return 0
+            assertEq(cost, 0, "Moonbeam: bridgeCost should be 0 (no quoter)");
+        } else {
+            /// Base + Optimism (post-V6) have an EOA quoter and a live router —
+            /// `bridgeCost` swallows quote failures and returns 0, so a strict
+            /// >0 check is the only way to surface a misconfigured quoter.
+            assertGt(
+                cost,
+                0,
+                "bridgeCost returned 0 on a chain with an on-chain quoter"
+            );
+        }
     }
 
     // ---------------------------------------------------------------
@@ -321,7 +338,7 @@ contract WormholeBridgeAdapterIntegrationTest is PostProposalCheck {
             sourceWormholeChainId,
             address(adapter).toBytes(),
             "",
-            abi.encode(address(0), uint256(1000e18))
+            abi.encode(address(0), uint256(1000e18), currentWormholeChainId)
         );
 
         vm.expectRevert("ERC20: mint to the zero address");

--- a/test/integration/xWELL/xWellRouterIntegration.t.sol
+++ b/test/integration/xWELL/xWellRouterIntegration.t.sol
@@ -11,15 +11,17 @@ import {xWELLRouter} from "@protocol/xWELL/xWELLRouter.sol";
 import {XERC20Lockbox} from "@protocol/xWELL/XERC20Lockbox.sol";
 import {WormholeBridgeAdapter} from "@protocol/xWELL/WormholeBridgeAdapter.sol";
 import {MockExecutorQuoterRouter} from "@test/mock/MockExecutorQuoterRouter.sol";
-import {PostProposalCheck} from "@test/integration/PostProposalCheck.sol";
 import {BASE_WORMHOLE_CHAIN_ID, MOONBEAM_WORMHOLE_CHAIN_ID, ETHEREUM_WORMHOLE_CHAIN_ID} from "@utils/ChainIds.sol";
 
 /// @notice Tests the xWELLRouter on Moonbeam after the V5 (Executor framework)
 ///         upgrade. Moonbeam has no on-chain quoter, so the only working
 ///         bridge-out path is the off-chain signed-quote `bridge(uint16,...)`
-///         overload. Uses PostProposalCheck so any in-development proposals
-///         are simulated before tests run.
-contract xWellRouterMoonbeamTest is PostProposalCheck {
+///         overload. Uses plain `Test` so the moonbeam-integration CI
+///         workflow (--fork-url moonbeam, only Moonbeam fork) can run it.
+contract xWellRouterMoonbeamTest is Test {
+    /// @notice address registry — read from chains/1284.json
+    Addresses public addresses;
+
     /// @notice xWELL token
     xWELL public xwell;
 
@@ -55,8 +57,8 @@ contract xWellRouterMoonbeamTest is PostProposalCheck {
         uint256 amount
     );
 
-    function setUp() public override {
-        super.setUp();
+    function setUp() public {
+        addresses = new Addresses();
 
         well = IERC20(addresses.getAddress("GOVTOKEN"));
         xwell = xWELL(addresses.getAddress("xWELL_PROXY"));

--- a/test/integration/xWELL/xWellRouterIntegration.t.sol
+++ b/test/integration/xWELL/xWellRouterIntegration.t.sol
@@ -10,51 +10,53 @@ import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
 import {xWELLRouter} from "@protocol/xWELL/xWELLRouter.sol";
 import {XERC20Lockbox} from "@protocol/xWELL/XERC20Lockbox.sol";
 import {WormholeBridgeAdapter} from "@protocol/xWELL/WormholeBridgeAdapter.sol";
+import {MockExecutorQuoterRouter} from "@test/mock/MockExecutorQuoterRouter.sol";
+import {PostProposalCheck} from "@test/integration/PostProposalCheck.sol";
 import {BASE_WORMHOLE_CHAIN_ID, MOONBEAM_WORMHOLE_CHAIN_ID, ETHEREUM_WORMHOLE_CHAIN_ID} from "@utils/ChainIds.sol";
 
-contract xWellRouterMoonbeamTest is Test {
-    /// @notice addresses contract, stores all addresses
-    Addresses public addresses;
-
-    /// @notice logic contract, not initializable
+/// @notice Tests the xWELLRouter on Moonbeam after the V5 (Executor framework)
+///         upgrade. Moonbeam has no on-chain quoter, so the only working
+///         bridge-out path is the off-chain signed-quote `bridge(uint16,...)`
+///         overload. Uses PostProposalCheck so any in-development proposals
+///         are simulated before tests run.
+contract xWellRouterMoonbeamTest is PostProposalCheck {
+    /// @notice xWELL token
     xWELL public xwell;
 
-    /// @notice well token contract
+    /// @notice WELL token
     IERC20 public well;
 
-    /// @notice wormhole bridge adapter contract
+    /// @notice wormhole bridge adapter (V5)
     WormholeBridgeAdapter public wormholeAdapter;
 
-    /// @notice xWELL router contract
-    xWELLRouter public router;
-
-    /// @notice xWELL lockbox contract
+    /// @notice xWELL lockbox
     XERC20Lockbox public lockbox;
 
-    /// @notice user address for testing
-    address user = address(0x123);
+    /// @notice fresh router pointing at the live (post-V5) adapter
+    xWELLRouter public router;
 
-    /// @notice whether or not the fallback reverts
+    /// @notice fixed test user — avoids any state on `address(this)` from
+    ///         PostProposalCheck setup
+    address public constant USER = address(0xCAFE);
+
+    /// @notice executor fee used in tests (would normally come from signed quote)
+    uint256 public constant EXECUTOR_FEE = 0.001 ether;
+
+    /// @notice signed quote stub — the real flow validates this off-chain
+    bytes public constant SIGNED_QUOTE = hex"deadbeef";
+
+    /// @notice whether USER's receive() reverts on refund attempts
     bool public fallbackReverts;
 
-    /// @notice amount of well to mint
-    uint256 public constant startingWellAmount = 100_000 * 1e18;
-
-    uint16 public constant wormholeMoonbeamChainid =
-        uint16(MOONBEAM_WORMHOLE_CHAIN_ID);
-
-    /// @notice event emitted when WELL is bridged to xWELL via the base chain
-    /// @param to address that receives the xWELL
-    /// @param destWormholeChainId chain id to send xWELL to
-    /// @param amount amount of xWELL bridged
+    /// @notice mirror of the router event for vm.expectEmit
     event BridgeOutSuccess(
         address indexed to,
         uint16 indexed destWormholeChainId,
         uint256 amount
     );
 
-    function setUp() public {
-        addresses = new Addresses();
+    function setUp() public override {
+        super.setUp();
 
         well = IERC20(addresses.getAddress("GOVTOKEN"));
         xwell = xWELL(addresses.getAddress("xWELL_PROXY"));
@@ -65,12 +67,26 @@ contract xWellRouterMoonbeamTest is Test {
 
         router = new xWELLRouter(
             address(xwell),
-            addresses.getAddress("GOVTOKEN"),
-            addresses.getAddress("xWELL_LOCKBOX"),
+            address(well),
+            address(lockbox),
             address(wormholeAdapter)
         );
 
-        fallbackReverts = false; /// default to not revert
+        /// Etch a mock executor onto the live executor address so
+        /// requestExecution accepts the off-chain signed quote.
+        address executorAddr = address(wormholeAdapter.executor());
+        MockExecutorQuoterRouter mockExecutor = new MockExecutorQuoterRouter();
+        vm.etch(executorAddr, address(mockExecutor).code);
+
+        fallbackReverts = false;
+
+        /// Set this contract's `receive()` to optionally revert so refund
+        /// tests can assert the router-level failure path.
+        vm.etch(USER, address(this).code);
+    }
+
+    function _value() internal view returns (uint256) {
+        return wormholeAdapter.wormhole().messageFee() + EXECUTOR_FEE;
     }
 
     function _boundMintAmount(
@@ -78,265 +94,215 @@ contract xWellRouterMoonbeamTest is Test {
     ) internal view returns (uint256) {
         uint256 buffer = xwell.buffer(address(wormholeAdapter));
         uint256 bufferCap = xwell.bufferCap(address(wormholeAdapter));
-
         return _bound(mintAmount, 1, bufferCap - buffer);
     }
+
+    /// --------------------------------------------------------
+    /// ------------------- Setup Tests ------------------------
+    /// --------------------------------------------------------
 
     function testSetup() public view {
         assertEq(
             address(router.xwell()),
             address(xwell),
-            "Xwell address incorrect"
+            "router.xwell() incorrect"
         );
         assertEq(
             address(router.well()),
-            addresses.getAddress("GOVTOKEN"),
-            "Well address incorrect"
+            address(well),
+            "router.well() incorrect"
         );
         assertEq(
             address(router.lockbox()),
-            addresses.getAddress("xWELL_LOCKBOX"),
-            "Lockbox address incorrect"
+            address(lockbox),
+            "router.lockbox() incorrect"
         );
         assertEq(
             address(router.wormholeBridge()),
             address(wormholeAdapter),
-            "Wormhole bridge address incorrect"
+            "router.wormholeBridge() incorrect"
         );
     }
 
-    function testBridgeOutNoApprovalFails() public {
-        uint256 mintAmount = 100_000_000 * 1e18;
+    /// --------------------------------------------------------
+    /// ----------- Signed-Quote Bridge Out Success ------------
+    /// --------------------------------------------------------
 
-        deal(address(well), address(this), mintAmount);
-        uint256 bridgeCost = router.bridgeCost(BASE_WORMHOLE_CHAIN_ID);
+    function testBridgeToSenderSucceeds() public {
+        _bridgeToSenderSucceeds(_boundMintAmount(300_000_000 * 1e18));
+    }
 
-        vm.deal(address(this), bridgeCost);
+    function testBridgeToSenderFuzz(uint256 mintAmount) public {
+        _bridgeToSenderSucceeds(_boundMintAmount(mintAmount));
+    }
 
+    function testBridgeToRecipientFuzz(
+        uint256 mintAmount,
+        uint256 glmrAmount
+    ) public {
+        mintAmount = _boundMintAmount(mintAmount);
+        uint256 totalValue = _value();
+        glmrAmount = _bound(glmrAmount, totalValue, type(uint128).max);
+
+        deal(address(well), USER, mintAmount);
+        vm.deal(USER, glmrAmount);
+
+        uint256 startingXWellSupply = xwell.totalSupply();
+        uint256 startingBuffer = xwell.buffer(address(wormholeAdapter));
+        uint256 startingLockboxWell = well.balanceOf(address(lockbox));
+
+        vm.startPrank(USER);
+        well.approve(address(router), mintAmount);
+
+        vm.expectEmit(true, true, true, true, address(router));
+        emit BridgeOutSuccess(USER, BASE_WORMHOLE_CHAIN_ID, mintAmount);
+
+        router.bridgeToRecipient{value: glmrAmount}(
+            USER,
+            mintAmount,
+            BASE_WORMHOLE_CHAIN_ID,
+            SIGNED_QUOTE
+        );
+        vm.stopPrank();
+
+        /// Mock executor consumes any value forwarded by the adapter, so the
+        /// router never has leftover. The caller only spends the messageFee
+        /// portion of the executor request — the remainder is forwarded
+        /// without checking it equals the actual quote.
+        assertEq(address(router).balance, 0, "router holds leftover GLMR");
+        assertEq(
+            xwell.buffer(address(wormholeAdapter)),
+            startingBuffer + mintAmount,
+            "buffer did not increase by burn amount"
+        );
+        assertEq(
+            xwell.totalSupply(),
+            startingXWellSupply,
+            "xWELL totalSupply changed (mint then burn should net to zero)"
+        );
+        assertEq(
+            well.balanceOf(address(lockbox)),
+            startingLockboxWell + mintAmount,
+            "lockbox did not receive WELL"
+        );
+    }
+
+    function _bridgeToSenderSucceeds(uint256 mintAmount) internal {
+        deal(address(well), USER, mintAmount);
+        uint256 totalValue = _value();
+        vm.deal(USER, totalValue);
+
+        uint256 startingXWellSupply = xwell.totalSupply();
+        uint256 startingBuffer = xwell.buffer(address(wormholeAdapter));
+        uint256 startingLockboxWell = well.balanceOf(address(lockbox));
+
+        vm.startPrank(USER);
+        well.approve(address(router), mintAmount);
+
+        vm.expectEmit(true, true, true, true, address(router));
+        emit BridgeOutSuccess(USER, BASE_WORMHOLE_CHAIN_ID, mintAmount);
+
+        router.bridgeToSender{value: totalValue}(
+            mintAmount,
+            BASE_WORMHOLE_CHAIN_ID,
+            SIGNED_QUOTE
+        );
+        vm.stopPrank();
+
+        assertEq(address(router).balance, 0, "router holds leftover GLMR");
+        assertEq(
+            xwell.buffer(address(wormholeAdapter)),
+            startingBuffer + mintAmount,
+            "buffer did not increase by burn amount"
+        );
+        assertEq(
+            xwell.totalSupply(),
+            startingXWellSupply,
+            "xWELL totalSupply changed (mint then burn should net to zero)"
+        );
+        assertEq(
+            well.balanceOf(address(lockbox)),
+            startingLockboxWell + mintAmount,
+            "lockbox did not receive WELL"
+        );
+    }
+
+    /// --------------------------------------------------------
+    /// ----------- Signed-Quote Bridge Out Failure ------------
+    /// --------------------------------------------------------
+
+    function testBridgeFailsNoApproval() public {
+        uint256 mintAmount = 1_000e18;
+        deal(address(well), USER, mintAmount);
+        uint256 totalValue = _value();
+        vm.deal(USER, totalValue);
+
+        vm.prank(USER);
         vm.expectRevert(
             "Well::transferFrom: transfer amount exceeds spender allowance"
         );
-        router.bridgeToSender{value: bridgeCost}(
+        router.bridgeToSender{value: totalValue}(
             mintAmount,
-            BASE_WORMHOLE_CHAIN_ID
+            BASE_WORMHOLE_CHAIN_ID,
+            SIGNED_QUOTE
         );
     }
 
-    function testBridgeOutNoBalanceFails() public {
-        uint256 mintAmount = 100_000_000 * 1e18;
+    function testBridgeFailsNoBalance() public {
+        uint256 mintAmount = 1_000e18;
+        uint256 totalValue = _value();
+        vm.deal(USER, totalValue);
 
-        uint256 bridgeCost = router.bridgeCost(BASE_WORMHOLE_CHAIN_ID);
-
-        vm.deal(address(this), bridgeCost);
+        vm.startPrank(USER);
         well.approve(address(router), mintAmount);
-
         vm.expectRevert(
             "Well::_transferTokens: transfer amount exceeds balance"
         );
-        router.bridgeToSender{value: bridgeCost}(
+        router.bridgeToSender{value: totalValue}(
             mintAmount,
-            BASE_WORMHOLE_CHAIN_ID
-        );
-    }
-
-    function testBridgeOutSuccess() public {
-        testBridgeOutSuccess(300_000_000 * 1e18);
-    }
-
-    function testBridgeOutToSuccess(
-        uint256 mintAmount,
-        uint256 glmrAmount
-    ) public returns (uint256) {
-        uint256 bridgeCost = router.bridgeCost(BASE_WORMHOLE_CHAIN_ID);
-
-        mintAmount = _boundMintAmount(mintAmount);
-        glmrAmount = _bound(glmrAmount, bridgeCost, type(uint256).max);
-
-        uint256 startingXWellBalance = xwell.balanceOf(address(this));
-        uint256 startingXWellTotalSupply = xwell.totalSupply();
-        uint256 startingBuffer = xwell.buffer(address(wormholeAdapter));
-
-        deal(address(well), address(this), mintAmount);
-        vm.deal(address(this), glmrAmount);
-
-        uint256 startingWellBalance = well.balanceOf(address(this));
-        uint256 startingLockboxWellBalance = well.balanceOf(address(lockbox));
-
-        well.approve(address(router), mintAmount);
-
-        vm.expectEmit(true, true, true, true, address(router));
-        emit BridgeOutSuccess(
-            address(this),
             BASE_WORMHOLE_CHAIN_ID,
-            mintAmount
+            SIGNED_QUOTE
         );
-
-        router.bridgeToRecipient{value: bridgeCost}(
-            address(this),
-            mintAmount,
-            BASE_WORMHOLE_CHAIN_ID
-        );
-
-        assertEq(address(router).balance, 0, "incorrect router balance");
-        assertEq(
-            address(this).balance,
-            glmrAmount - bridgeCost,
-            "incorrect router balance"
-        );
-
-        assertEq(
-            xwell.buffer(address(wormholeAdapter)),
-            startingBuffer + mintAmount,
-            "incorrect buffer"
-        );
-        assertEq(
-            xwell.balanceOf(address(this)),
-            startingXWellBalance,
-            "incorrect user xwell balance"
-        );
-        assertEq(
-            well.balanceOf(address(this)),
-            startingWellBalance - mintAmount,
-            "incorrect user well balance"
-        );
-        assertEq(
-            well.balanceOf(address(lockbox)),
-            startingLockboxWellBalance + mintAmount,
-            "incorrect lockbox well balance"
-        );
-        assertEq(
-            xwell.totalSupply(),
-            startingXWellTotalSupply,
-            "incorrect xwell total supply"
-        );
-        return mintAmount;
+        vm.stopPrank();
     }
 
-    function testBridgeOutSuccess(uint256 mintAmount) public returns (uint256) {
-        mintAmount = _boundMintAmount(mintAmount);
+    function testBridgeFailsZeroAmount() public {
+        uint256 totalValue = _value();
+        vm.deal(USER, totalValue);
 
-        uint256 startingXWellBalance = xwell.balanceOf(address(this));
-        uint256 startingXWellTotalSupply = xwell.totalSupply();
-        uint256 startingBuffer = xwell.buffer(address(wormholeAdapter));
-
-        deal(address(well), address(this), mintAmount);
-        uint256 bridgeCost = router.bridgeCost(BASE_WORMHOLE_CHAIN_ID);
-        vm.deal(address(this), bridgeCost);
-        uint256 startingWellBalance = well.balanceOf(address(this));
-        uint256 startingLockboxWellBalance = well.balanceOf(address(lockbox));
-
-        well.approve(address(router), mintAmount);
-        vm.expectEmit(true, true, true, true, address(router));
-        emit BridgeOutSuccess(
-            address(this),
-            BASE_WORMHOLE_CHAIN_ID,
-            mintAmount
-        );
-        router.bridgeToSender{value: bridgeCost}(
-            mintAmount,
-            BASE_WORMHOLE_CHAIN_ID
-        );
-
-        assertEq(
-            xwell.buffer(address(wormholeAdapter)),
-            startingBuffer + mintAmount,
-            "incorrect buffer"
-        );
-        assertEq(
-            xwell.balanceOf(address(this)),
-            startingXWellBalance,
-            "incorrect user xwell balance"
-        );
-        assertEq(
-            well.balanceOf(address(this)),
-            startingWellBalance - mintAmount,
-            "incorrect user well balance"
-        );
-        assertEq(
-            well.balanceOf(address(lockbox)),
-            startingLockboxWellBalance + mintAmount,
-            "incorrect lockbox well balance"
-        );
-        assertEq(
-            xwell.totalSupply(),
-            startingXWellTotalSupply,
-            "incorrect xwell total supply"
-        );
-        return mintAmount;
-    }
-
-    /// @notice With bridgeCost returning 0 (messageFee), the insufficient GLMR
-    ///         check passes for any msg.value >= 0. Instead, sending amount=0
-    ///         hits MintLimits: deplete amount cannot be 0.
-    function testBridgeToSenderFailsZeroAmount() public {
+        vm.prank(USER);
         vm.expectRevert("MintLimits: deplete amount cannot be 0");
-        router.bridgeToSender{value: 1}(0, BASE_WORMHOLE_CHAIN_ID);
-    }
-
-    /// @notice With bridgeCost returning 0, send excess ETH to trigger
-    ///         a refund failure when caller cannot receive funds.
-    function testBridgeToSenderFailsRefund() public {
-        uint256 mintAmount = xwell.buffer(address(wormholeAdapter)) / 2;
-
-        deal(address(well), address(this), mintAmount);
-
-        uint256 excessValue = 1 ether;
-        vm.deal(address(this), excessValue);
-
-        well.approve(address(router), mintAmount);
-
-        fallbackReverts = true;
-        vm.expectRevert("xWELLRouter: failed to refund excess GLMR");
-        router.bridgeToSender{value: excessValue}(
-            mintAmount,
-            BASE_WORMHOLE_CHAIN_ID
-        );
-    }
-
-    function testBridgeToSenderSucceedsNoRefund() public {
-        uint256 mintAmount = xwell.buffer(address(wormholeAdapter)) / 2;
-
-        deal(address(well), address(this), mintAmount);
-
-        uint256 bridgeCost = router.bridgeCost(BASE_WORMHOLE_CHAIN_ID); /// no extra, no refund amount
-        vm.deal(address(this), bridgeCost);
-
-        well.approve(address(router), mintAmount);
-
-        fallbackReverts = true;
-
-        vm.expectEmit(true, true, true, true, address(router));
-        emit BridgeOutSuccess(
-            address(this),
+        router.bridgeToSender{value: totalValue}(
+            0,
             BASE_WORMHOLE_CHAIN_ID,
-            mintAmount
+            SIGNED_QUOTE
         );
-        router.bridgeToSender{value: bridgeCost}(
-            mintAmount,
-            BASE_WORMHOLE_CHAIN_ID
-        );
-        assertEq(address(router).balance, 0, "incorrect router balance");
     }
 
-    function testBridgeToNonBridgeAdapterWhitelistedWormholeChainIdFails()
-        public
-    {
-        uint256 mintAmount = xwell.buffer(address(wormholeAdapter));
+    function testBridgeFailsInvalidTargetChain() public {
+        uint256 mintAmount = 1_000e18;
+        deal(address(well), USER, mintAmount);
+        uint256 totalValue = _value();
+        vm.deal(USER, totalValue);
 
-        deal(address(well), address(this), mintAmount);
+        /// Pick an arbitrary unconfigured chain id. Moonbeam's adapter only
+        /// has Base and Optimism (and post-PR-624, Ethereum) targets — 9999
+        /// is guaranteed unset.
+        uint16 unconfiguredChain = 9999;
 
-        uint256 bridgeCost = router.bridgeCost(ETHEREUM_WORMHOLE_CHAIN_ID); /// no extra, no refund amount
-        vm.deal(address(this), bridgeCost);
-
+        vm.startPrank(USER);
         well.approve(address(router), mintAmount);
-
-        vm.expectRevert("WormholeBridgeAdapter: invalid target chain");
-        router.bridgeToSender{value: bridgeCost}(
+        vm.expectRevert("WormholeBridge: invalid target chain");
+        router.bridgeToSender{value: totalValue}(
             mintAmount,
-            ETHEREUM_WORMHOLE_CHAIN_ID
+            unconfiguredChain,
+            SIGNED_QUOTE
         );
+        vm.stopPrank();
     }
 
+    /// USER is etched with this contract's bytecode so we can toggle its
+    /// receive() behavior between accepting and reverting.
     receive() external payable {
         require(!fallbackReverts, "fallback reverted");
     }

--- a/test/unit/WormholeBridgeAdapter.t.sol
+++ b/test/unit/WormholeBridgeAdapter.t.sol
@@ -43,6 +43,8 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
 
     event GasLimitUpdated(uint96 oldGasLimit, uint96 newGasLimit);
 
+    event QuoterAddressUpdated(address oldQuoter, address newQuoter);
+
     /// state variables
     address to;
     uint256 amount;
@@ -309,6 +311,27 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         wormholeBridgeAdapterProxy.setGasLimit(newGasLimit);
 
         assertEq(wormholeBridgeAdapterProxy.gasLimit(), newGasLimit);
+    }
+
+    function testSetQuoterAddressNonOwnerFails() public {
+        vm.expectRevert("Ownable: caller is not the owner");
+        wormholeBridgeAdapterProxy.setQuoterAddress(address(0xa54008));
+    }
+
+    function testSetQuoterAddressOwnerSucceeds(address newQuoter) public {
+        address oldQuoter = wormholeBridgeAdapterProxy.quoterAddress();
+        vm.prank(owner);
+        vm.expectEmit(
+            true,
+            true,
+            true,
+            true,
+            address(wormholeBridgeAdapterProxy)
+        );
+        emit QuoterAddressUpdated(oldQuoter, newQuoter);
+        wormholeBridgeAdapterProxy.setQuoterAddress(newQuoter);
+
+        assertEq(wormholeBridgeAdapterProxy.quoterAddress(), newQuoter);
     }
 
     function testRemoveTrustedSendersOwnerSucceeds() public {


### PR DESCRIPTION
## Summary

mip-x52 upgraded the xwell wormhole adapter contract to the new wormhole executor pattern. two issues were discovered
- the executor receiving end consumes more than double the gas as before
- the wormhole docs and example source code contain discrepancies in which address to use as the quoter (contract vs. EOA) 

the first issue can be fixed via the current setter that exists, but the second issues requires a new setter. this proposal deploys a new implementation with that setter, and calls it to update the address used for the quoter as the EOA. validations in the proposal script confirm that the bridgeCost() returns a positive value, as the onchain bridge function expects for `msg.value`

also, a new instance of the helper contract `xWELLRouter` was deployed to moonbeam to support offchain quotes (as onchain quotes are not supported on moombeam)

## Simulation output

<!-- For MIPs: paste the proposal description, actions, and calldata from
`forge script ... --sig "printProposalActionSteps()"` or the default run.
Delete this section if the PR does not touch `proposals/`. -->

### TODO

## Notes

See TG message with wormhole team for further context

---

## Checklist

**General**

- [x] `forge build` clean (no new warnings)
- [x] `forge test` passing locally for new/modified tests
- [ ] `npm run lint` and `npm run prettier` clean
- [ ] `make slither` reviewed (no new findings, or findings justified in PR)
- [ ] Ran `@security-auditor` agent against new/modified contracts
- [x] All CI checks green

**If this PR adds a new MIP**

- [x] `id: 0` set in `proposals/mips/mips.json`
- [x] Folder `proposals/mips/mip-{chain}{number}/` contains the three required files: `.sh`, `.json`, `.md`
- [] `.sh` sets `JSON_PATH`, `DESCRIPTION_PATH`, `PRIMARY_FORK_ID`
- [x] New addresses live in `proposals/Addresses.sol` or `chains/*.json` — nothing hardcoded
- [ ] Forum discussion linked in the PR body (required for risk-parameter changes and market adds)
- [x] For cross-chain proposals: simulated on every affected `PRIMARY_FORK_ID`
- [x] Wormhole message encoding matches the receiving `TemporalGovernor` expectations

**If this PR modifies existing protocol state** (oracle swaps, proxy upgrades, IRM changes, comptroller config)

- [ ] `beforeSimulationHook()` captures downstream outputs (prices, rates, balances)
- [x] `validate()` asserts those outputs are preserved (see MIP-B57 pattern)

**Proposal summary bot**

- [ ] Reviewed the `<!-- proposal-summary -->` comment from the `Proposal Summary` workflow
- [ ] Addressed any flagged gaps or mismatches
- [ ] Deleted the stale comment before pushing changes (forces the workflow to regenerate)
