### PR TITLE
mip-x57: rewards distribution (2026-05-22 → 2026-06-19)

### DIFF
--- a/proposals/mips/mip-x57/mip-x57.sol
+++ b/proposals/mips/mip-x57/mip-x57.sol
@@ -1,0 +1,54 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+
+import {IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+import {RewardsDistributionTemplate} from "@proposals/templates/RewardsDistribution.sol";
+import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
+import {BASE_FORK_ID, OPTIMISM_FORK_ID} from "@utils/ChainIds.sol";
+
+/// @title MIP-X57
+/// @notice Rewards distribution for the 2026-05-22 -> 2026-06-19 epoch.
+///         Unlike prior rewards MIPs, this one does NOT bridge xWELL from
+///         Moonbeam in-proposal. xWELL on Base TG and Optimism TG is
+///         expected to be pre-staged via a separate fast-path (prep MIP
+///         or direct MGLIMMER multisig action) before x57 executes on
+///         chain. Rationale: Wormhole Executor signed quotes have ~1h
+///         expiry and Moonwell governance takes ~5 days, so a quote
+///         signed at MIP-authoring time would be stale on execution.
+///
+///         For fork simulation, beforeSimulationHook() deals xWELL to
+///         the destination TGs to model that pre-staging.
+contract mipx57 is RewardsDistributionTemplate {
+    function name() external pure override returns (string memory) {
+        return "MIP-X57";
+    }
+
+    function beforeSimulationHook(Addresses addresses) public override {
+        super.beforeSimulationHook(addresses);
+
+        // Pre-stage xWELL on destination TGs to simulate the separate
+        // bridge step that happens outside this proposal.
+        _preStageDestinationTG(
+            addresses,
+            BASE_FORK_ID,
+            12_000_000e18 // covers Base TG outflow 11,856,475.01 WELL
+        );
+        _preStageDestinationTG(
+            addresses,
+            OPTIMISM_FORK_ID,
+            900_000e18 // covers Optimism TG outflow 877,006.57 WELL
+        );
+    }
+
+    function _preStageDestinationTG(
+        Addresses addresses,
+        uint256 forkId,
+        uint256 amount
+    ) internal {
+        vm.selectFork(forkId);
+        address xwell = addresses.getAddress("xWELL_PROXY");
+        address tg = addresses.getAddress("TEMPORAL_GOVERNOR");
+        deal(xwell, tg, IERC20(xwell).balanceOf(tg) + amount);
+    }
+}

--- a/proposals/mips/mip-x57/x57.json
+++ b/proposals/mips/mip-x57/x57.json
@@ -1,0 +1,595 @@
+{
+    "10": {
+        "setMRDSpeeds": [
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_USDC",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 103095263137940400
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_USDT",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 2710083253679854
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_DAI",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 1652639930798268
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_WBTC",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_WETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 207765001769954430
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_wstETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 7824790848611313
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_cbETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_rETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 1164764334367017
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_OP",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 2681617572587461
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_weETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 589302184952060
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_VELO",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 14733162458094390
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_wrsETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 788829780894151
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_USDT0",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 1387838233971787
+            }
+        ],
+        "stkWellEmissionsPerSecond": 18125963229457216,
+        "transferFrom": [
+            {
+                "amount": 8.33156245649355e23,
+                "from": "TEMPORAL_GOVERNOR",
+                "to": "MRD_PROXY",
+                "token": "xWELL_PROXY"
+            },
+            {
+                "amount": 4.38503292447029e22,
+                "from": "TEMPORAL_GOVERNOR",
+                "to": "ECOSYSTEM_RESERVE_PROXY",
+                "token": "xWELL_PROXY"
+            }
+        ],
+        "withdrawWell": [],
+        "multiRewarder": [],
+        "merkleCampaigns": []
+    },
+    "1284": {
+        "bridgeToRecipient": [
+            {
+                "amount": 1.1856475119648211e25,
+                "nativeValue": 0,
+                "network": 8453,
+                "signedQuote": "0x",
+                "target": "TEMPORAL_GOVERNOR"
+            },
+            {
+                "amount": 8.770065948940579e23,
+                "nativeValue": 0,
+                "network": 10,
+                "signedQuote": "0x",
+                "target": "TEMPORAL_GOVERNOR"
+            }
+        ],
+        "transferFrom": [
+            {
+                "amount": 1.1856475119648211e25,
+                "from": "MGLIMMER_MULTISIG",
+                "to": "MULTICHAIN_GOVERNOR_PROXY",
+                "token": "GOVTOKEN"
+            },
+            {
+                "amount": 8.77006684894058e23,
+                "from": "MGLIMMER_MULTISIG",
+                "to": "MULTICHAIN_GOVERNOR_PROXY",
+                "token": "GOVTOKEN"
+            },
+            {
+                "amount": 2.0298300395433994e22,
+                "from": "MGLIMMER_MULTISIG",
+                "to": "MULTICHAIN_GOVERNOR_PROXY",
+                "token": "GOVTOKEN"
+            },
+            {
+                "amount": 1.948635877961663e23,
+                "from": "MGLIMMER_MULTISIG",
+                "to": "UNITROLLER",
+                "token": "GOVTOKEN"
+            },
+            {
+                "amount": 1.908039297170795e23,
+                "from": "MGLIMMER_MULTISIG",
+                "to": "ECOSYSTEM_RESERVE_PROXY",
+                "token": "GOVTOKEN"
+            }
+        ],
+        "addRewardInfo": {
+            "amount": 2.0298300395433994e22,
+            "endTimestamp": 1781875818,
+            "pid": 15,
+            "rewardPerSec": 8390497021922119,
+            "target": "STELLASWAP_REWARDER"
+        },
+        "setRewardSpeed": [
+            {
+                "market": "mGLIMMER",
+                "newBorrowSpeed": 803470355100711,
+                "newSupplySpeed": 803470355100711,
+                "rewardType": 0
+            },
+            {
+                "market": "mGLIMMER",
+                "newBorrowSpeed": 1,
+                "newSupplySpeed": 0,
+                "rewardType": 1
+            },
+            {
+                "market": "mxcDOT",
+                "newBorrowSpeed": 1,
+                "newSupplySpeed": 77208255471401620,
+                "rewardType": 0
+            },
+            {
+                "market": "mxcDOT",
+                "newBorrowSpeed": 1,
+                "newSupplySpeed": 0,
+                "rewardType": 1
+            },
+            {
+                "market": "mFRAX",
+                "newBorrowSpeed": 226930211156792,
+                "newSupplySpeed": 226930211156792,
+                "rewardType": 0
+            },
+            {
+                "market": "mFRAX",
+                "newBorrowSpeed": 1,
+                "newSupplySpeed": 0,
+                "rewardType": 1
+            },
+            {
+                "market": "mETHwh",
+                "newBorrowSpeed": 1,
+                "newSupplySpeed": 0,
+                "rewardType": 0
+            },
+            {
+                "market": "mETHwh",
+                "newBorrowSpeed": 1,
+                "newSupplySpeed": 0,
+                "rewardType": 1
+            },
+            {
+                "market": "MOONWELL_mWBTC",
+                "newBorrowSpeed": 1,
+                "newSupplySpeed": 0,
+                "rewardType": 0
+            },
+            {
+                "market": "MOONWELL_mWBTC",
+                "newBorrowSpeed": 1,
+                "newSupplySpeed": 0,
+                "rewardType": 1
+            },
+            {
+                "market": "mUSDCwh",
+                "newBorrowSpeed": 207862689850108,
+                "newSupplySpeed": 207862689850108,
+                "rewardType": 0
+            },
+            {
+                "market": "mUSDCwh",
+                "newBorrowSpeed": 1,
+                "newSupplySpeed": 0,
+                "rewardType": 1
+            },
+            {
+                "market": "mxcUSDT",
+                "newBorrowSpeed": 283571720670763,
+                "newSupplySpeed": 283571720670763,
+                "rewardType": 0
+            },
+            {
+                "market": "mxcUSDT",
+                "newBorrowSpeed": 1,
+                "newSupplySpeed": 0,
+                "rewardType": 1
+            },
+            {
+                "market": "mxcUSDC",
+                "newBorrowSpeed": 148422992746988,
+                "newSupplySpeed": 148422992746988,
+                "rewardType": 0
+            },
+            {
+                "market": "mxcUSDC",
+                "newBorrowSpeed": 1,
+                "newSupplySpeed": 0,
+                "rewardType": 1
+            }
+        ],
+        "stkWellEmissionsPerSecond": 78870672006067920
+    },
+    "8453": {
+        "multiRewarder": [],
+        "setMRDSpeeds": [
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_USDBC",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_USDBC",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_WETH",
+                "newBorrowSpeed": 232329739708668220,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 232329739708668220
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_WETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_cbETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_cbETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_DAI",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_DAI",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_USDC",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 1432348249496850400
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_USDC",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_wstETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_wstETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_rETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_rETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_AERO",
+                "newBorrowSpeed": 14401399256454370,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 11782963028008120
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_AERO",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_weETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_weETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_cbBTC",
+                "newBorrowSpeed": 80707451515797710,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 80707451515797710
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_cbBTC",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_EURC",
+                "newBorrowSpeed": 5760709821796533,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 5760709821796533
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_EURC",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_wrsETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_wrsETH",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_WELL",
+                "newBorrowSpeed": 31937715577103980,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 26130858199448710
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_WELL",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_USDS",
+                "newBorrowSpeed": -1,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_USDS",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_TBTC",
+                "newBorrowSpeed": 467254008037854,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 467254008037854
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_TBTC",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_LBTC",
+                "newBorrowSpeed": 33588286377421910,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 33588286377421910
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_LBTC",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_VIRTUAL",
+                "newBorrowSpeed": 60270619355435220,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 49312324927174264
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_VIRTUAL",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_MORPHO",
+                "newBorrowSpeed": 127800516706372690,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 104564059123395800
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_MORPHO",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            },
+            {
+                "emissionToken": "xWELL_PROXY",
+                "market": "MOONWELL_cbXRP",
+                "newBorrowSpeed": 72208902762979780,
+                "newEndTime": 1781875818,
+                "newSupplySpeed": 59080011351528910
+            },
+            {
+                "emissionToken": "USDC",
+                "market": "MOONWELL_cbXRP",
+                "newBorrowSpeed": -1,
+                "newEndTime": -1,
+                "newSupplySpeed": -1
+            }
+        ],
+        "transferFrom": [
+            {
+                "amount": 6.521061250806517e24,
+                "from": "TEMPORAL_GOVERNOR",
+                "to": "MRD_PROXY",
+                "token": "xWELL_PROXY"
+            }
+        ],
+        "withdrawWell": [],
+        "merkleCampaigns": [
+            {
+                "amount": 2.371295004929642e24,
+                "campaignData": "0x000000000000000000000000e66e3a37c3274ac24fe8590f7d84a2427194dc1700000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000180000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "campaignType": 18,
+                "duration": 2419200,
+                "rewardToken": "xWELL_PROXY",
+                "startTimestamp": 1779456618
+            },
+            {
+                "amount": 1.7746813188885173e24,
+                "campaignData": "0x000000000000000000000000c1256ae5ff1cf2719d4937adb3bbccab2e00a2ca0000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000001a000000000000000000000000000000000000000000000000000000000000001c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "campaignType": 56,
+                "duration": 2419200,
+                "rewardToken": "xWELL_PROXY",
+                "startTimestamp": 1779456618
+            },
+            {
+                "amount": 7.331379956091847e23,
+                "campaignData": "0x000000000000000000000000a0e430870c4604ccfc7b38ca7845b1ff653d0ff10000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000001a000000000000000000000000000000000000000000000000000000000000001c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "campaignType": 56,
+                "duration": 2419200,
+                "rewardToken": "xWELL_PROXY",
+                "startTimestamp": 1779456618
+            },
+            {
+                "amount": 2.8263517591494445e23,
+                "campaignData": "0x000000000000000000000000f24608e0ccb972b0b0f4a6446a0bbf58c701a0260000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000001a000000000000000000000000000000000000000000000000000000000000001c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "campaignType": 56,
+                "duration": 2419200,
+                "rewardToken": "xWELL_PROXY",
+                "startTimestamp": 1779456618
+            },
+            {
+                "amount": 1.736642644994064e23,
+                "campaignData": "0x000000000000000000000000543257ef2161176d7c8cd90ba65c2d4caef5a7960000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000001a000000000000000000000000000000000000000000000000000000000000001c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "campaignType": 56,
+                "duration": 2419200,
+                "rewardToken": "xWELL_PROXY",
+                "startTimestamp": 1779456618
+            }
+        ]
+    },
+    "endTimeSTamp": 1781875818,
+    "startTimeStamp": 1779456618
+}

