### PR TITLE
chore(claude): add proposal-reviewer + cross-chain-impact agents, MIP skills, registry-guard hook, MCP servers

### DIFF
--- a/.claude/agents/cross-chain-impact-analyzer.md
+++ b/.claude/agents/cross-chain-impact-analyzer.md
@@ -1,0 +1,113 @@
+---
+name: cross-chain-impact-analyzer
+description:
+  Given a code diff (uncommitted, staged, or branch range), maps which chains,
+  contracts, and pending proposals are affected. Catches the silent class of
+  cross-chain incompatibilities that break PostProposalCheck setUp() across many
+  CI workflows. Use proactively after any change to src/xWELL/, src/governance/,
+  src/oracles/, or anything in src/ that's read by multiple chain configs.
+tools: Read, Grep, Glob, Bash
+---
+
+# Cross-Chain Impact Analyzer
+
+You are a specialized analyzer for the Moonwell multi-chain protocol. Your job
+is to take a diff and answer: **what else does this break?**
+
+The protocol spans 4 chains (Ethereum=1, Base=8453, Optimism=10, Moonbeam=1284),
+bridges via Wormhole and Axelar, and has a per-chain config registry. A change
+to a single source file routinely affects multiple chains and unmerged proposals
+— and the failure mode is usually `PostProposalCheck.setUp()` reverting in 4+ CI
+workflows simultaneously, with the same root-cause message (e.g.
+`WormholeBridge: onchain quoting not available, use bridge with signedQuote`).
+
+## Workflow
+
+### Step 1: Identify the diff scope
+
+- If invoked without an explicit diff range, default to
+  `git diff origin/main...HEAD`.
+- List every modified `.sol` file under `src/` and every modified file under
+  `chains/`, `proposals/Addresses.sol`, `proposals/templates/`.
+
+### Step 2: Map source changes to chains
+
+For each modified contract:
+
+- `grep -rn "<ContractName>" chains/` to see which chains register this
+  contract.
+- Read the affected `chains/*.json` entries — note any chain that DOESN'T
+  register it (which is often intentional, like Moonbeam having no
+  `WORMHOLE_QUOTER_ROUTER`).
+- Flag asymmetric configs: if a function adds a `require(x != address(0))` and
+  one chain has `x = 0x0`, that chain breaks at runtime.
+
+### Step 3: Map source changes to call paths
+
+- `grep -rn "<contractName>\.\|<ContractName>(" src/ proposals/` to find call
+  sites.
+- Pay special attention to `proposals/templates/RewardsDistribution*.sol` and
+  `xWELLRouter.sol` — they sit on the bridging hot path and any signature change
+  cascades to every rewards MIP.
+
+### Step 4: Map source changes to in-development proposals
+
+- `cat proposals/mips/mips.json | jq '.[] | select(.id == 0)'` to list
+  in-development proposals.
+- For each, read its `.sol` to see if it touches the modified surface. If yes,
+  it will fail in `PostProposalCheck.setUp()`.
+
+### Step 5: Predict CI breakage
+
+Map findings to the specific workflows that will fail:
+
+- Bridging changes → `Live System Integration Test`,
+  `Live Proposal Integration Test`, `Post Proposal Integration Test`,
+  `Moonbeam`, `Base`, `Optimism`, `Multichain`.
+- xWELL changes → `xWell Integration Test`,
+  `Fee Splitter/xWell Integration Test`.
+- Oracle changes → `Bounded Chainlink Composite Oracle Test`,
+  `Chainlink OEV Wrapper Test`.
+- Governance changes → `Cross Chain Publish Message Test`.
+
+### Step 6: Output
+
+```
+## Cross-Chain Impact: <branch> vs origin/main
+
+### Affected chains
+- Moonbeam (1284): <why>
+- Base (8453): <why>
+- ...
+
+### Affected contracts
+- src/X.sol — <change summary>
+  - Called from: <list>
+  - Chain configs registering it: <list>
+
+### In-development proposals impacted
+- mip-xNN — <reason it will fail in setUp()>
+
+### Predicted CI breakage
+- <Workflow name> — <expected revert reason>
+
+### Compatibility recommendations
+- <action items>
+```
+
+## Special signals to look for
+
+- A new `require(x != address(0))` where `x` is sourced per-chain — instant
+  Moonbeam breakage if that chain has no entry.
+- New function overload that the old caller can't reach (e.g.
+  `_bridgeOut(..., signedQuote)` added but `xWELLRouter.bridge(...)` still calls
+  the old path).
+- Initializer function added or signature changed without an upgrade proposal —
+  flags `Initializable: contract is already initialized` failures.
+- New cheatcode usage in templates that other proposals inherit — verify all
+  subclasses still compile and simulate.
+- `chains/*.json` address change without a corresponding deployment script
+  update.
+
+Be specific. Cite `file:line`. Predict failures concretely (workflow name +
+revert reason) rather than generically.

