### PR TITLE
Deploy MoonwellViewsV3 (script hardening for Optimism/Ethereum rollout)

### DIFF
--- a/script/DeployMoonwellViewsV3.s.sol
+++ b/script/DeployMoonwellViewsV3.s.sol
@@ -4,24 +4,35 @@ pragma experimental ABIEncoderV2;
 
 import {console} from "@forge-std/console.sol";
 import {Script} from "@forge-std/Script.sol";
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-
-import "@forge-std/Test.sol";
 
 import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
 import {MoonwellViewsV3} from "@protocol/views/MoonwellViewsV3.sol";
-import {TransparentUpgradeableProxy, ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
-import {console} from "@forge-std/console.sol";
 /*
-to run:
-forge script script/DeployMoonwellViewsV3.s.sol:DeployMoonwellViewsV3 -vvvv --rpc-url {rpc}  --broadcast --etherscan-api-key {key}
-forge script script/DeployMoonwellViewsV3.s.sol:DeployMoonwellViewsV3 -vvvv --rpc-url https://sepolia.base.org --broadcast
+Standalone deployment for MoonwellViewsV3 (impl + dedicated ProxyAdmin +
+TransparentUpgradeableProxy initialized in one shot). Skips if
+MOONWELL_VIEWS_PROXY is already registered for the current chain in
+chains/<chainId>.json.
 
+How to use (Optimism):
+forge script script/DeployMoonwellViewsV3.s.sol:DeployMoonwellViewsV3 \
+    -vvvv \
+    --rpc-url optimism --etherscan-api-key optimism \
+    --verify --broadcast
+
+How to use (Base):
+forge script script/DeployMoonwellViewsV3.s.sol:DeployMoonwellViewsV3 \
+    -vvvv \
+    --rpc-url base --etherscan-api-key base \
+    --verify --broadcast
+
+Omit --broadcast for a dry run. After a successful broadcast, register the
+emitted addresses in chains/<chainId>.json under MOONWELL_VIEWS_IMPLEMENTATION,
+MOONWELL_VIEWS_PROXY_ADMIN, and MOONWELL_VIEWS_PROXY.
 */
-
-contract DeployMoonwellViewsV3 is Script, Test {
+contract DeployMoonwellViewsV3 is Script {
     Addresses public addresses;
 
     function setUp() public {
@@ -29,14 +40,24 @@ contract DeployMoonwellViewsV3 is Script, Test {
     }
 
     function run() public {
-        vm.startBroadcast();
+        if (addresses.isAddressSet("MOONWELL_VIEWS_PROXY", block.chainid)) {
+            console.log(
+                "MOONWELL_VIEWS_PROXY already deployed on chain %s at %s - skipping",
+                block.chainid,
+                addresses.getAddress("MOONWELL_VIEWS_PROXY")
+            );
+            return;
+        }
 
         address unitroller = addresses.getAddress("UNITROLLER");
-        address tokenSaleDistributor = address(0);
         address safetyModule = addresses.getAddress("stkWELL_PROXY");
         address governanceToken = addresses.getAddress("xWELL_PROXY");
+        address tokenSaleDistributor = address(0);
         address nativeMarket = address(0);
         address governanceTokenLP = address(0);
+
+        vm.startBroadcast();
+
         MoonwellViewsV3 viewsContract = new MoonwellViewsV3();
 
         bytes memory initdata = abi.encodeWithSignature(
@@ -58,5 +79,14 @@ contract DeployMoonwellViewsV3 is Script, Test {
         );
 
         vm.stopBroadcast();
+
+        console.log("Deployed MoonwellViewsV3 on chain %s:", block.chainid);
+        console.log("  MOONWELL_VIEWS_IMPLEMENTATION:", address(viewsContract));
+        console.log("  MOONWELL_VIEWS_PROXY_ADMIN:   ", address(proxyAdmin));
+        console.log("  MOONWELL_VIEWS_PROXY:         ", address(proxy));
+        console.log(
+            "  Register these in chains/%s.json after broadcast.",
+            block.chainid
+        );
     }
 }


### PR DESCRIPTION
## Summary

Prepares `script/DeployMoonwellViewsV3.s.sol` for fresh deployments on chains where `MOONWELL_VIEWS_PROXY` is not yet registered (currently Optimism and Ethereum — Base, Moonbeam, and Moonriver already have it).

- Idempotency guard: skip with a log line if `MOONWELL_VIEWS_PROXY` is already set for the current chain in `chains/<id>.json`.
- Logs deployed `MOONWELL_VIEWS_IMPLEMENTATION`, `MOONWELL_VIEWS_PROXY_ADMIN`, and `MOONWELL_VIEWS_PROXY` after broadcast.
- Drops unused `Test` inheritance and stray `ERC20` import — deploy logic is unchanged (same init args, same proxy pattern, dedicated `ProxyAdmin` so view-only upgrades stay out of governance).
- Per-chain usage snippets in the header comment.

## Deploy command (Optimism)

```
forge script script/DeployMoonwellViewsV3.s.sol:DeployMoonwellViewsV3 \
    -vvvv \
    --rpc-url optimism --etherscan-api-key optimism \
    --verify --broadcast
```

## Test plan

- [ ] `forge build --force script/DeployMoonwellViewsV3.s.sol` — passes (verified locally).
- [ ] Dry-run against Optimism (no `--broadcast`) to confirm `UNITROLLER`, `stkWELL_PROXY`, and `xWELL_PROXY` resolve from `chains/10.json`.
- [ ] Broadcast on Optimism, then register the three printed addresses in `chains/10.json`.
- [ ] Re-run the script — confirm "already deployed - skipping" path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)