### PR TITLE
Cap Comptroller account asset memberships

### DIFF
--- a/src/Comptroller.sol
+++ b/src/Comptroller.sol
@@ -94,6 +94,9 @@ contract Comptroller is
     // No collateralFactorMantissa may exceed this value
     uint internal constant collateralFactorMaxMantissa = 0.9e18; // 0.9
 
+    /// @notice Maximum number of markets an account can enter.
+    uint public constant maxAssets = 20;
+
     constructor() {
         admin = msg.sender;
     }
@@ -166,6 +169,10 @@ contract Comptroller is
         if (marketToJoin.accountMembership[borrower] == true) {
             // already joined
             return Error.NO_ERROR;
+        }
+
+        if (accountAssets[borrower].length >= maxAssets) {
+            return Error.TOO_MANY_ASSETS;
         }
 
         // survived the gauntlet, add to list

--- a/test/unit/Comptroller.t.sol
+++ b/test/unit/Comptroller.t.sol
@@ -84,6 +84,31 @@ contract ComptrollerUnitTest is
         sigUtils = new SigUtils(faucetToken.DOMAIN_SEPARATOR());
     }
 
+    function _deployAndSupportMarket() internal returns (MErc20Immutable) {
+        FaucetTokenWithPermit underlying = new FaucetTokenWithPermit(
+            1e18,
+            "Testing",
+            18,
+            "TEST"
+        );
+
+        MErc20Immutable market = new MErc20Immutable(
+            address(underlying),
+            comptroller,
+            irModel,
+            1e18,
+            "Test mToken",
+            "mTEST",
+            8,
+            payable(address(this))
+        );
+
+        comptroller._supportMarket(market);
+        oracle.setUnderlyingPrice(market, 1e18);
+
+        return market;
+    }
+
     function testWiring() public {
         // Ensure things are wired correctly
         assertEq(comptroller.admin(), address(this));
@@ -136,6 +161,65 @@ contract ComptrollerUnitTest is
             );
             assertEq(collateralFactorUpdated, cfToSet);
         }
+    }
+
+    function testEnterMarketsCapsAccountAssets() public {
+        uint maxAssets = comptroller.maxAssets();
+        address[] memory markets = new address[](maxAssets + 1);
+
+        for (uint i = 0; i < markets.length; i++) {
+            markets[i] = address(_deployAndSupportMarket());
+        }
+
+        uint[] memory results = comptroller.enterMarkets(markets);
+
+        for (uint i = 0; i < maxAssets; i++) {
+            assertEq(results[i], uint(Error.NO_ERROR));
+        }
+        assertEq(results[maxAssets], uint(Error.TOO_MANY_ASSETS));
+
+        MToken[] memory assetsIn = comptroller.getAssetsIn(address(this));
+        assertEq(assetsIn.length, maxAssets);
+        assertFalse(
+            comptroller.checkMembership(
+                address(this),
+                MToken(markets[maxAssets])
+            )
+        );
+    }
+
+    function testBorrowAllowedCannotAutoEnterAboveMaxAssets() public {
+        uint maxAssets = comptroller.maxAssets();
+        address borrower = address(0xB0B);
+        address[] memory markets = new address[](maxAssets + 1);
+
+        for (uint i = 0; i < markets.length; i++) {
+            markets[i] = address(_deployAndSupportMarket());
+        }
+
+        address[] memory marketsToEnter = new address[](maxAssets);
+        for (uint i = 0; i < marketsToEnter.length; i++) {
+            marketsToEnter[i] = markets[i];
+        }
+
+        vm.prank(borrower);
+        uint[] memory results = comptroller.enterMarkets(marketsToEnter);
+
+        for (uint i = 0; i < results.length; i++) {
+            assertEq(results[i], uint(Error.NO_ERROR));
+        }
+
+        vm.prank(markets[maxAssets]);
+        uint result = comptroller.borrowAllowed(
+            markets[maxAssets],
+            borrower,
+            1
+        );
+
+        assertEq(result, uint(Error.TOO_MANY_ASSETS));
+        assertFalse(
+            comptroller.checkMembership(borrower, MToken(markets[maxAssets]))
+        );
     }
 
     function testRewards() public {


### PR DESCRIPTION
Closes #640.

## Summary
- add a storage-layout-safe `maxAssets` constant capped at 20 entered markets per account
- return the existing `TOO_MANY_ASSETS` error before adding another `accountAssets` entry
- cover both direct `enterMarkets` and `borrowAllowed` auto-enter paths with regression tests

## Notes
- The cap is a constant, not a new storage slot, so it does not shift the Comptroller proxy storage layout.

## Validation
- `forge build`
- `forge test --match-contract ComptrollerUnitTest -vv` (5 passed)
- `forge test --match-contract MErc20UnitTest -vv` (1 passed)
- `git diff --check`

`forge fmt --check src/Comptroller.sol test/unit/Comptroller.t.sol` wants to restyle existing files wholesale under the current local Foundry formatter, so I left formatting scoped to the repository's existing style instead of introducing unrelated churn.