--- a/.claude/agents/proposal-reviewer.md
+++ b/.claude/agents/proposal-reviewer.md
@@ -24,8 +24,12 @@ list (CRITICAL / HIGH / MEDIUM / LOW).
 
 - New proposals MUST have `id: 0` (in-development sentinel). A non-zero id on an
   unmerged proposal breaks `PostProposalCheck` integration tests.
-- The `envpath` must match the proposal folder
-  (`proposals/mips/mip-{chain}{number}/{number}.sh`).
+- The `envpath` must match the proposal folder. Convention is
+  `proposals/mips/mip-{chain}{number}{suffix?}/{chain}{number}{suffix?}.sh` —
+  the basename of the `.sh` mirrors the folder name with the `mip-` prefix
+  stripped (e.g. `mip-b59` → `b59.sh`, `mip-x47` → `x47.sh`, `mip-x51a` →
+  `x51a.sh`). Some entries leave `envpath: ""` (proposals with no shell script —
+  only `.sol` + `.md`); that is also valid.
 - The `path` must match the compiled artifact under `artifacts/foundry/` (NOT
   `out/`).
 

--- a/.claude/agents/proposal-reviewer.md
+++ b/.claude/agents/proposal-reviewer.md
@@ -1,0 +1,147 @@
+---
+name: proposal-reviewer
+description:
+  Reviews Moonwell governance proposals (mip-b##, mip-x##, mip-m##, mip-o##) for
+  protocol-specific gotchas — Moonbeam gas cap, silent admin failures, sentinel
+  clipping, bridge fan-out math, validate() invariant brittleness, and mips.json
+  sentinel hygiene. Use after writing or modifying any file under
+  `proposals/mips/` or `proposals/templates/`.
+tools: Read, Grep, Glob, Bash
+---
+
+# Proposal Reviewer
+
+You are a specialized reviewer for Moonwell governance proposals. You know the
+recurring footguns that have caused real production incidents and bad PR cycles
+in this repo.
+
+## Mandatory checks
+
+Run these against every proposal you review and report findings as a prioritized
+list (CRITICAL / HIGH / MEDIUM / LOW).
+
+### 1. mips.json hygiene
+
+- New proposals MUST have `id: 0` (in-development sentinel). A non-zero id on an
+  unmerged proposal breaks `PostProposalCheck` integration tests.
+- The `envpath` must match the proposal folder
+  (`proposals/mips/mip-{chain}{number}/{number}.sh`).
+- The `path` must match the compiled artifact under `artifacts/foundry/` (NOT
+  `out/`).
+
+### 2. Moonbeam gas cap (16,777,216 = 2^24)
+
+- Run `cast estimate` against `propose()` if possible. If gas estimate exceeds
+  ~15M, the tx will be silently dropped by Goldsky/Alchemy/public Moonbeam RPC.
+- Any rewards-distribution MIP whose Moonbeam payload bridges to multiple
+  destinations (Base + Optimism + Ethereum) is at risk. Recommend a
+  chain-destination split (e.g. x51a/x51b/x51c).
+
+### 3. Silent admin-call failures
+
+MToken admin functions return error codes WITHOUT reverting. Flag any of:
+
+- `_reduceReserves(...)` followed by a dependent action (approve,
+  repayBorrowBehalf) without a `totalReserves()` snapshot before/after to
+  confirm success.
+- `_setPendingAdmin(...)` without verification.
+- `_acceptAdmin()` chained without confirmation.
+
+### 4. `repayBorrowBehalf(uint256.max)` sentinel
+
+- The sentinel clips to `accountBorrows` (see `src/MToken.sol:1297`).
+- ONLY safe for FULL repays where the market has been pre-funded for the entire
+  debt.
+- For PARTIAL repays sized by reserve availability (e.g. bad-debt recovery), the
+  sentinel will clip to full debt and revert in `doTransferIn` when allowance is
+  short. Use a literal amount.
+
+### 5. Bridge fan-out (rewards MIPs)
+
+- Build order is fixed:
+  `transferFrom → setRewardSpeeds → withdrawWell → transferReserves → multiRewarder → merkleCampaigns`.
+- `bridgeToRecipient` for each destination must cover that split's FIRST
+  Base/Optimism TG outflow, NOT the net TG balance.
+- Trace TG inflow/outflow step-by-step when rebalancing bridge amounts in split
+  MIPs.
+
+### 6. V3+ Wormhole adapter path
+
+- Cross-chain xWELL bridging (`xWELLRouter.bridgeToRecipient`) on V3+
+  `WormholeBridgeAdapter` uses `publishMessage`/`processVAA`, NOT the deprecated
+  relayer path the template's `WormholeRelayerAdapter` mocks.
+- Rewards MIPs that bridge MUST pre-fund destination `TEMPORAL_GOVERNOR`
+  balances in `beforeSimulationHook`, otherwise bridged WELL never arrives in
+  fork simulation.
+- If the proposal is post-xWELL-executor-migration: outbound bridging from
+  Moonbeam now requires `executorQuoterRouter` to be configured OR the new
+  `_bridgeOut(..., bytes calldata signedQuote)` overload.
+
+### 7. validate() invariant brittleness
+
+- Invariants must only couple values that accrue under the SAME protocol
+  mechanism.
+- `reservesDown` ≈ `borrowDown` + other terms drift 1-7% across harnesses
+  because `PostProposalCheck` consumers run different numbers of
+  vote/queue/execute warps.
+- Prefer directional assertions (`assertLt`) and `value ≈ target` checks over
+  `valueA ≈ valueB` equalities.
+- Prefer `assertEq(allowance, 0)` over `assertLe(allowance, amount)` after a
+  matched `approve`/`repayBorrowBehalf` pair — the latter is trivially true even
+  if the repay never executed.
+
+### 8. Address discipline
+
+- Load all addresses from `proposals/Addresses.sol` or `chains/*.json` — flag
+  any hardcoded addresses.
+- Check `chains/{1,8453,10,1284}.json` for the specific chain when verifying
+  multi-chain logic.
+
+### 9. `deal()` and on-chain state
+
+- Before any `deal(...)` in `beforeSimulationHook` or proposal body, the author
+  should have compared against real on-chain state
+  (`cast call <market> "totalReserves()(uint256)"` / `"getCash()(uint256)"`).
+- Flag any `deal` that reduces a mainnet balance — that's a mock that lies about
+  live state.
+
+### 10. Shell script + ffi hygiene
+
+- The proposal `.sh` file must be marked executable
+  (`git update-index --chmod=+x`). `forge test --ffi` fails with
+  `Permission denied` otherwise.
+- Shell script must export `MIP_REWARDS_PATH` (or `JSON_PATH`),
+  `DESCRIPTION_PATH`, `PRIMARY_FORK_ID`.
+
+### 11. audit-rewards
+
+- If this is a rewards-distribution MIP (template or subclass), the author MUST
+  have run `make audit-rewards PROPOSAL=mip-xNN`. Check whether worker-generated
+  numbers balance: TG flow conservation, MRD budget = Σ speeds × duration, no
+  negative `withdrawWell`, no `nativeValue: 0`.
+
+## Output format
+
+```
+## Proposal Review: <mip-name>
+
+### CRITICAL
+- [issue] @ <file:line> — [why it's broken, what to do]
+
+### HIGH
+- ...
+
+### MEDIUM
+- ...
+
+### LOW / Style
+- ...
+
+### Verified clean
+- mips.json id=0 ✓
+- shell script executable ✓
+- ...
+```
+
+Cite file:line references for every finding. Read the actual proposal source
+before claiming an issue exists.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
                     {
                         "type": "command",
                         "command": "if echo \"$CC_EDIT_FILE_PATH\" | grep -q '\\.sol$'; then forge build 2>&1 | tail -5; elif echo \"$CC_EDIT_FILE_PATH\" | grep -q '\\.ts$'; then npx tsc --noEmit 2>&1 | tail -10; fi"
+                    },
+                    {
+                        "type": "command",
+                        "command": "if echo \"$CC_EDIT_FILE_PATH\" | grep -qE 'proposals/mips/mip-[xbmo][0-9]+/'; then echo '↳ rewards/mip edit detected — remember: make audit-rewards PROPOSAL=$(echo \"$CC_EDIT_FILE_PATH\" | grep -oE \"mip-[xbmo][0-9]+\" | head -1) before opening the PR'; fi"
                     }
                 ]
             },
