### PR TITLE
fix(test): align ChainlinkCompositeOracle test with HAL-02 semantics

### DIFF
--- a/test/integration/oracle/ChainlinkCompositeOracleIntegration.t.sol
+++ b/test/integration/oracle/ChainlinkCompositeOracleIntegration.t.sol
@@ -44,7 +44,7 @@ contract ChainlinkCompositeOracleIntegrationTest is Test {
             uint80 roundId, /// always 0, value unused in ChainlinkOracle.sol
             int256 answer, /// the composite price
             uint256 startedAt, /// always 0, value unused in ChainlinkOracle.sol
-            uint256 updatedAt, /// always block.timestamp
+            uint256 updatedAt, /// minimum `updatedAt` across underlying feeds (HAL-02)
             uint80 answeredInRound /// always 0, value unused in ChainlinkOracle.sol
         ) = oracle.latestRoundData();
         uint256 price = oracle.getDerivedPrice(
@@ -56,7 +56,15 @@ contract ChainlinkCompositeOracleIntegrationTest is Test {
         assertTrue(answer > 0, "Price should be greater than 0");
 
         assertEq(price, uint256(answer));
-        assertEq(updatedAt, block.timestamp);
+        /// HAL-02: `latestRoundData` propagates `min(updatedAt)` across underlying
+        /// feeds instead of substituting `block.timestamp`, so consumers can detect
+        /// staleness. Assert it is a real, non-future timestamp.
+        assertGt(updatedAt, 0, "updatedAt should be > 0");
+        assertLe(
+            updatedAt,
+            block.timestamp,
+            "updatedAt should not be in the future"
+        );
         assertEq(roundId, 0);
         assertEq(startedAt, 0);
         assertEq(answeredInRound, 0);


### PR DESCRIPTION
## Summary

- After audit finding **HAL-02**, \`ChainlinkCompositeOracle.latestRoundData()\` returns \`min(updatedAt)\` across underlying feeds instead of \`block.timestamp\` so downstream consumers can detect staleness ([src/oracles/ChainlinkCompositeOracle.sol:47-49](../blob/main/src/oracles/ChainlinkCompositeOracle.sol#L47)).
- \`testTestLatestRoundData()\` still asserted the old behavior (\`assertEq(updatedAt, block.timestamp)\`), so it broke whenever the cbETH/ETH feed's last on-chain push lagged the fork's wall-clock — which is the normal case (~18h between Chainlink heartbeats).
- Replace the equality with two stricter checks that match the new contract: \`updatedAt > 0\` and \`updatedAt <= block.timestamp\`. Also update the outdated docstring on the \`updatedAt\` tuple slot.

## Test plan

- [x] \`forge build\` (clean)
- [x] \`forge test --match-contract ChainlinkCompositeOracleIntegrationTest --fork-url ethereum\` — 5/5 PASS locally
- [ ] CI \`Oracle Integration Test\` job green on this PR