--- a/proposals/mips/mip-x57/x57.json
+++ b/proposals/mips/mip-x57/x57.json
@@ -113,35 +113,8 @@
         "merkleCampaigns": []
     },
     "1284": {
-        "bridgeToRecipient": [
-            {
-                "amount": 1.1856475119648211e25,
-                "nativeValue": 0,
-                "network": 8453,
-                "signedQuote": "0x",
-                "target": "TEMPORAL_GOVERNOR"
-            },
-            {
-                "amount": 8.770065948940579e23,
-                "nativeValue": 0,
-                "network": 10,
-                "signedQuote": "0x",
-                "target": "TEMPORAL_GOVERNOR"
-            }
-        ],
+        "bridgeToRecipient": [],
         "transferFrom": [
-            {
-                "amount": 1.1856475119648211e25,
-                "from": "MGLIMMER_MULTISIG",
-                "to": "MULTICHAIN_GOVERNOR_PROXY",
-                "token": "GOVTOKEN"
-            },
-            {
-                "amount": 8.77006684894058e23,
-                "from": "MGLIMMER_MULTISIG",
-                "to": "MULTICHAIN_GOVERNOR_PROXY",
-                "token": "GOVTOKEN"
-            },
             {
                 "amount": 2.0298300395433994e22,
                 "from": "MGLIMMER_MULTISIG",

--- a/proposals/mips/mip-x57/x57.json
+++ b/proposals/mips/mip-x57/x57.json
@@ -110,7 +110,8 @@
         ],
         "withdrawWell": [],
         "multiRewarder": [],
-        "merkleCampaigns": []
+        "merkleCampaigns": [],
+        "preStagedTG": "877006574894057915416576"
     },
     "1284": {
         "bridgeToRecipient": [],
@@ -561,7 +562,8 @@
                 "rewardToken": "xWELL_PROXY",
                 "startTimestamp": 1779456618
             }
-        ]
+        ],
+        "preStagedTG": "11856475010648212162740224"
     },
     "endTimeSTamp": 1781875818,
     "startTimeStamp": 1779456618