@@ -16,6 +20,10 @@
                     {
                         "type": "command",
                         "command": "if echo \"$CC_WRITE_FILE_PATH\" | grep -q '\\.sol$'; then forge build 2>&1 | tail -5; elif echo \"$CC_WRITE_FILE_PATH\" | grep -q '\\.ts$'; then npx tsc --noEmit 2>&1 | tail -10; fi"
+                    },
+                    {
+                        "type": "command",
+                        "command": "if echo \"$CC_WRITE_FILE_PATH\" | grep -qE 'proposals/mips/mip-[xbmo][0-9]+/'; then echo '↳ rewards/mip edit detected — remember: make audit-rewards PROPOSAL=$(echo \"$CC_WRITE_FILE_PATH\" | grep -oE \"mip-[xbmo][0-9]+\" | head -1) before opening the PR'; fi"
                     }
                 ]
             }
@@ -27,6 +35,15 @@
                     {
                         "type": "command",
                         "command": "if echo \"$CC_BASH_COMMAND\" | grep -qE 'git (commit|push)'; then echo \"Current branch: $(git branch --show-current)\"; fi"
+                    }
+                ]
+            },
+            {
+                "matcher": "EditTool|WriteTool",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "case \"$CC_EDIT_FILE_PATH$CC_WRITE_FILE_PATH\" in *Addresses.sol|*chains/*.json) echo '⚠️  Editing multi-chain registry — verify chain ID and live on-chain state (cast call) before saving';; esac"
                     }
                 ]
             }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
                     },
                     {
                         "type": "command",
-                        "command": "if echo \"$CC_EDIT_FILE_PATH\" | grep -qE 'proposals/mips/mip-[xbmo][0-9]+/'; then echo '↳ rewards/mip edit detected — remember: make audit-rewards PROPOSAL=$(echo \"$CC_EDIT_FILE_PATH\" | grep -oE \"mip-[xbmo][0-9]+\" | head -1) before opening the PR'; fi"
+                        "command": "if echo \"$CC_EDIT_FILE_PATH\" | grep -qE 'proposals/mips/mip-[xbmo][0-9]+[a-z]?/'; then echo '↳ rewards/mip edit detected — remember: make audit-rewards PROPOSAL=$(echo \"$CC_EDIT_FILE_PATH\" | grep -oE \"mip-[xbmo][0-9]+[a-z]?\" | head -1) before opening the PR'; fi"
                     }
                 ]
             },
