### PR TITLE
Decouple ProposalView deployment from MIP-X58

### DIFF
--- a/proposals/mips/mip-x58/mip-x58.sol
+++ b/proposals/mips/mip-x58/mip-x58.sol
@@ -7,7 +7,6 @@ import {TransparentUpgradeableProxy, ITransparentUpgradeableProxy} from "@openze
 import {ProxyAdmin} from "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
 
 import {MultichainGovernorV2} from "@protocol/governance/multichain/MultichainGovernorV2.sol";
-import {ProposalView} from "@protocol/views/ProposalView.sol";
 import {MultichainGovernor} from "@protocol/governance/multichain/MultichainGovernor.sol";
 import {TemporalGovernor} from "@protocol/governance/TemporalGovernor.sol";
 import {ITemporalGovernor} from "@protocol/governance/ITemporalGovernor.sol";
@@ -274,23 +273,6 @@ contract mipx58 is HybridProposal {
             vm.stopBroadcast();
 
             addresses.addAddress("TEMPORAL_GOVERNOR", temporalGovernor);
-        }
-
-        // Deploy ProposalView on Moonbeam (references TemporalGovernor)
-        if (!addresses.isAddressSet("PROPOSAL_VIEW", block.chainid)) {
-            address temporalGovernor = addresses.getAddress(
-                "TEMPORAL_GOVERNOR"
-            );
-
-            vm.startBroadcast();
-
-            address proposalView = address(
-                new ProposalView(ITemporalGovernor(temporalGovernor))
-            );
-
-            vm.stopBroadcast();
-
-            addresses.addAddress("PROPOSAL_VIEW", proposalView);
         }
 
         // Deploy VotingPowerAggregator on Moonbeam
@@ -1793,19 +1775,6 @@ contract mipx58 is HybridProposal {
                 ethereumGovernorV2
             ),
             "Ethereum MultichainGovernorV2 not trusted sender on Moonbeam TemporalGovernor"
-        );
-
-        // 5.6. Validate ProposalView is deployed and references TemporalGovernor
-        address proposalView = addresses.getAddress("PROPOSAL_VIEW");
-        assertGt(
-            proposalView.code.length,
-            0,
-            "ProposalView not deployed on Moonbeam"
-        );
-        assertEq(
-            address(ProposalView(proposalView).temporalGovernor()),
-            temporalGovernor,
-            "ProposalView does not reference correct TemporalGovernor"
         );
 
         // 6. Validate MultichainGovernor was upgraded to v1.1 (with recoverETH)

--- a/script/DeployProposalView.s.sol
+++ b/script/DeployProposalView.s.sol
@@ -33,6 +33,12 @@ forge script script/DeployProposalView.s.sol:DeployProposalView \
     --rpc-url optimism --etherscan-api-key optimism \
     --verify --broadcast --always-use-create-2-factory
 
+How to use (Ethereum):
+forge script script/DeployProposalView.s.sol:DeployProposalView \
+    -vvvv \
+    --rpc-url ethereum --etherscan-api-key ethereum \
+    --verify --broadcast --always-use-create-2-factory
+
 Omit --broadcast for a dry run (no gas spent). After a successful broadcast,
 register the deployed address in chains/<chainId>.json under PROPOSAL_VIEW.
 */

--- a/script/DeployProposalView.s.sol
+++ b/script/DeployProposalView.s.sol
@@ -9,18 +9,47 @@ import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
 import {ITemporalGovernor} from "@protocol/governance/ITemporalGovernor.sol";
 
 /*
-How to use:
+Standalone deployment for the ProposalView contract. Decoupled from any
+governance proposal — runnable today, by anyone, against any chain where
+TEMPORAL_GOVERNOR is registered in chains/<id>.json.
+
+How to use (Moonbeam):
+forge script script/DeployProposalView.s.sol:DeployProposalView \
+    -vvvv \
+    --rpc-url moonbeam \
+    --verify --verifier-url https://api-moonbeam.moonscan.io/api \
+    --etherscan-api-key moonbeam \
+    --broadcast --always-use-create-2-factory
+
+How to use (Base):
 forge script script/DeployProposalView.s.sol:DeployProposalView \
     -vvvv \
     --rpc-url base --etherscan-api-key base \
     --verify --broadcast --always-use-create-2-factory
-Remove --broadcast if you want to try locally first, without paying any gas.
+
+How to use (Optimism):
+forge script script/DeployProposalView.s.sol:DeployProposalView \
+    -vvvv \
+    --rpc-url optimism --etherscan-api-key optimism \
+    --verify --broadcast --always-use-create-2-factory
+
+Omit --broadcast for a dry run (no gas spent). After a successful broadcast,
+register the deployed address in chains/<chainId>.json under PROPOSAL_VIEW.
 */
 contract DeployProposalView is Script {
     bytes32 public constant salt = keccak256("PROPOSAL_VIEW");
 
     function run() public {
         Addresses addresses = new Addresses();
+
+        if (addresses.isAddressSet("PROPOSAL_VIEW", block.chainid)) {
+            console.log(
+                "PROPOSAL_VIEW already deployed on chain %s at %s - skipping",
+                block.chainid,
+                addresses.getAddress("PROPOSAL_VIEW")
+            );
+            return;
+        }
 
         ITemporalGovernor temporalGovernor = ITemporalGovernor(
             addresses.getAddress("TEMPORAL_GOVERNOR")
@@ -30,12 +59,19 @@ contract DeployProposalView is Script {
         ProposalView proposalView = new ProposalView{salt: salt}(
             temporalGovernor
         );
-
         vm.stopBroadcast();
 
         console.log(
-            "successfully deployed ProposalView: %s",
+            "successfully deployed ProposalView on chain %s: %s",
+            block.chainid,
             address(proposalView)
+        );
+        console.log(
+            "  referencing TemporalGovernor:",
+            address(temporalGovernor)
+        );
+        console.log(
+            "  remember to register this under PROPOSAL_VIEW in chains/<chainId>.json"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Removes the inline ProposalView deploy + validate blocks from `proposals/mips/mip-x58/mip-x58.sol` so the contract can be deployed today, independently of the governance timeline.
- Upgrades `script/DeployProposalView.s.sol`:
  - Idempotency guard: skips with a log line if `PROPOSAL_VIEW` is already set in `chains/<chainId>.json`.
  - Per-chain usage docs for Moonbeam, Base, and Optimism.
  - Clearer post-deploy logging (chain id, referenced `TemporalGovernor`, reminder to update `chains/<id>.json`).

Base: `feat/multichain-gov-refactor` — this PR is a precursor edit on top of that branch so MIP-X58 stops carrying the ProposalView deployment.

## Test plan

- [ ] `forge build` — confirmed both files compile (only pre-existing unrelated warnings remain).
- [ ] Dry-run on Moonbeam: `forge script script/DeployProposalView.s.sol:DeployProposalView -vvvv --rpc-url moonbeam` (no `--broadcast`) — expects `TEMPORAL_GOVERNOR` resolution + CREATE2 deploy preview.
- [ ] Broadcast on Moonbeam, then register the resulting address under `PROPOSAL_VIEW` in `chains/1284.json`.
- [ ] Re-run the script — confirms idempotency guard logs "already deployed - skipping".

🤖 Generated with [Claude Code](https://claude.com/claude-code)