--- a/proposals/mips/mip-x57/x57.md
+++ b/proposals/mips/mip-x57/x57.md
@@ -1,0 +1,669 @@
+# MIP-X57 Automated Liquidity Incentive Proposal
+
+This is an automated liquidity incentive governance proposal for the Moonwell
+protocol.
+
+## Base Network
+
+If successful, the proposal would automatically distribute and adjust liquidity
+incentives for the period beginning 2026-05-22 at 13:30:18 UTC and ending on
+2026-06-19 at 13:30:18 UTC.
+
+| Metric                                              | Value              |
+| --------------------------------------------------- | ------------------ |
+| Timestamp of capture                                | 1779114588         |
+| Closest block number                                | 46162620           |
+| Total Supply in USD for incentivized markets        | $169,548,257.12    |
+| Total Borrows in USD                                | $28,047,100.12     |
+| Safety Module APR (Base)                            | 2.51%              |
+| Safety Module APR (Capped at 10%)                   | 2.51%              |
+| WELL from auctions (this epoch)                     | 0.001 WELL         |
+| WELL from auctions (reserved for future)            | 0 WELL             |
+| **Total WELL acquired in auctions (USD)**           | **$0.00**          |
+|                                                     |                    |
+| Total LP (ETH/WELL on Aerodrome)                    | $12,669,760.00     |
+|                                                     |                    |
+| Total WELL to distribute DEX                        | 0 WELL             |
+| Total WELL to distribute Safety Module              | 2,371,284.526 WELL |
+| Total WELL from auctions (available)                | 0.001 WELL         |
+| Total WELL from auctions (this epoch - capped)      | 0.001 WELL         |
+| Total WELL from auctions (reserved for future)      | 0 WELL             |
+| Total WELL to distribute Markets (Config)           | 6,521,032.448 WELL |
+| Total WELL to distribute Markets (Sanity Check)     | 6521032.4477 WELL  |
+| Total WELL to distribute Markets (Supply Side)      | 4925655.1459 WELL  |
+| Total WELL to distribute Markets (Borrow Side)      | 1595377.3019 WELL  |
+| Total WELL to distribute Markets (Borrow + Supply)  | 6521032.4477 WELL  |
+| Total WELL to distribute Markets (By Speed)         | 6521032.4477 WELL  |
+| Total WELL to distribute (Config + Capped Auctions) | 11856422.6333 WELL |
+| Total WELL to distribute (Sanity Check - Capped)    | 8892316.9752 WELL  |
+|                                                     |                    |
+
+### Merkle Campaigns
+
+| Campaign                   | WELL Rewards (28 days) |
+| -------------------------- | ---------------------- |
+| stkWELL (Safety Module)    | 2,371,284.527 WELL     |
+| USDC MetaMorpho Vault      | 1,774,673.478 WELL     |
+| WETH MetaMorpho Vault      | 733,134.756 WELL       |
+| EURC MetaMorpho Vault      | 282,633.927 WELL       |
+| cbBTC MetaMorpho Vault     | 173,663.497 WELL       |
+| **Total Merkle Campaigns** | **5,335,390.186 WELL** |
+
+### ETH (MOONWELL_WETH)
+
+Total Supply in USD: $9,225,833.86 Total Borrows in USD: $7,196,653.83
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.77%         | 0.77%     |
+| Borrow APY                             | 1.09%         | 1.09%     |
+| WELL Supply APR                        | 0.1%          | 0.1%      |
+| WELL Borrow APR                        | 0.39%         | 0.4%      |
+| Total Supply APR                       | 0.87%         | 0.87%     |
+| Total Borrow APR                       | 0.70%         | 0.69%     |
+| Total Supply Incentives Per Day in USD | $77.37        | $78.05    |
+| Total Borrow Incentives Per Day in USD | $77.37        | $78.05    |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | 0.89%    |
+| WELL Borrow | 0.89%    |
+
+### USDC (MOONWELL_USDC)
+
+Total Supply in USD: $15,094,547.83 Total Borrows in USD: $13,420,055.54
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 3.98%         | 3.98%     |
+| Borrow APY                             | 4.98%         | 4.98%     |
+| WELL Supply APR                        | 0.19%         | 0.19%     |
+| WELL Borrow APR                        | 0%            | 0%        |
+| Total Supply APR                       | 4.17%         | 4.17%     |
+| Total Borrow APR                       | 4.98%         | 4.98%     |
+| Total Supply Incentives Per Day in USD | $478.04       | $481.24   |
+| Total Borrow Incentives Per Day in USD | $0.00         | $0.00     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | 0.67%    |
+| WELL Borrow | 0%       |
+
+### AERO (MOONWELL_AERO)
+
+Total Supply in USD: $6,646,993.51 Total Borrows in USD: $2,119,420.16
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 1.52%         | 1.52%     |
+| Borrow APY                             | 7.33%         | 7.33%     |
+| WELL Supply APR                        | 0.03%         | 0.09%     |
+| WELL Borrow APR                        | 0.03%         | 0.08%     |
+| Total Supply APR                       | 1.55%         | 1.61%     |
+| Total Borrow APR                       | 7.30%         | 7.25%     |
+| Total Supply Incentives Per Day in USD | $1.58         | $3.96     |
+| Total Borrow Incentives Per Day in USD | $1.93         | $4.84     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | 151.09%  |
+| WELL Borrow | 151.09%  |
+
+### cbBTC (MOONWELL_cbBTC)
+
+Total Supply in USD: $10,152,979.69 Total Borrows in USD: $1,836,253.49
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.18%         | 0.18%     |
+| Borrow APY                             | 1.11%         | 1.11%     |
+| WELL Supply APR                        | 0.09%         | 0.1%      |
+| WELL Borrow APR                        | 0.49%         | 0.54%     |
+| Total Supply APR                       | 0.27%         | 0.28%     |
+| Total Borrow APR                       | 0.62%         | 0.57%     |
+| Total Supply Incentives Per Day in USD | $24.40        | $27.12    |
+| Total Borrow Incentives Per Day in USD | $24.40        | $27.12    |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | 11.12%   |
+| WELL Borrow | 11.12%   |
+
+### EURC (MOONWELL_EURC)
+
+Total Supply in USD: $724,696.03 Total Borrows in USD: $660,488.86
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 12.55%        | 12.55%    |
+| Borrow APY                             | 15.30%        | 15.30%    |
+| WELL Supply APR                        | 0.16%         | 0.1%      |
+| WELL Borrow APR                        | 0.18%         | 0.11%     |
+| Total Supply APR                       | 12.71%        | 12.65%    |
+| Total Borrow APR                       | 15.12%        | 15.19%    |
+| Total Supply Incentives Per Day in USD | $3.20         | $1.94     |
+| Total Borrow Incentives Per Day in USD | $3.20         | $1.94     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -39.6%   |
+| WELL Borrow | -39.6%   |
+
+### WELL (MOONWELL_WELL)
+
+Total Supply in USD: $652,506.92 Total Borrows in USD: $113,753.36
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.50%         | 0.50%     |
+| Borrow APY                             | 3.84%         | 3.84%     |
+| WELL Supply APR                        | 0.09%         | 0.09%     |
+| WELL Borrow APR                        | 3.45%         | 3.44%     |
+| Total Supply APR                       | 0.59%         | 0.59%     |
+| Total Borrow APR                       | 0.39%         | 0.40%     |
+| Total Supply Incentives Per Day in USD | $8.80         | $8.78     |
+| Total Borrow Incentives Per Day in USD | $10.75        | $10.73    |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -0.21%   |
+| WELL Borrow | -0.21%   |
+
+### tBTC (MOONWELL_TBTC)
+
+Total Supply in USD: $58,780.45 Total Borrows in USD: $5,856.01
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.05%         | 0.05%     |
+| Borrow APY                             | 0.61%         | 0.61%     |
+| WELL Supply APR                        | 0.1%          | 0.1%      |
+| WELL Borrow APR                        | 0.99%         | 0.98%     |
+| Total Supply APR                       | 0.15%         | 0.15%     |
+| Total Borrow APR                       | 0.00%         | 0.00%     |
+| Total Supply Incentives Per Day in USD | $0.16         | $0.16     |
+| Total Borrow Incentives Per Day in USD | $0.16         | $0.16     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -1.47%   |
+| WELL Borrow | -1.47%   |
+
+### LBTC (MOONWELL_LBTC)
+
+Total Supply in USD: $4,225,399.05 Total Borrows in USD: $333,249.73
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.03%         | 0.03%     |
+| Borrow APY                             | 0.49%         | 0.49%     |
+| WELL Supply APR                        | 0.1%          | 0.1%      |
+| WELL Borrow APR                        | 1.22%         | 1.24%     |
+| Total Supply APR                       | 0.13%         | 0.13%     |
+| Total Borrow APR                       | 0.00%         | 0.00%     |
+| Total Supply Incentives Per Day in USD | $11.14        | $11.28    |
+| Total Borrow Incentives Per Day in USD | $11.14        | $11.28    |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | 1.33%    |
+| WELL Borrow | 1.33%    |
+
+### VIRTUAL (MOONWELL_VIRTUAL)
+
+Total Supply in USD: $1,892,755.17 Total Borrows in USD: $886,821.05
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.00%         | 0.00%     |
+| Borrow APY                             | 1.00%         | 1.00%     |
+| WELL Supply APR                        | 0.09%         | 0.09%     |
+| WELL Borrow APR                        | 0.84%         | 0.83%     |
+| Total Supply APR                       | 0.09%         | 0.09%     |
+| Total Borrow APR                       | 0.16%         | 0.17%     |
+| Total Supply Incentives Per Day in USD | $16.69        | $16.57    |
+| Total Borrow Incentives Per Day in USD | $20.40        | $20.25    |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -0.75%   |
+| WELL Borrow | -0.75%   |
+
+### MORPHO (MOONWELL_MORPHO)
+
+Total Supply in USD: $9,615,706.32 Total Borrows in USD: $349,255.06
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.02%         | 0.02%     |
+| Borrow APY                             | 0.84%         | 0.84%     |
+| WELL Supply APR                        | 0.1%          | 0.09%     |
+| WELL Borrow APR                        | 4.95%         | 4.49%     |
+| Total Supply APR                       | 0.12%         | 0.11%     |
+| Total Borrow APR                       | 0.00%         | 0.00%     |
+| Total Supply Incentives Per Day in USD | $38.77        | $35.13    |
+| Total Borrow Incentives Per Day in USD | $47.39        | $42.94    |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -9.39%   |
+| WELL Borrow | -9.39%   |
+
+### cbXRP (MOONWELL_cbXRP)
+
+Total Supply in USD: $3,258,058.29 Total Borrows in USD: $1,125,293.03
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.00%         | 0.00%     |
+| Borrow APY                             | 1.00%         | 1.00%     |
+| WELL Supply APR                        | 0.09%         | 0.09%     |
+| WELL Borrow APR                        | 0.79%         | 0.79%     |
+| Total Supply APR                       | 0.09%         | 0.09%     |
+| Total Borrow APR                       | 0.21%         | 0.21%     |
+| Total Supply Incentives Per Day in USD | $19.91        | $19.85    |
+| Total Borrow Incentives Per Day in USD | $24.33        | $24.26    |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -0.3%    |
+| WELL Borrow | -0.3%    |
+
+## Optimism Network
+
+If successful, the proposal would automatically distribute and adjust liquidity
+incentives for the period beginning 2026-05-22 at 13:30:18 UTC and ending on
+2026-06-19 at 13:30:18 UTC.
+
+| Metric                                             | Value            |
+| -------------------------------------------------- | ---------------- |
+| Timestamp of capture                               | 1779114588       |
+| Closest block number                               | 151757905        |
+| Total Supply in USD for incentivized markets       | $12,201,688.79   |
+| Total Borrows in USD                               | $2,414,820.00    |
+| Safety Module APR (Base)                           | 4.69%            |
+| Safety Module APR (Capped at 10%)                  | 4.69%            |
+| WELL from auctions (this epoch)                    | 0.001 WELL       |
+| WELL from auctions (reserved for future)           | 0 WELL           |
+| **Total WELL acquired in auctions (USD)**          | **$0.00**        |
+|                                                    |                  |
+| Total WELL to distribute DEX                       | 0 WELL           |
+| Total WELL to distribute Safety Module             | 43,852.12 WELL   |
+| Total WELL to distribute Safety Module (Auctions)  | 0.001 WELL       |
+| Total WELL to distribute Markets (Config)          | 833,190.276 WELL |
+| Total WELL to distribute Markets (Sanity Check)    | 833190.2758 WELL |
+| Total WELL to distribute Markets (Supply Side)     | 833190.2758 WELL |
+| Total WELL to distribute Markets (Borrow Side)     | 0.0000 WELL      |
+| Total WELL to distribute Markets (Borrow + Supply) | 833190.2758 WELL |
+| Total WELL to distribute Markets (By Speed)        | 833190.2758 WELL |
+| Total WELL to distribute (Config + Auctions)       | 877042.3965 WELL |
+| Total WELL to distribute (Sanity Check)            | 877042.3965 WELL |
+|                                                    |                  |
+
+### USDC (MOONWELL_USDC)
+
+Total Supply in USD: $652,615.60 Total Borrows in USD: $524,306.00
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 2.90%         | 2.90%     |
+| Borrow APY                             | 4.02%         | 4.02%     |
+| WELL Supply APR                        | 0.34%         | 0.35%     |
+| WELL Borrow APR                        | 0%            | 0%        |
+| Total Supply APR                       | 3.24%         | 3.25%     |
+| Total Borrow APR                       | 4.02%         | 4.02%     |
+| Total Supply Incentives Per Day in USD | $34.49        | $34.64    |
+| Total Borrow Incentives Per Day in USD | $0.00         | $0.00     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | 0.44%    |
+| WELL Borrow | 0%       |
+
+### USDT (MOONWELL_USDT)
+
+Total Supply in USD: $96,016.95 Total Borrows in USD: $78,893.46
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 3.04%         | 3.04%     |
+| Borrow APY                             | 4.11%         | 4.11%     |
+| WELL Supply APR                        | 0.35%         | 0.35%     |
+| WELL Borrow APR                        | 0%            | 0%        |
+| Total Supply APR                       | 3.39%         | 3.39%     |
+| Total Borrow APR                       | 4.11%         | 4.11%     |
+| Total Supply Incentives Per Day in USD | $0.91         | $0.91     |
+| Total Borrow Incentives Per Day in USD | $0.00         | $0.00     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -0.07%   |
+| WELL Borrow | 0%       |
+
+### DAI (MOONWELL_DAI)
+
+Total Supply in USD: $58,552.24 Total Borrows in USD: $52,844.67
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 6.74%         | 6.74%     |
+| Borrow APY                             | 8.30%         | 8.30%     |
+| WELL Supply APR                        | 0.26%         | 0.35%     |
+| WELL Borrow APR                        | 0%            | 0%        |
+| Total Supply APR                       | 7.00%         | 7.09%     |
+| Total Borrow APR                       | 8.30%         | 8.30%     |
+| Total Supply Incentives Per Day in USD | $0.42         | $0.56     |
+| Total Borrow Incentives Per Day in USD | $0.00         | $0.00     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | 32.43%   |
+| WELL Borrow | 0%       |
+
+### ETH (MOONWELL_WETH)
+
+Total Supply in USD: $2,361,014.11 Total Borrows in USD: $1,621,847.18
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.59%         | 0.59%     |
+| Borrow APY                             | 0.96%         | 0.96%     |
+| WELL Supply APR                        | 0.38%         | 0.35%     |
+| WELL Borrow APR                        | 0%            | 0%        |
+| Total Supply APR                       | 0.97%         | 0.94%     |
+| Total Borrow APR                       | 0.96%         | 0.96%     |
+| Total Supply Incentives Per Day in USD | $77.12        | $69.81    |
+| Total Borrow Incentives Per Day in USD | $0.00         | $0.00     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -9.48%   |
+| WELL Borrow | 0%       |
+
+### wstETH (MOONWELL_wstETH)
+
+Total Supply in USD: $277,228.58 Total Borrows in USD: $9,199.31
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.01%         | 0.01%     |
+| Borrow APY                             | 0.20%         | 0.20%     |
+| WELL Supply APR                        | 0.4%          | 0.35%     |
+| WELL Borrow APR                        | 0%            | 0%        |
+| Total Supply APR                       | 0.41%         | 0.36%     |
+| Total Borrow APR                       | 0.20%         | 0.20%     |
+| Total Supply Incentives Per Day in USD | $3.04         | $2.63     |
+| Total Borrow Incentives Per Day in USD | $0.00         | $0.00     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -13.59%  |
+| WELL Borrow | 0%       |
+
+### rETH (MOONWELL_rETH)
+
+Total Supply in USD: $41,267.04 Total Borrows in USD: $5,715.65
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.11%         | 0.11%     |
+| Borrow APY                             | 0.84%         | 0.84%     |
+| WELL Supply APR                        | 0.38%         | 0.35%     |
+| WELL Borrow APR                        | 0%            | 0%        |
+| Total Supply APR                       | 0.49%         | 0.46%     |
+| Total Borrow APR                       | 0.84%         | 0.84%     |
+| Total Supply Incentives Per Day in USD | $0.43         | $0.39     |
+| Total Borrow Incentives Per Day in USD | $0.00         | $0.00     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -8.64%   |
+| WELL Borrow | 0%       |
+
+### OP (MOONWELL_OP)
+
+Total Supply in USD: $95,008.42 Total Borrows in USD: $42,868.38
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 2.33%         | 2.33%     |
+| Borrow APY                             | 6.88%         | 6.88%     |
+| WELL Supply APR                        | 0.39%         | 0.35%     |
+| WELL Borrow APR                        | 0%            | 0%        |
+| Total Supply APR                       | 2.72%         | 2.68%     |
+| Total Borrow APR                       | 6.88%         | 6.88%     |
+| Total Supply Incentives Per Day in USD | $1.01         | $0.90     |
+| Total Borrow Incentives Per Day in USD | $0.00         | $0.00     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -10.48%  |
+| WELL Borrow | 0%       |
+
+### weETH (MOONWELL_weETH)
+
+Total Supply in USD: $20,878.69 Total Borrows in USD: $2,989.57
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.26%         | 0.26%     |
+| Borrow APY                             | 2.15%         | 2.15%     |
+| WELL Supply APR                        | 0.44%         | 0.35%     |
+| WELL Borrow APR                        | 0%            | 0%        |
+| Total Supply APR                       | 0.70%         | 0.61%     |
+| Total Borrow APR                       | 2.15%         | 2.15%     |
+| Total Supply Incentives Per Day in USD | $0.25         | $0.20     |
+| Total Borrow Incentives Per Day in USD | $0.00         | $0.00     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -20.84%  |
+| WELL Borrow | 0%       |
+
+### VELO (MOONWELL_VELO)
+
+Total Supply in USD: $521,988.86 Total Borrows in USD: $31,766.27
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.12%         | 0.12%     |
+| Borrow APY                             | 2.61%         | 2.61%     |
+| WELL Supply APR                        | 0.36%         | 0.35%     |
+| WELL Borrow APR                        | 0%            | 0%        |
+| Total Supply APR                       | 0.48%         | 0.47%     |
+| Total Borrow APR                       | 2.61%         | 2.61%     |
+| Total Supply Incentives Per Day in USD | $5.09         | $4.95     |
+| Total Borrow Incentives Per Day in USD | $0.00         | $0.00     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -2.72%   |
+| WELL Borrow | 0%       |
+
+### wrsETH (MOONWELL_wrsETH)
+
+Total Supply in USD: $27,947.86 Total Borrows in USD: $627.51
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.01%         | 0.01%     |
+| Borrow APY                             | 0.34%         | 0.34%     |
+| WELL Supply APR                        | 0.38%         | 0.35%     |
+| WELL Borrow APR                        | 0%            | 0%        |
+| Total Supply APR                       | 0.39%         | 0.36%     |
+| Total Borrow APR                       | 0.34%         | 0.34%     |
+| Total Supply Incentives Per Day in USD | $0.29         | $0.27     |
+| Total Borrow Incentives Per Day in USD | $0.00         | $0.00     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -8.95%   |
+| WELL Borrow | 0%       |
+
+### USDT0 (MOONWELL_USDT0)
+
+Total Supply in USD: $49,170.44 Total Borrows in USD: $43,762.00
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 4.38%         | 4.38%     |
+| Borrow APY                             | 5.47%         | 5.47%     |
+| WELL Supply APR                        | 0.38%         | 0.35%     |
+| WELL Borrow APR                        | 0%            | 0%        |
+| Total Supply APR                       | 4.76%         | 4.73%     |
+| Total Borrow APR                       | 5.47%         | 5.47%     |
+| Total Supply Incentives Per Day in USD | $0.51         | $0.47     |
+| Total Borrow Incentives Per Day in USD | $0.00         | $0.00     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -7.85%   |
+| WELL Borrow | 0%       |
+
+## Moonbeam Network
+
+If successful, the proposal would automatically distribute and adjust liquidity
+incentives for the period beginning 2026-05-22 at 13:30:18 UTC and ending on
+2026-06-19 at 13:30:18 UTC.
+
+| Metric                                             | Value            |
+| -------------------------------------------------- | ---------------- |
+| Timestamp of capture                               | 1779114588       |
+| Closest block number                               | 15668826         |
+| Total Supply in USD for incentivized markets       | $6,528,565.15    |
+| Total Borrows in USD                               | $237,407.76      |
+| Safety Module APR                                  | 7.90%            |
+|                                                    |                  |
+| Total LP (GLMR/WELL on StellaSwap)                 | $53,283.00       |
+|                                                    |                  |
+| Total WELL to distribute DEX                       | 20,299.119 WELL  |
+| Total WELL to distribute Safety Module             | 190,811.721 WELL |
+| Total WELL to distribute Markets (Config)          | 194,871.545 WELL |
+| Total WELL to distribute Markets (Sanity Check)    | 194871.5446 WELL |
+| Total WELL to distribute Markets (Supply Side)     | 190830.6916 WELL |
+| Total WELL to distribute Markets (Borrow Side)     | 4040.8531 WELL   |
+| Total WELL to distribute Markets (Borrow + Supply) | 194871.5446 WELL |
+| Total WELL to distribute Markets (By Speed)        | 194871.5446 WELL |
+| Total WELL to distribute (Config)                  | 405982.3846 WELL |
+| Total WELL to distribute (Sanity Check)            | 405982.3846 WELL |
+|                                                    |                  |
+
+### GLMR (mGLIMMER)
+
+Total Supply in USD: $130,244.28 Total Borrows in USD: $205,391.72
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.02%         | 0.02%     |
+| Borrow APY                             | 1.00%         | 1.00%     |
+| WELL Supply APR                        | 0.09%         | 0.08%     |
+| WELL Borrow APR                        | 0.06%         | 0.05%     |
+| Total Supply APR                       | 0.11%         | 0.10%     |
+| Total Borrow APR                       | 0.94%         | 0.95%     |
+| Total Supply Incentives Per Day in USD | $0.33         | $0.27     |
+| Total Borrow Incentives Per Day in USD | $0.33         | $0.27     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | -18.53%  |
+| WELL Borrow | -18.53%  |
+
+### DOT (mxcDOT)
+
+Total Supply in USD: $1,257,812.72 Total Borrows in USD: $4,050.00
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.01%         | 0.01%     |
+| Borrow APY                             | 2.05%         | 2.05%     |
+| WELL Supply APR                        | 0.15%         | 0.15%     |
+| WELL Borrow APR                        | 0%            | 0%        |
+| Total Supply APR                       | 0.16%         | 0.16%     |
+| Total Borrow APR                       | 2.05%         | 2.05%     |
+| Total Supply Incentives Per Day in USD | $25.79        | $25.94    |
+| Total Borrow Incentives Per Day in USD | $0.00         | $0.00     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | 0.57%    |
+| WELL Borrow | 0%       |
+
+### FRAX (mFRAX)
+
+Total Supply in USD: $36,785.88 Total Borrows in USD: $133.19
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.00%         | 0.00%     |
+| Borrow APY                             | 0.05%         | 0.05%     |
+| WELL Supply APR                        | 0.07%         | 0.08%     |
+| WELL Borrow APR                        | 20.62%        | 20.9%     |
+| Total Supply APR                       | 0.07%         | 0.08%     |
+| Total Borrow APR                       | 0.00%         | 0.00%     |
+| Total Supply Incentives Per Day in USD | $0.08         | $0.08     |
+| Total Borrow Incentives Per Day in USD | $0.08         | $0.08     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | 1.34%    |
+| WELL Borrow | 1.34%    |
+
+### USDC.wh (mUSDCwh)
+
+Total Supply in USD: $33,694.99 Total Borrows in USD: $7,863.82
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.53%         | 0.53%     |
+| Borrow APY                             | 3.27%         | 3.27%     |
+| WELL Supply APR                        | 0.07%         | 0.08%     |
+| WELL Borrow APR                        | 0.32%         | 0.32%     |
+| Total Supply APR                       | 0.60%         | 0.61%     |
+| Total Borrow APR                       | 2.95%         | 2.95%     |
+| Total Supply Incentives Per Day in USD | $0.07         | $0.07     |
+| Total Borrow Incentives Per Day in USD | $0.07         | $0.07     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | 1.48%    |
+| WELL Borrow | 1.48%    |
+
+### xcUSDT (mxcUSDT)
+
+Total Supply in USD: $45,967.59 Total Borrows in USD: $11,976.42
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 0.67%         | 0.67%     |
+| Borrow APY                             | 3.65%         | 3.65%     |
+| WELL Supply APR                        | 0.07%         | 0.08%     |
+| WELL Borrow APR                        | 0.29%         | 0.29%     |
+| Total Supply APR                       | 0.74%         | 0.75%     |
+| Total Borrow APR                       | 3.36%         | 3.36%     |
+| Total Supply Incentives Per Day in USD | $0.09         | $0.10     |
+| Total Borrow Incentives Per Day in USD | $0.09         | $0.10     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | 1.35%    |
+| WELL Borrow | 1.35%    |
+
+### xcUSDC (mxcUSDC)
+
+Total Supply in USD: $24,059.69 Total Borrows in USD: $7,992.61
+
+| Metric                                 | Current Value | New Value |
+| -------------------------------------- | ------------- | --------- |
+| Supply APY                             | 1.08%         | 1.08%     |
+| Borrow APY                             | 4.65%         | 4.65%     |
+| WELL Supply APR                        | 0.07%         | 0.08%     |
+| WELL Borrow APR                        | 0.22%         | 0.23%     |
+| Total Supply APR                       | 1.15%         | 1.16%     |
+| Total Borrow APR                       | 4.43%         | 4.42%     |
+| Total Supply Incentives Per Day in USD | $0.05         | $0.05     |
+| Total Borrow Incentives Per Day in USD | $0.05         | $0.05     |
+
+| Metric      | % Change |
+| ----------- | -------- |
+| WELL Supply | 1.54%    |
+| WELL Borrow | 1.54%    |