@@ -23,7 +23,7 @@
                     },
                     {
                         "type": "command",
-                        "command": "if echo \"$CC_WRITE_FILE_PATH\" | grep -qE 'proposals/mips/mip-[xbmo][0-9]+/'; then echo '↳ rewards/mip edit detected — remember: make audit-rewards PROPOSAL=$(echo \"$CC_WRITE_FILE_PATH\" | grep -oE \"mip-[xbmo][0-9]+\" | head -1) before opening the PR'; fi"
+                        "command": "if echo \"$CC_WRITE_FILE_PATH\" | grep -qE 'proposals/mips/mip-[xbmo][0-9]+[a-z]?/'; then echo '↳ rewards/mip edit detected — remember: make audit-rewards PROPOSAL=$(echo \"$CC_WRITE_FILE_PATH\" | grep -oE \"mip-[xbmo][0-9]+[a-z]?\" | head -1) before opening the PR'; fi"
                     }
                 ]
             }
@@ -39,11 +39,20 @@
                 ]
             },
             {
-                "matcher": "EditTool|WriteTool",
+                "matcher": "EditTool",
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "case \"$CC_EDIT_FILE_PATH$CC_WRITE_FILE_PATH\" in *Addresses.sol|*chains/*.json) echo '⚠️  Editing multi-chain registry — verify chain ID and live on-chain state (cast call) before saving';; esac"
+                        "command": "case \"$CC_EDIT_FILE_PATH\" in *Addresses.sol|*chains/*.json) echo '⚠️  Editing multi-chain registry — verify chain ID and live on-chain state (cast call) before saving';; esac"
+                    }
+                ]
+            },
+            {
+                "matcher": "WriteTool",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "case \"$CC_WRITE_FILE_PATH\" in *Addresses.sol|*chains/*.json) echo '⚠️  Editing multi-chain registry — verify chain ID and live on-chain state (cast call) before saving';; esac"
                     }
                 ]
             }

