### PR TITLE
fix(oev): gate updatePriceEarlyAndLiquidate behind market allowlist (C4 #195)

### DIFF
--- a/docs/OEV_FEE_BYPASS_ANALYSIS.md
+++ b/docs/OEV_FEE_BYPASS_ANALYSIS.md
@@ -1,0 +1,167 @@
+# OEV Fee Bypass — Analysis of C4 Issue #195
+
+**Source:**
+[code-423n4/moonwell-bug-bounty-submissions#195](https://github.com/code-423n4/moonwell-bug-bounty-submissions/issues/195)
+**Title:** OEV Fee Bypass via Permissionless Auxiliary Morpho Market
+**Contract:** `src/oracles/ChainlinkOEVMorphoWrapper.sol` **Status:** Triage —
+submitter claims High; reviewer suggests Medium; this analysis recommends
+Medium.
+
+---
+
+## Summary
+
+`ChainlinkOEVMorphoWrapper.updatePriceEarlyAndLiquidate()` advances
+`cachedRoundId` (unlocking the fresh Chainlink price for every consumer of
+`latestRoundData()`) on any successful call, regardless of which Morpho market
+is passed in. The only validation is that
+`marketParams.oracle.BASE_FEED_1() == address(this)`. Because Morpho Blue
+markets and `MorphoChainlinkOracleV2` oracles are permissionless, an attacker
+can construct a throwaway market that satisfies this check, self-liquidate a
+dust position, and unlock the fresh price while paying ~zero protocol fee. They
+(or any other liquidator) can then liquidate real Moonwell-Morpho positions
+through Morpho Blue's standard `liquidate()` at the freshly unlocked price —
+entirely bypassing the OEV split.
+
+## Verified Technical Claims (vs. on-chain code)
+
+| Claim                                                                                | Result    |
+| ------------------------------------------------------------------------------------ | --------- |
+| L392-397 only checks `BASE_FEED_1() == address(this)`; no market allowlist           | confirmed |
+| L414 sets `cachedRoundId = roundId` unconditionally on success                       | confirmed |
+| Morpho oracle factory and `createMarket` are permissionless                          | confirmed |
+| Dust seizure → `protocolFee = 0` via L590-594 short-circuit                          | confirmed |
+| `_calculateCollateralSplit` uses real prices for both legs (not the attacker oracle) | confirmed |
+
+## Exploit Path (two-step, two markets)
+
+**Step 1 — Unlock price via dummy market**
+
+```solidity
+wrapper.updatePriceEarlyAndLiquidate(attackerMarket, attacker, 1, ...);
+```
+
+- Attacker created `attackerOracle` via the permissionless Morpho factory with
+  `baseFeed1 = wrapper`.
+- Attacker created `attackerMarket` via `morphoBlue.createMarket(...)` using
+  that oracle.
+- Inside the wrapper:
+  - L392-397 check passes.
+  - L414 sets `cachedRoundId = newRoundId`. ← side effect on shared state.
+  - L432-438 calls `morphoBlue.liquidate(attackerMarket, ...)` — only the dust
+    market is touched.
+- `_calculateCollateralSplit` returns `protocolFee = 0` because
+  `collateralUSD = 1 wei × realWELLprice / 1e18` truncates to 0.
+
+**Step 2 — Liquidate real victim through Morpho Blue directly**
+
+```solidity
+morphoBlue.liquidate(realMoonwellMarket, realVictim, seizedAssets, 0, "");
+```
+
+- Reads the real market's oracle → which reads the wrapper's
+  `latestRoundData()`.
+- L240 condition `roundId != cachedRoundId` is now **false** (just synced in
+  Step 1) → wrapper returns the fresh price with no delay.
+- Real victim is underwater at the fresh price → liquidation succeeds at the
+  full Morpho 1.05× bonus.
+- The OEV-split logic only runs inside `updatePriceEarlyAndLiquidate`; native
+  Morpho Blue `liquidate()` knows nothing about it.
+
+## PoC Quality Notes
+
+The submitted Foundry test relies on
+`vm.mockCall(attackerOracle, price.selector, abi.encode(1))` to force the
+position underwater. On mainnet, `vm.mockCall` is unavailable; an attacker would
+have to engineer the oracle factory inputs (`baseTokenDecimals`,
+`quoteTokenDecimals`, `*VaultConversionSample`) so that
+`MorphoChainlinkOracleV2.price()` returns a near-zero value while
+`BASE_FEED_1 = wrapper` still holds. This is plausible (those parameters are
+factory inputs, not enforced to match real token decimals) but is **not**
+demonstrated by the submitted PoC. Before paying out, request a non-mocked PoC
+that constructs a self-liquidating dust position end-to-end on a Base fork.
+
+## Severity Assessment — Medium (not High)
+
+- No theft of user or protocol principal.
+- No insolvency risk.
+- Liquidations on real markets still execute correctly.
+- What's lost is **OEV revenue** — the entire purpose of the wrapper.
+
+This maps to "function/availability impacted; assets not at risk" → Medium. The
+bypass nullifies the wrapper's design intent, which is material, but is
+opportunity cost rather than asset loss.
+
+## Mitigation Analysis
+
+### Option A — Minimum protocol-fee floor (partial mitigation, NOT recommended as primary)
+
+```solidity
+require(protocolFee >= minProtocolFee, "fee too low");
+```
+
+Why this only partially works:
+
+- `_calculateCollateralSplit` uses **real prices** for both legs, so the
+  attacker can't manipulate the fee math via their malicious oracle.
+- However, the attacker can scale up `seizedAssets` to clear the floor; the
+  seized collateral is their own self-supplied WELL, of which 30% returns to
+  them as `liquidatorFee` (they are `msg.sender`) and the remainder goes to
+  `feeRecipient`.
+- Net cost to attacker ≈ `protocolFee` (≈ the floor amount, in WELL).
+- If real OEV per round > floor, the bypass is still profitable.
+- A floor pegged to expected OEV is impractical (varies per round, per market).
+
+Effectively the floor becomes a fixed per-round tax: protocol captures the
+floor, attacker keeps the surplus.
+
+### Option B — Market allowlist (recommended primary fix)
+
+```solidity
+mapping(bytes32 => bool) public approvedMarkets;
+event MarketApproved(bytes32 indexed id, bool approved);
+
+function setApprovedMarket(bytes32 marketId, bool approved) external onlyOwner {
+    approvedMarkets[marketId] = approved;
+    emit MarketApproved(marketId, approved);
+}
+
+function updatePriceEarlyAndLiquidate(MarketParams memory marketParams, ...) external {
+    bytes32 id = keccak256(abi.encode(marketParams));
+    require(approvedMarkets[id], "ChainlinkOEVMorphoWrapper: market not approved");
+    // ... existing logic
+}
+```
+
+Wrappers are deployed per-feed, so the legitimate market(s) using each wrapper
+are known and finite at deploy time. Forcing every successful call to be on an
+approved market means any `cachedRoundId` advance is by definition a _real_
+liquidation generating real OEV split. No dust path is possible.
+
+### Option C — Defense-in-depth (allowlist + floor)
+
+Use the allowlist as the gate, plus a small floor as a safety net in case an
+approved market is misconfigured or its oracle is attacked.
+
+## Recommended Action
+
+1. **Primary fix:** market allowlist on `updatePriceEarlyAndLiquidate`.
+2. Add `MarketApproved(bytes32 indexed id, bool approved)` event so
+   governance/monitoring can audit approvals.
+3. Wire initial allowlist into the existing initializer pattern via
+   `reinitializer(3)` taking `bytes32[] _approvedMarkets`, so the upgrade flips
+   the gate and seeds approvals atomically (otherwise legitimate liquidations
+   break the moment the gate goes live).
+4. Optional: minimum protocol-fee floor as defense-in-depth.
+
+## Reference — Verified Code Locations
+
+- Only check on `marketParams`:
+  `src/oracles/ChainlinkOEVMorphoWrapper.sol:392-397`
+- Round-id advance: `src/oracles/ChainlinkOEVMorphoWrapper.sol:414`
+- Delay logic that consults `cachedRoundId`:
+  `src/oracles/ChainlinkOEVMorphoWrapper.sol:239-266`
+- Dust → zero-fee short-circuit:
+  `src/oracles/ChainlinkOEVMorphoWrapper.sol:590-594`
+- Real-price fee math (immune to attacker oracle):
+  `src/oracles/ChainlinkOEVMorphoWrapper.sol:496-561`

--- a/src/oracles/ChainlinkOEVMorphoWrapper.sol
+++ b/src/oracles/ChainlinkOEVMorphoWrapper.sol
@@ -54,6 +54,10 @@ contract ChainlinkOEVMorphoWrapper is
     /// @notice The max decrements
     uint256 public maxDecrements;
 
+    /// @notice Whether a Morpho market id is approved for early price updates and liquidations
+    /// @dev Market id is `keccak256(abi.encode(MarketParams))` — the canonical Morpho Blue id
+    mapping(bytes32 => bool) public approvedMarkets;
+
     /// @notice Emitted when the fee recipient is changed
     event FeeRecipientChanged(address oldFeeRecipient, address newFeeRecipient);
 
@@ -74,6 +78,9 @@ contract ChainlinkOEVMorphoWrapper is
         uint256 oldMaxDecrements,
         uint256 newMaxDecrements
     );
+
+    /// @notice Emitted when a Morpho market is approved or unapproved for early liquidation
+    event MarketApproved(bytes32 indexed id, bool approved);
 
     /// @notice Emitted when the price is updated early and liquidated
     event PriceUpdatedEarlyAndLiquidated(
@@ -154,6 +161,22 @@ contract ChainlinkOEVMorphoWrapper is
         maxDecrements = _maxDecrements;
 
         _transferOwnership(_owner);
+    }
+
+    /**
+     * @notice Seed the market allowlist atomically with the upgrade that introduces the gate
+     * @dev Must be called as part of the same upgrade that activates the allowlist gate in
+     *      `updatePriceEarlyAndLiquidate`, otherwise legitimate liquidations would revert
+     *      between the upgrade and the first `setApprovedMarket` call.
+     * @param _approvedMarkets The list of canonical Morpho market ids to approve at upgrade time
+     */
+    function initializeV3(
+        bytes32[] calldata _approvedMarkets
+    ) external reinitializer(3) {
+        for (uint256 i = 0; i < _approvedMarkets.length; i++) {
+            approvedMarkets[_approvedMarkets[i]] = true;
+            emit MarketApproved(_approvedMarkets[i], true);
+        }
     }
 
     /**
@@ -327,6 +350,19 @@ contract ChainlinkOEVMorphoWrapper is
     }
 
     /**
+     * @notice Approve or unapprove a Morpho market for early price updates and liquidation
+     * @dev Only approved markets may advance `cachedRoundId` via `updatePriceEarlyAndLiquidate`.
+     *      This prevents an attacker from spinning up a permissionless dust market with this
+     *      wrapper as base feed and using it to unlock the fresh price for free.
+     * @param id The canonical Morpho Blue market id (`keccak256(abi.encode(MarketParams))`)
+     * @param approved Whether the market is approved
+     */
+    function setApprovedMarket(bytes32 id, bool approved) external onlyOwner {
+        approvedMarkets[id] = approved;
+        emit MarketApproved(id, approved);
+    }
+
+    /**
      * @notice Sets the max number of decrements to search previous rounds
      * @param _maxDecrements The new max decrements (must be > 0)
      */
@@ -387,6 +423,16 @@ contract ChainlinkOEVMorphoWrapper is
         require(
             maxRepayAmount > 0,
             "ChainlinkOEVMorphoWrapper: max repay amount cannot be zero"
+        );
+
+        // gate: only approved markets may advance cachedRoundId. Without this an attacker
+        // could create a permissionless Morpho market + oracle pointing at this wrapper,
+        // self-liquidate a dust position, unlock the fresh price for shared consumers, and
+        // then liquidate real positions through Morpho Blue's native `liquidate()` at zero
+        // OEV cost. (C4 #195)
+        require(
+            approvedMarkets[keccak256(abi.encode(marketParams))],
+            "ChainlinkOEVMorphoWrapper: market not approved"
         );
 
         require(

--- a/test/unit/ChainlinkOEVMorphoWrapperAllowlistUnit.t.sol
+++ b/test/unit/ChainlinkOEVMorphoWrapperAllowlistUnit.t.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.19;
+
+import {Test} from "@forge-std/Test.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import {ChainlinkOEVMorphoWrapper} from "@protocol/oracles/ChainlinkOEVMorphoWrapper.sol";
+import {MockChainlinkOracle} from "@test/mock/MockChainlinkOracle.sol";
+import {MarketParams} from "@protocol/morpho/IMetaMorpho.sol";
+
+/// @notice Unit tests for the market allowlist gate added to fix C4 #195
+///         (OEV fee bypass via permissionless auxiliary Morpho market).
+contract ChainlinkOEVMorphoWrapperAllowlistUnitTest is Test {
+    address internal owner = address(0xA11CE);
+    address internal proxyAdmin = address(0xAD317);
+    address internal morphoBlue = address(0xB10E);
+    address internal chainlinkOracle = address(0xCAFE);
+    address internal feeRecipient = address(0xFEE);
+
+    MockChainlinkOracle internal priceFeed;
+    ChainlinkOEVMorphoWrapper internal wrapper;
+
+    event MarketApproved(bytes32 indexed id, bool approved);
+
+    function setUp() public {
+        priceFeed = new MockChainlinkOracle(1e8, 8);
+        priceFeed.set(1, 1e8, 1, 1, 1);
+
+        ChainlinkOEVMorphoWrapper impl = new ChainlinkOEVMorphoWrapper();
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(impl),
+            proxyAdmin,
+            ""
+        );
+        wrapper = ChainlinkOEVMorphoWrapper(address(proxy));
+
+        wrapper.initializeV2(
+            address(priceFeed),
+            owner,
+            morphoBlue,
+            chainlinkOracle,
+            feeRecipient,
+            500, // liquidatorFeeBps
+            3600, // maxRoundDelay
+            10 // maxDecrements
+        );
+    }
+
+    function _id(MarketParams memory p) internal pure returns (bytes32) {
+        return keccak256(abi.encode(p));
+    }
+
+    function _market(
+        address oracle
+    ) internal pure returns (MarketParams memory p) {
+        p.loanToken = address(0xA);
+        p.collateralToken = address(0xB);
+        p.oracle = oracle;
+        p.irm = address(0xC);
+        p.lltv = 0.625e18;
+    }
+
+    function testInitializeV3SeedsAllowlistAndEmits() public {
+        bytes32[] memory ids = new bytes32[](2);
+        ids[0] = bytes32(uint256(0xAAAA));
+        ids[1] = bytes32(uint256(0xBBBB));
+
+        vm.expectEmit(true, false, false, true, address(wrapper));
+        emit MarketApproved(ids[0], true);
+        vm.expectEmit(true, false, false, true, address(wrapper));
+        emit MarketApproved(ids[1], true);
+        wrapper.initializeV3(ids);
+
+        assertTrue(wrapper.approvedMarkets(ids[0]));
+        assertTrue(wrapper.approvedMarkets(ids[1]));
+    }
+
+    function testInitializeV3CanOnlyBeCalledOnce() public {
+        bytes32[] memory ids = new bytes32[](0);
+        wrapper.initializeV3(ids);
+        vm.expectRevert("Initializable: contract is already initialized");
+        wrapper.initializeV3(ids);
+    }
+
+    function testSetApprovedMarketOnlyOwner() public {
+        bytes32 id = bytes32(uint256(0x1234));
+        vm.expectRevert("Ownable: caller is not the owner");
+        wrapper.setApprovedMarket(id, true);
+    }
+
+    function testSetApprovedMarketTogglesAndEmits() public {
+        bytes32 id = bytes32(uint256(0xDEAD));
+
+        vm.expectEmit(true, false, false, true, address(wrapper));
+        emit MarketApproved(id, true);
+        vm.prank(owner);
+        wrapper.setApprovedMarket(id, true);
+        assertTrue(wrapper.approvedMarkets(id));
+
+        vm.expectEmit(true, false, false, true, address(wrapper));
+        emit MarketApproved(id, false);
+        vm.prank(owner);
+        wrapper.setApprovedMarket(id, false);
+        assertFalse(wrapper.approvedMarkets(id));
+    }
+
+    /// @notice The exploit path: an attacker passes a permissionless dummy market.
+    ///         With the fix, the allowlist check rejects it before any state mutation.
+    function testUpdatePriceEarlyAndLiquidateRevertsForUnapprovedMarket()
+        public
+    {
+        MarketParams memory params = _market(address(0xDEADBEEF));
+
+        vm.expectRevert("ChainlinkOEVMorphoWrapper: market not approved");
+        wrapper.updatePriceEarlyAndLiquidate(
+            params,
+            address(0x1111),
+            1, // seizedAssets
+            1 // maxRepayAmount
+        );
+
+        // cachedRoundId must remain at the value seeded by initializeV2 (priceFeed.latestRound() == 1).
+        // i.e. the failed call did NOT advance the round, which is the whole point of the gate.
+        assertEq(wrapper.cachedRoundId(), 1);
+    }
+
+    /// @notice An approved market gets past the allowlist gate. We can't drive a full
+    ///         liquidation in a unit test without a live Morpho Blue, so we verify only
+    ///         that the call proceeds past the allowlist and stops at the next downstream
+    ///         check — `BASE_FEED_1()` on the oracle, which here is unset.
+    function testApprovedMarketBypassesAllowlistGate() public {
+        MarketParams memory params = _market(address(0xDEADBEEF));
+        bytes32 id = _id(params);
+
+        vm.prank(owner);
+        wrapper.setApprovedMarket(id, true);
+
+        vm.expectRevert();
+        wrapper.updatePriceEarlyAndLiquidate(params, address(0x1111), 1, 1);
+    }
+
+    /// @notice Approval is tuple-specific: the id is derived from the full MarketParams
+    ///         struct, so any field difference produces a distinct id.
+    function testApprovalIsTupleSpecific() public {
+        MarketParams memory approved = _market(address(0x1));
+        MarketParams memory other = _market(address(0x2));
+
+        vm.prank(owner);
+        wrapper.setApprovedMarket(_id(approved), true);
+
+        assertTrue(wrapper.approvedMarkets(_id(approved)));
+        assertFalse(wrapper.approvedMarkets(_id(other)));
+
+        vm.expectRevert("ChainlinkOEVMorphoWrapper: market not approved");
+        wrapper.updatePriceEarlyAndLiquidate(other, address(0x1111), 1, 1);
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes Code4rena bug bounty submission [#195](https://github.com/code-423n4/moonwell-bug-bounty/issues/305) — OEV fee bypass via permissionless auxiliary Morpho market.
- Adds an allowlist gate to \`ChainlinkOEVMorphoWrapper.updatePriceEarlyAndLiquidate\`, plus seeding via a new \`initializeV3\`.
- Full rationale and severity analysis in \`docs/OEV_FEE_BYPASS_ANALYSIS.md\`.

### Bug

\`updatePriceEarlyAndLiquidate\` advanced \`cachedRoundId\` (unlocking the fresh Chainlink price for every consumer of \`latestRoundData()\`) on any successful call, regardless of which Morpho market was passed in. Morpho Blue markets and \`MorphoChainlinkOracleV2\` oracles are permissionless, so an attacker could:

1. Spin up a throwaway oracle wired with \`baseFeed1 = wrapper\` + a dust market.
2. Self-liquidate → \`cachedRoundId\` advances, \`protocolFee = 0\` (dust short-circuit at L590-594).
3. Liquidate real Moonwell-Morpho positions through native \`morphoBlue.liquidate()\` at the now-unlocked price, paying zero OEV split.

### Fix

- New storage: \`mapping(bytes32 => bool) public approvedMarkets\` (appended — storage-layout safe).
- New event: \`MarketApproved(bytes32 indexed id, bool approved)\`.
- New admin function: \`setApprovedMarket(bytes32, bool)\` (\`onlyOwner\`).
- New \`initializeV3(bytes32[])\` with \`reinitializer(3)\` to seed the allowlist atomically with the upgrade — without this, legitimate liquidations would revert in the window between the gate going live and the first \`setApprovedMarket\` call.
- Allowlist check at the top of \`updatePriceEarlyAndLiquidate\` using the canonical Morpho id \`keccak256(abi.encode(marketParams))\`.
- Existing \`BASE_FEED_1 == address(this)\` check preserved as defense-in-depth.

## Test plan

- [x] \`forge build\` passes
- [x] New unit tests in \`test/unit/ChainlinkOEVMorphoWrapperAllowlistUnit.t.sol\` cover: initializer seeding + one-shot, owner-gating of \`setApprovedMarket\`, event emission, unapproved market reverts (and cached round does NOT advance), approved market clears the gate, approval is tuple-specific
- [x] All existing OEV unit tests still pass (\`forge test --match-path "test/unit/ChainlinkOEV*"\` → 45/45 green)
- [ ] Companion governance MIP that calls \`initializeV3\` with the live legitimate market ids (separate PR)

## Notes for reviewers

- Storage layout is strictly append-only.
- This PR contains the contract change + unit tests only. The governance MIP wiring \`initializeV3\` for the live wrappers will follow in a separate PR so the upgrade and the seed go in together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)