--- a/proposals/mips/mip-x57/x57.sh
+++ b/proposals/mips/mip-x57/x57.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+export MIP_REWARDS_PATH=proposals/mips/mip-x57/x57.json
+echo "MIP_REWARDS_PATH=$MIP_REWARDS_PATH"
+
+export DESCRIPTION_PATH=proposals/mips/mip-x57/x57.md
+echo "DESCRIPTION_PATH=$DESCRIPTION_PATH"
+
+export PRIMARY_FORK_ID=0
+echo "PRIMARY_FORK_ID=$PRIMARY_FORK_ID"

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -2,7 +2,7 @@
     {
         "envpath": "proposals/mips/mip-x57/x57.sh",
         "governor": "MultichainGovernor",
-        "id": 0,
+        "id": 166,
         "path": "mip-x57.sol/mipx57.json",
         "proposalType": "HybridProposal"
     },

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -2,7 +2,7 @@
     {
         "envpath": "proposals/mips/mip-x57/x57.sh",
         "governor": "MultichainGovernor",
-        "id": 166,
+        "id": 0,
         "path": "mip-x57.sol/mipx57.json",
         "proposalType": "HybridProposal"
     },

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -1,5 +1,12 @@
 [
     {
+        "envpath": "proposals/mips/mip-x57/x57.sh",
+        "governor": "MultichainGovernor",
+        "id": 0,
+        "path": "RewardsDistribution.sol/RewardsDistributionTemplate.json",
+        "proposalType": "HybridProposal"
+    },
+    {
         "envpath": "proposals/mips/mip-x56/x56.sh",
         "governor": "MultichainGovernor",
         "id": 165,

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -2,7 +2,7 @@
     {
         "envpath": "proposals/mips/mip-x57/x57.sh",
         "governor": "MultichainGovernor",
-        "id": 0,
+        "id": 167,
         "path": "mip-x57.sol/mipx57.json",
         "proposalType": "HybridProposal"
     },

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -3,7 +3,7 @@
         "envpath": "proposals/mips/mip-x57/x57.sh",
         "governor": "MultichainGovernor",
         "id": 0,
-        "path": "RewardsDistribution.sol/RewardsDistributionTemplate.json",
+        "path": "mip-x57.sol/mipx57.json",
         "proposalType": "HybridProposal"
     },
     {

--- a/script/rewards/check-rewards-math.sh
+++ b/script/rewards/check-rewards-math.sh
@@ -235,10 +235,17 @@ for CHAIN in $CHAINS; do
 
   # --- Check 1: flow conservation on TEMPORAL_GOVERNOR ---
   # (skipped for sending chain 1284 — Moonbeam has its own conservation)
-  # TG receives: bridge + withdrawWell(to=TG)
+  # TG receives: bridge + withdrawWell(to=TG) + preStagedTG (external pre-stage)
   # TG sends:    transferFrom(from=TG, to=*) + merkleCampaign.amount (approved, pulled)
+  #
+  # preStagedTG is for MIPs that intentionally do NOT bridge from Moonbeam in
+  # the proposal itself (because off-chain Wormhole Executor signed quotes
+  # expire in ~1h while governance takes ~5 days). The proposal author commits
+  # to having xWELL pre-staged on the destination TG via a separate fast-path
+  # (prep MIP or multisig action) before this proposal executes on-chain.
+  PRESTAGED_TG=$(jq -r --arg c "$CHAIN" '.[$c].preStagedTG // "0"' "$JSON_PATH")
   if [ "$CHAIN" != "1284" ]; then
-    INFLOW=$(awkf -v a="$BRIDGE_IN" -v b="$WITHDRAW_TO_TG" 'BEGIN{printf "%.0f", a+b}')
+    INFLOW=$(awkf -v a="$BRIDGE_IN" -v b="$WITHDRAW_TO_TG" -v p="$PRESTAGED_TG" 'BEGIN{printf "%.0f", a+b+p}')
     OUTFLOW=$(awkf -v a="$TRANSFER_MRD" -v b="$TRANSFER_ECOSYSTEM" -v c="$MERKLE_TOTAL" 'BEGIN{printf "%.0f", a+b+c}')
     DIFF=$(awkf -v x="$INFLOW" -v y="$OUTFLOW" 'BEGIN{d=x-y; if (d<0) d=-d; printf "%.0f", d}')
     TOLERANCE="20000000000000000000"  # 20 WELL

--- a/test/integration/governance/StakedWellIntegration.t.sol
+++ b/test/integration/governance/StakedWellIntegration.t.sol
@@ -638,6 +638,13 @@ contract StakedWellIntegrationTest is PostProposalCheck {
             "Ethereum: Staker should have xWELL"
         );
 
+        // Snapshot stkWELL contract's xWELL balance before the stake — it
+        // may already be non-zero from live mainnet stakers, so we assert
+        // the delta rather than the absolute post-stake balance.
+        uint256 stkWellContractBalanceBefore = IERC20(xWellProxy).balanceOf(
+            address(stkWellEthereum)
+        );
+
         // Approve and stake
         vm.startPrank(staker);
         IERC20(xWellProxy).approve(address(stkWellEthereum), stakeAmount);
@@ -660,12 +667,13 @@ contract StakedWellIntegrationTest is PostProposalCheck {
             "Ethereum: xWELL should be transferred to stkWELL contract"
         );
 
-        // Verify stkWELL contract holds xWELL
-        uint256 stkWellContractBalance = IERC20(xWellProxy).balanceOf(
+        // Verify stkWELL contract received the staker's xWELL (delta check
+        // is robust to live mainnet stakers raising the baseline balance).
+        uint256 stkWellContractBalanceAfter = IERC20(xWellProxy).balanceOf(
             address(stkWellEthereum)
         );
         assertEq(
-            stkWellContractBalance,
+            stkWellContractBalanceAfter - stkWellContractBalanceBefore,
             stakeAmount,
             "Ethereum: stkWELL contract should hold staked xWELL"
         );


### PR DESCRIPTION
## Summary

Monthly automated liquidity-incentive proposal for the 28-day epoch **2026-05-22 13:30:18 UTC → 2026-06-19 13:30:18 UTC**. Generated from the rewards-automation Cloudflare worker (timestamp `1779114588`), template-only (`RewardsDistributionTemplate`), registered in `mips.json` with `id: 0`.

## ⚠️ Architectural change: pre-staged xWELL instead of in-proposal bridges

The first commit included Wormhole `bridgeToRecipient` actions from Moonbeam → Base/OP. **Removed in the second commit** because off-chain signed quotes have a ~1h expiry and governance takes ~5 days — quotes signed at MIP-authoring time go stale before execution and revert with `QuoteSrcChainMismatch`.

**Strategy:** xWELL must be pre-staged on Base TG and Optimism TG via a separate fast-path (prep MIP or direct multisig action) **before x57 executes**. Required pre-staged amounts:

| Destination | TG Amount |
|---|---|
| Base TG (`8453`) | 11,856,475.12 WELL |
| Optimism TG (`10`) | 877,006.59 WELL |

Until on-chain quoting is wired on Moonbeam (no `WORMHOLE_QUOTER` in `chains/1284.json`), this is the only viable path for governance-driven rewards bridging.

## Hand-fixes applied to worker output

- Removed negative `withdrawWell` dust (chain 10: `-1687686`, chain 8453: `-236359936`) — known worker rounding artifacts.
- Removed Moonbeam `bridgeToRecipient` entries and their two feeding `transferFrom` entries (MGLIMMER → MULTICHAIN_GOVERNOR_PROXY for the 11.86M + 877k WELL bridge fund).

## Known gaps before merge

- [ ] **`make audit-rewards PROPOSAL=mip-x57`** fails Base/OP TG conservation (inflow=0 vs outflow=N). Expected — the audit script can't see the external pre-staging. Either teach the audit to recognize the pre-staged pattern or accept the failure with an explicit override.
- [ ] **`forge test --ffi --match-test testSetup`** fails `ERC20: transfer amount exceeds balance` on the destination-TG `transferFrom(TG, MRD)` because dest TGs aren't pre-funded in the fork. Needs one of:
  - sibling prep MIP at `id: 0` that bridges first (PostProposalCheck.setUp runs them in id order)
  - custom `mip-x57.sol` with `beforeSimulationHook` that `deal()`s xWELL to dest TGs
- [ ] **Decide pre-staging mechanism**: separate fast-path MIP, MGLIMMER multisig direct action, or another path
- [ ] **`cast estimate propose()` on Moonbeam** to confirm `< 16,777,216` gas (likely fine now that bridges are gone, but verify)

## Test plan

- [ ] Pre-staging mechanism decided and documented in `x57.md`
- [ ] `forge test --ffi --match-path test/integration/MultichainProposalIntegration.t.sol --match-test testSetup` passes
- [ ] `make audit-rewards PROPOSAL=mip-x57` passes (or audit override documented)
- [ ] `cast estimate propose()` < 16.7M gas

🤖 Generated with [Claude Code](https://claude.com/claude-code)