--- a/.claude/skills/simulate-mip/SKILL.md
+++ b/.claude/skills/simulate-mip/SKILL.md
@@ -26,10 +26,15 @@ If no argument is provided, list every entry in `proposals/mips/mips.json` with
 ### 1. Resolve paths
 
 - Folder: `proposals/mips/<arg>/`
-- Shell script: `proposals/mips/<arg>/<chain-letter><number>.sh` (e.g.
-  `x51a.sh`)
+- Shell script: `proposals/mips/<arg>/<basename>.sh`, where `<basename>` is the
+  folder name with the `mip-` prefix stripped (e.g. `mip-b59` → `b59.sh`,
+  `mip-x47` → `x47.sh`, `mip-x51a` → `x51a.sh`). Suffix letters are preserved
+  verbatim.
 - If the folder doesn't exist, list folders under `proposals/mips/` that start
   with the same prefix and ask the user to pick.
+- If the proposal has no `.sh` (its `mips.json` `envpath` is `""` — e.g.
+  `mip-x52/` only carries `.sol` + `.md`), skip the source step in §4 and run
+  the standalone simulation directly via the artifact path from `mips.json`.
 
 ### 2. Verify shell-script exec bit
 
@@ -43,11 +48,15 @@ Read the `.sh` to find `FOUNDRY_SCRIPT` or check `mips.json` for the `path`
 field — the artifact name maps to a template under `proposals/templates/`.
 Common cases:
 
-- `RewardsDistributionTemplate.sol` →
-  `proposals/templates/RewardsDistribution.sol`
-- `MarketUpdateTemplate.sol` → `proposals/templates/MarketUpdate.sol`
-- `MarketAddV3.sol` → `proposals/templates/MarketAddV3.sol`
-- standalone (e.g. `mip-x51a.sol`) → `proposals/mips/<arg>/<arg>.sol`
+- `RewardsDistribution.sol/RewardsDistributionTemplate.json` →
+  `proposals/templates/RewardsDistribution.sol` (contract
+  `RewardsDistributionTemplate`)
+- `MarketUpdate.sol/MarketUpdateTemplate.json` →
+  `proposals/templates/MarketUpdate.sol` (contract `MarketUpdateTemplate`)
+- `MarketAddV3.sol/MarketAddV3.json` → `proposals/templates/MarketAddV3.sol`
+- standalone (e.g. `mip-x51a.sol/mipx51a.json`) →
+  `proposals/mips/<arg>/<basename>.sol` (where `<basename>` is the folder name
+  without the `mip-` prefix)
 
 ### 4. Run the sim
 
@@ -67,8 +76,10 @@ Echo the last `validate()` block — this is what reviewers care about.
 
 ## Notes
 
-- Always pass `--ffi`. Proposal `.sh` files are sourced via `vm.ffi`; without it
-  the run reverts on `Permission denied`.
+- Always pass `--ffi`. `PostProposalCheck` invokes `vm.ffi` during `setUp` —
+  without it the run reverts with an `FFI is disabled` error. (Distinct from
+  `Permission denied`, which means the `.sh` itself is not executable; fix with
+  `chmod +x` per §2.)
 - Always use `FOUNDRY_PROFILE=ci` — matches what GitHub Actions runs (1000 fuzz
   runs, deterministic).
 - `-vvvv` shows full traces including `console.log` from inside `setUp()`;

--- a/.claude/skills/simulate-mip/SKILL.md
+++ b/.claude/skills/simulate-mip/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: simulate-mip
+description:
+  Run a Moonwell governance proposal simulation against the canonical fork
+  command (DO_VALIDATE=true DO_PRINT=true DO_BUILD=true DO_RUN=false forge
+  script ... --ffi). Pass the MIP folder name as the argument (e.g.
+  /simulate-mip mip-x51a). Verifies the .sh is executable, sources it, picks the
+  right template, and runs the sim with FOUNDRY_PROFILE=ci.
+disable-model-invocation: true
+---
+
+# Simulate MIP
+
+User-only skill that runs a proposal simulation with the canonical command from
+`.claude/rules/proposals.md`.
+
+## Argument
+
+Single argument: the MIP folder name (e.g. `mip-x51a`, `mip-b59`).
+
+If no argument is provided, list every entry in `proposals/mips/mips.json` with
+`id: 0` (in-development proposals) and ask which one to simulate.
+
+## Steps
+
+### 1. Resolve paths
+
+- Folder: `proposals/mips/<arg>/`
+- Shell script: `proposals/mips/<arg>/<chain-letter><number>.sh` (e.g.
+  `x51a.sh`)
+- If the folder doesn't exist, list folders under `proposals/mips/` that start
+  with the same prefix and ask the user to pick.
+
+### 2. Verify shell-script exec bit
+
+```bash
+test -x "<script-path>" || (echo "marking executable for ffi"; chmod +x "<script-path>" && git update-index --chmod=+x "<script-path>")
+```
+
+### 3. Pick the template
+
+Read the `.sh` to find `FOUNDRY_SCRIPT` or check `mips.json` for the `path`
+field — the artifact name maps to a template under `proposals/templates/`.
+Common cases:
+
+- `RewardsDistributionTemplate.sol` →
+  `proposals/templates/RewardsDistribution.sol`
+- `MarketUpdateTemplate.sol` → `proposals/templates/MarketUpdate.sol`
+- `MarketAddV3.sol` → `proposals/templates/MarketAddV3.sol`
+- standalone (e.g. `mip-x51a.sol`) → `proposals/mips/<arg>/<arg>.sol`
+
+### 4. Run the sim
+
+```bash
+source proposals/mips/<arg>/<script>.sh \
+  && DO_VALIDATE=true DO_PRINT=true DO_BUILD=true DO_RUN=false \
+     FOUNDRY_PROFILE=ci \
+     forge script <template-path> --ffi -vvv 2>&1 | tail -100
+```
+
+If the run fails in `setUp()` with a cross-chain error (`WormholeBridge: ...`,
+`Initializable: ...`), suggest invoking the `cross-chain-impact-analyzer` agent.
+
+### 5. Surface validate() output
+
+Echo the last `validate()` block — this is what reviewers care about.
+
+## Notes
+
+- Always pass `--ffi`. Proposal `.sh` files are sourced via `vm.ffi`; without it
+  the run reverts on `Permission denied`.
+- Always use `FOUNDRY_PROFILE=ci` — matches what GitHub Actions runs (1000 fuzz
+  runs, deterministic).
+- `-vvvv` shows full traces including `console.log` from inside `setUp()`;
+  default to `-vvv` and offer to bump to `-vvvv` on failure.
+- After in-file renames (functions or vars), prepend `forge build --force` —
+  incremental builds can serve stale bytecode and mask compile errors.
+- For rewards MIPs, also offer to run `make audit-rewards PROPOSAL=<arg>`
+  separately — the sim doesn't catch worker-output bugs.

--- a/.claude/skills/split-rewards-mip/SKILL.md
+++ b/.claude/skills/split-rewards-mip/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: split-rewards-mip
+description:
+  Split a rewards-distribution MIP that exceeds Moonbeam's 16,777,216 (2^24)
+  per-tx gas cap into chain-destination chunks (e.g. x51 → x51a/x51b/x51c).
+  Walks through the cast estimate precheck, generates new folders/JSON/SH/SOL,
+  and rebalances the bridgeToRecipient amounts in TG-flow order so each split's
+  first outflow is fully funded.
+---
+
+# Split Rewards MIP
+
+Use when a rewards-distribution MIP's `propose()` gas estimate exceeds ~15M
+(Moonbeam's per-tx cap is 16,777,216). Above that, the tx is silently dropped by
+Goldsky/Alchemy/public RPC, or rejected at submit on Alchemy/public Moonbeam
+RPC.
+
+## Inputs
+
+- The original MIP folder name (e.g. `mip-x51`).
+- Suggested split scheme — usually by destination chain. Example for x51:
+  - `x51a` = Moonbeam-only payload + Optimism rewards bridge
+  - `x51b` = Base rewards bridge
+  - `x51c` = Base bad-debt repayment
+
+## Workflow
+
+### 1. Pre-check the gas estimate
+
+```bash
+cast estimate <governor-address> "propose(...)" --rpc-url $MOONBEAM_RPC_URL
+```
+
+If this returns > ~15M, splitting is required. If it's between 14M and 16M,
+recommend splitting anyway — Moonbeam block-cap headroom is unforgiving.
+
+### 2. Plan the split
+
+Decide chain-destination boundaries. The build order in
+`_buildExternalChainActions` is **fixed** and cannot be reordered:
+
+```
+transferFrom → setRewardSpeeds → withdrawWell → transferReserves → multiRewarder → merkleCampaigns
+```
+
+For each split, identify which actions move into it. Each split's Moonbeam
+payload runs independently as a separate `propose()`.
+
+### 3. Rebalance the bridge amounts
+
+Critical math: `bridgeToRecipient` for each destination chain in each split must
+cover that split's **FIRST** Base/Optimism `TEMPORAL_GOVERNOR` outflow — NOT the
+net TG balance after all actions.
+
+Why: `transferFrom(TG → MRD)` runs BEFORE `withdrawWell` brings WELL back into
+TG. A bridge sized only for the net balance will revert on the first transfer
+with `ERC20: transfer amount exceeds balance`.
+
+Trace TG inflow/outflow step-by-step. Show the math explicitly to the user for
+verification.
+
+### 4. Generate new folders
+
+For each split (e.g. `x51a`, `x51b`, `x51c`):
+
+- `proposals/mips/mip-x51<letter>/x51<letter>.sh`
+- `proposals/mips/mip-x51<letter>/x51<letter>.json`
+- `proposals/mips/mip-x51<letter>/x51<letter>.md`
+- `proposals/mips/mip-x51<letter>/mip-x51<letter>.sol` (if standalone — copies
+  the parent)
+
+Mark every `.sh` executable in git:
+`git update-index --chmod=+x proposals/mips/mip-x51<letter>/x51<letter>.sh`.
+
+### 5. Regenerate the JSON for each split
+
+Pull from the rewards automation worker:
+
+```
+https://moonwell-reward-automation.moonwell.workers.dev/?type=json&timestamp=<unix>
+```
+
+Filter the worker output to the actions that belong to this split. Sanity-check:
+no negative `withdrawWell`, no `nativeValue: 0`.
+
+### 6. Update mips.json
+
+Add an entry per split with `id: 0` (in-development sentinel). Path points to
+the artifact:
+
+```json
+{
+  "envpath": "proposals/mips/mip-x51a/x51a.sh",
+  "governor": "MultichainGovernor",
+  "id": 0,
+  "path": "mip-x51a.sol/mipx51a.json",
+  "proposalType": "HybridProposal"
+}
+```
+
+Keep the array sorted with `id: 0` entries at the top, then descending by id.
+
+### 7. Re-run gas estimate per split
+
+After splitting, run `cast estimate` on each split's `propose()` to confirm all
+are below 15M. If any one is still over, sub-split it further.
+
+### 8. Verify with audit-rewards
+
+Run `make audit-rewards PROPOSAL=mip-x51a` (and b, c) on each split. The audit
+runs in CI via `proposal-summary.yml` and verifies:
+
+- TG flow conservation
+- MRD budget = Σ speeds × duration
+- Safety-module budget = stkEPS × duration
+- Moonbeam bridge fan-out
+- 4-week epoch
+- No negative amounts
+
+### 9. Simulate each split
+
+Use the `/simulate-mip` skill once per split.
+
+## Common pitfalls
+
+- **Net-balance bridge sizing**: see step 3 above. Always size to the first
+  outflow.
+- **Forgot exec bit**: `forge test --ffi` will fail with `Permission denied` on
+  the new `.sh` files. Always `git update-index --chmod=+x`.
+- **Stale cached IDs in `mips.json`**: keep `id: 0` until the proposal lands
+  on-chain. Reviewers will catch real IDs in unmerged PRs.
+- **Double-counting bridged WELL**: when one split bridges WELL that the next
+  split assumes already arrived in TG, fork sims will pass but on-chain ordering
+  matters. Document the sequencing in each split's `.md`.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,18 @@
+{
+    "mcpServers": {
+        "context7": {
+            "command": "npx",
+            "args": ["-y", "@upstash/context7-mcp@latest"]
+        },
+        "evm-rpc": {
+            "command": "npx",
+            "args": ["-y", "@mcpdotdirect/evm-mcp-server"],
+            "env": {
+                "ETHEREUM_RPC_URL": "${ETH_RPC_URL}",
+                "BASE_RPC_URL": "${BASE_RPC_URL}",
+                "OPTIMISM_RPC_URL": "${OP_RPC_URL}",
+                "MOONBEAM_RPC_URL": "${MOONBEAM_RPC_URL}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds Claude Code automations tailored to this repo's recurring pain points (cross-chain bridge incompatibilities, Moonbeam gas-cap MIP splits, multi-chain registry edits). Read-only configuration — no production code changes.

### Hooks (`.claude/settings.json`)
- Multi-chain registry guard: warns on edits to `Addresses.sol` and `chains/*.json`, reminding to verify chain ID and live on-chain state before saving.
- Rewards-MIP audit reminder: prints `make audit-rewards PROPOSAL=mip-xNN` after any edit under `proposals/mips/mip-*/`.

### Subagents (`.claude/agents/`)
- **proposal-reviewer** — checks the 11 protocol-specific gotchas codified in `.claude/rules/proposals.md` (mips.json sentinel, Moonbeam 2^24 gas cap, silent admin failures, `repayBorrowBehalf(uint256.max)` clipping, bridge fan-out, V3+ Wormhole adapter path, validate() invariant brittleness, address discipline, `deal()` vs live state, ffi exec bit, audit-rewards).
- **cross-chain-impact-analyzer** — given a diff, maps which chains/contracts/in-development proposals are affected and predicts which CI workflows will break with which revert reason. Designed to catch the failure mode where one source change silently breaks PostProposalCheck.setUp() across many integration jobs.

### Skills (`.claude/skills/`)
- **simulate-mip** (user-only `/simulate-mip <folder>`) — runs the canonical `DO_VALIDATE=true DO_PRINT=true DO_BUILD=true DO_RUN=false forge script ... --ffi` with `FOUNDRY_PROFILE=ci`.
- **split-rewards-mip** — workflow for splitting a rewards MIP that exceeds Moonbeam's 16,777,216 per-tx gas cap (e.g. the recent x51 → x51a/x51b/x51c). Bakes in the bridge-fan-out math (\`bridgeToRecipient\` must cover the FIRST TG outflow, not the net balance) so it doesn't have to be re-derived.

### MCP servers (`.mcp.json`)
- \`context7\` — live documentation for Foundry / OpenZeppelin / Wormhole / Axelar.
- \`evm-rpc\` — multi-chain \`cast\`-style lookups via the existing \`ETH_RPC_URL\` / \`BASE_RPC_URL\` / \`OP_RPC_URL\` / \`MOONBEAM_RPC_URL\` env vars; useful for the "verify against live state before adding \`deal(...)\`" rule.

## Test plan
- [ ] Confirm both MCP servers register on next Claude Code session start
- [ ] Edit any file under \`proposals/mips/mip-*/\` and confirm the audit-rewards reminder prints
- [ ] Edit \`chains/8453.json\` (any harmless field, then revert) and confirm the registry-guard warning prints
- [ ] Invoke \`/simulate-mip mip-x52\` (or any in-development proposal) and confirm it runs the canonical sim
- [ ] Spawn the \`proposal-reviewer\` subagent against \`proposals/mips/mip-x52/\` and confirm it produces structural findings
- [ ] Spawn the \`cross-chain-impact-analyzer\` against a sample diff (e.g. \`git diff origin/main...mip-x51\`) and confirm it lists affected chains + predicted CI failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)