### PR TITLE
feat: pin proposal descriptions to IPFS and use the hash as descriptionUri

### DIFF
--- a/.github/workflows/pin-proposal-description.yml
+++ b/.github/workflows/pin-proposal-description.yml
@@ -1,0 +1,80 @@
+name: Pin Proposal Description to IPFS
+
+# When a proposal's description markdown changes, pin it to IPFS (Pinata) and
+# record the resulting ipfs://<cid> in the matching mips.json entry's optional
+# `descriptionUri` field, committing the update back to the PR branch.
+# HybridProposalV2 then submits that URI as the descriptionUri argument to
+# MultichainGovernorV2.propose() instead of the full markdown.
+#
+# Only fires on markdown changes, and the pin script only touches `id: 0`
+# (not-yet-submitted) proposals. Pinata is content-addressed, so unchanged
+# markdown re-pins to the same CID => no diff => no commit (no loop).
+#
+# Secrets:
+#   PINATA_JWT      (required) Pinata JWT bearer token.
+#   PIN_BOT_TOKEN   (optional) PAT used for checkout/push. Recommended: a push
+#                   made with the default GITHUB_TOKEN does NOT retrigger other
+#                   workflows, so the calldata-printing job won't auto-rerun on
+#                   the bot's commit. With a PAT the descriptionUri commit
+#                   retriggers CI so the printed calldata reflects the URI in
+#                   the same PR. Without it, the URI still lands in mips.json;
+#                   regenerate calldata after the commit (push again or re-run).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'proposals/mips/**/*.md'
+
+concurrency:
+  group: pin-description-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pin:
+    # skip drafts and fork PRs — forks cannot read repo secrets (no PINATA_JWT)
+    if: >
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.PIN_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Determine changed proposal markdown
+        id: changed
+        run: |
+          BASE_SHA=${{ github.event.pull_request.base.sha }}
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          FILES=$(git diff --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA" -- 'proposals/mips' \
+            | grep -E '\.md$' | xargs || true)
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          if [ -z "$FILES" ]; then
+            echo "No proposal markdown changed."
+          else
+            echo "Changed markdown: $FILES"
+          fi
+
+      - name: Pin descriptions and update mips.json
+        if: steps.changed.outputs.files != ''
+        env:
+          PINATA_JWT: ${{ secrets.PINATA_JWT }}
+        run: ./script/proposals/pin-descriptions.sh ${{ steps.changed.outputs.files }}
+
+      - name: Commit updated mips.json
+        if: steps.changed.outputs.files != ''
+        run: |
+          if git diff --quiet -- proposals/mips/mips.json; then
+            echo "No descriptionUri changes to commit (already pinned / no in-development entry)."
+            exit 0
+          fi
+          git config user.name "moonwell-bot"
+          git config user.email "bot@moonwell.fi"
+          git add proposals/mips/mips.json
+          git commit -m "chore: pin proposal description(s) to IPFS"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"

--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,12 @@ test-unit:
 audit-rewards:
 	@./script/rewards/check-rewards-math.sh $(PROPOSAL)
 
+# Pin in-development proposal descriptions to IPFS (Pinata) and record the
+# ipfs://<cid> in the matching mips.json entry. Requires PINATA_JWT.
+# Usage:
+#   PINATA_JWT=... make pin-descriptions FILES="proposals/mips/mip-e00/MIP-E00.md"
+#   PINATA_JWT=... make pin-descriptions   # auto-detect from git diff main
+#   PIN_DRY_RUN=1 make pin-descriptions FILES=...   # no network, fake CID
+pin-descriptions:
+	@./script/proposals/pin-descriptions.sh $(FILES)
+

--- a/proposals/Proposal.sol
+++ b/proposals/Proposal.sol
@@ -99,6 +99,12 @@ abstract contract Proposal is Script, Test {
     /// live fork is selected
     function initProposal(Addresses) public virtual {}
 
+    /// @notice optional IPFS URI for the proposal description. When set, V2
+    /// proposal types use it as the `descriptionUri` argument to propose()
+    /// instead of the raw markdown. No-op by default so proposal types that
+    /// don't support it (and V1) simply ignore it.
+    function setProposalDescriptionUri(string memory) public virtual {}
+
     /// @dev Print recorded addresses
     function _printAddressesChanges(Addresses addresses) internal view {
         bytes

--- a/proposals/proposalTypes/HybridProposalV2.sol
+++ b/proposals/proposalTypes/HybridProposalV2.sol
@@ -89,6 +89,12 @@ abstract contract HybridProposalV2 is
     /// @notice hex encoded description of the proposal
     bytes public PROPOSAL_DESCRIPTION;
 
+    /// @notice optional IPFS URI (e.g. ipfs://<cid>) pointing at the pinned
+    /// proposal description. When set, it is used as the `descriptionUri`
+    /// argument to propose() instead of the raw markdown. Populated off-chain
+    /// (see ProposalMap) from the optional `descriptionUri` field in mips.json.
+    string public PROPOSAL_DESCRIPTION_URI;
+
     /// @notice allows asserting wormhole core correctly emits data to temporal governor
     event LogMessagePublished(
         address indexed sender,
@@ -103,6 +109,20 @@ abstract contract HybridProposalV2 is
         bytes memory newProposalDescription
     ) internal {
         PROPOSAL_DESCRIPTION = newProposalDescription;
+    }
+
+    /// @notice set the optional IPFS URI for the proposal description
+    function setProposalDescriptionUri(string memory uri) public override {
+        PROPOSAL_DESCRIPTION_URI = uri;
+    }
+
+    /// @notice description argument used in propose() calldata: the pinned IPFS
+    /// URI when available, otherwise the raw markdown (backwards compatible)
+    function _proposeDescription() internal view returns (string memory) {
+        return
+            bytes(PROPOSAL_DESCRIPTION_URI).length > 0
+                ? PROPOSAL_DESCRIPTION_URI
+                : string(PROPOSAL_DESCRIPTION);
     }
 
     /// @notice push an action to the Hybrid proposal without specifying a
@@ -486,7 +506,7 @@ abstract contract HybridProposalV2 is
             targets,
             values,
             payloads,
-            string(PROPOSAL_DESCRIPTION),
+            _proposeDescription(),
             true // finalize = true
         );
 
@@ -669,7 +689,7 @@ abstract contract HybridProposalV2 is
                 targets,
                 values,
                 payloads,
-                string(PROPOSAL_DESCRIPTION),
+                _proposeDescription(),
                 true // finalize = true
             );
 

--- a/script/proposals/pin-descriptions.sh
+++ b/script/proposals/pin-descriptions.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# pin-descriptions.sh — pin in-development proposal descriptions to IPFS (Pinata)
+# and record the resulting ipfs://<cid> in the matching mips.json entry's
+# optional `descriptionUri` field. HybridProposalV2 then emits that URI as the
+# `descriptionUri` argument to MultichainGovernorV2.propose() instead of the
+# full markdown (smaller calldata; resolves off-chain).
+#
+# Usage:
+#   pin-descriptions.sh [<changed.md> ...]   # explicit list (CI passes the diff)
+#   pin-descriptions.sh                      # auto-detect from git diff vs BASE_REF
+#
+# Env:
+#   PINATA_JWT   Pinata JWT bearer token (required unless PIN_DRY_RUN=1)
+#   BASE_REF     base ref for auto-detect (default: main)
+#   PIN_DRY_RUN  =1 to skip the network call and use a deterministic fake CID
+#                (for local testing without credentials)
+#
+# Only entries with "id": 0 (not yet submitted on-chain) are processed — a
+# submitted proposal's descriptionUri is already immutable on-chain.
+#
+# Idempotent: Pinata is content-addressed, so re-pinning unchanged markdown
+# yields the same CID and produces no mips.json diff.
+#
+# Requires: bash, jq, curl. Exits: 0 ok, 1 on error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+MIPS_JSON="proposals/mips/mips.json"
+BASE_REF="${BASE_REF:-main}"
+
+log() { printf '%s\n' "$*" >&2; }
+err() { printf 'ERROR: %s\n' "$*" >&2; }
+
+# strip a leading ./ so paths from git diff and from .sol/.sh literals compare
+norm() { printf '%s' "${1#./}"; }
+
+# resolve the description .md path for a mips.json entry (raw path + envpath)
+resolve_md() {
+  local rawpath="$1" envpath="$2"
+  if [ -n "$envpath" ]; then
+    # entry has a .sh — it exports DESCRIPTION_PATH=<the .md>
+    ( set +u; . "$envpath" >/dev/null 2>&1; printf '%s' "${DESCRIPTION_PATH:-}" )
+  else
+    # concrete proposal — grep the vm.readFile("...md") literal from its .sol
+    local contract="${rawpath%%/*}" solfile
+    solfile="$(find proposals/mips -type f -name "$contract" 2>/dev/null | head -n1)"
+    [ -n "$solfile" ] || return 0
+    grep -oE 'vm\.readFile\("[^"]+\.md"\)' "$solfile" | head -n1 |
+      sed -E 's/.*"([^"]+)".*/\1/'
+  fi
+}
+
+# emit "<rawpath>\t<normalized md path>" for every id:0 entry that resolves
+id0_entries() {
+  jq -r '.[] | select(.id == 0) | [.path, (.envpath // .envPath // "")] | @tsv' \
+    "$MIPS_JSON" |
+  while IFS=$'\t' read -r rawpath envpath; do
+    local md
+    md="$(resolve_md "$rawpath" "$envpath")"
+    [ -n "$md" ] && printf '%s\t%s\n' "$rawpath" "$(norm "$md")"
+  done
+}
+
+# pin a file to Pinata, echo the CID
+pin_md() {
+  local md="$1"
+  if [ "${PIN_DRY_RUN:-0}" = "1" ]; then
+    local h
+    if command -v sha256sum >/dev/null 2>&1; then
+      h="$(printf '%s' "$md" | sha256sum | cut -c1-24)"
+    else
+      h="$(printf '%s' "$md" | shasum -a 256 | cut -c1-24)"
+    fi
+    printf 'bafkreidryrun%s' "$h"
+    return 0
+  fi
+  : "${PINATA_JWT:?PINATA_JWT must be set (or use PIN_DRY_RUN=1)}"
+  local resp cid
+  resp="$(curl -fsS -X POST https://api.pinata.cloud/pinning/pinFileToIPFS \
+    -H "Authorization: Bearer ${PINATA_JWT}" \
+    -F "file=@${md}" \
+    -F 'pinataOptions={"cidVersion":1}' \
+    -F "pinataMetadata={\"name\":\"$(basename "$md")\"}")" ||
+    { err "Pinata request failed for $md"; return 1; }
+  cid="$(printf '%s' "$resp" | jq -r '.IpfsHash // empty')"
+  [ -n "$cid" ] || { err "no IpfsHash in Pinata response for $md: $resp"; return 1; }
+  printf '%s' "$cid"
+}
+
+# write descriptionUri into the entry identified by its raw path. Writes in
+# place (truncate + rewrite) rather than mv so the file's existing mode is
+# preserved (mips.json is tracked executable; avoid a spurious mode change).
+write_uri() {
+  local path_key="$1" uri="$2" tmp
+  tmp="$(mktemp)"
+  jq --indent 4 --arg p "$path_key" --arg uri "$uri" \
+    'map(if .path == $p then . + {descriptionUri: $uri} else . end)' \
+    "$MIPS_JSON" >"$tmp"
+  cat "$tmp" >"$MIPS_JSON"
+  rm -f "$tmp"
+}
+
+# ---- collect candidate changed .md files ----------------------------------
+CANDIDATES=()
+if [ "$#" -gt 0 ]; then
+  CANDIDATES=("$@")
+else
+  while IFS= read -r f; do
+    [ -n "$f" ] && CANDIDATES+=("$f")
+  done < <(git diff --name-only --diff-filter=d "$BASE_REF" -- 'proposals/mips' |
+    grep -E '\.md$' || true)
+fi
+
+if [ "${#CANDIDATES[@]}" -eq 0 ]; then
+  log "No changed proposal markdown files; nothing to pin."
+  exit 0
+fi
+
+# ---- pin each candidate that maps to an in-development entry ---------------
+pinned=0
+for c in "${CANDIDATES[@]}"; do
+  cn="$(norm "$c")"
+  case "$cn" in
+    proposals/mips/*.md) ;;
+    *) continue ;;
+  esac
+  [ -f "$cn" ] || { log "skip $cn (file not found)"; continue; }
+
+  match=""
+  while IFS=$'\t' read -r rawpath md; do
+    if [ "$md" = "$cn" ]; then match="$rawpath"; break; fi
+  done < <(id0_entries)
+
+  if [ -z "$match" ]; then
+    log "skip $cn (no in-development mips.json entry references it)"
+    continue
+  fi
+
+  cid="$(pin_md "$cn")" || exit 1
+  write_uri "$match" "ipfs://$cid"
+  log "pinned $cn -> ipfs://$cid  (mips.json entry: $match)"
+  pinned=$((pinned + 1))
+done
+
+log "Done. Updated descriptionUri for $pinned proposal(s)."

--- a/test/unit/HybridProposalV2DescriptionUri.t.sol
+++ b/test/unit/HybridProposalV2DescriptionUri.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+
+import "@forge-std/Test.sol";
+
+import {HybridProposalV2} from "@proposals/proposalTypes/HybridProposalV2.sol";
+import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
+
+/// @notice Minimal concrete HybridProposalV2 used only to exercise how the
+/// proposal resolves the `descriptionUri` argument for propose().
+contract DescUriHarness is HybridProposalV2 {
+    function name() external pure override returns (string memory) {
+        return "TEST-DESC-URI";
+    }
+
+    function primaryForkId() public pure override returns (uint256) {
+        return 0;
+    }
+
+    function validate(Addresses, address) public override {}
+
+    function setMarkdown(string memory md) external {
+        _setProposalDescription(bytes(md));
+    }
+
+    function proposeDescription() external view returns (string memory) {
+        return _proposeDescription();
+    }
+}
+
+contract HybridProposalV2DescriptionUriTest is Test {
+    DescUriHarness internal harness;
+
+    function setUp() public {
+        harness = new DescUriHarness();
+        harness.setMarkdown("# Full markdown body");
+    }
+
+    function test_defaultsToMarkdownWhenNoUri() public {
+        assertEq(harness.proposeDescription(), "# Full markdown body");
+    }
+
+    function test_usesIpfsUriWhenSet() public {
+        harness.setProposalDescriptionUri("ipfs://bafytest");
+        assertEq(harness.proposeDescription(), "ipfs://bafytest");
+    }
+
+    function test_emptyUriFallsBackToMarkdown() public {
+        harness.setProposalDescriptionUri("");
+        assertEq(harness.proposeDescription(), "# Full markdown body");
+    }
+}

--- a/test/unit/ProposalMapParse.t.sol
+++ b/test/unit/ProposalMapParse.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+
+import "@forge-std/Test.sol";
+
+import {ProposalMap} from "@test/utils/ProposalMap.sol";
+
+/// @notice Characterization test for ProposalMap's per-element mips.json parse.
+/// It must read the real registry identically to the prior bulk abi.decode and
+/// expose the optional `descriptionUri` without disturbing entries that lack it.
+contract ProposalMapParseTest is Test {
+    ProposalMap internal map;
+
+    function setUp() public {
+        map = new ProposalMap();
+    }
+
+    function test_parsesKnownMultichainProposalById() public {
+        (string memory path, string memory envPath) = map.getProposalById(167);
+        assertEq(
+            path,
+            "artifacts/foundry/mip-x57.sol/mipx57.json",
+            "mip-x57 path"
+        );
+        assertEq(envPath, "proposals/mips/mip-x57/x57.sh", "mip-x57 envPath");
+    }
+
+    function test_inDevelopmentIncludesMipE00() public {
+        ProposalMap.ProposalFields[] memory dev = map
+            .getAllProposalsInDevelopment();
+
+        bool sawE00;
+        for (uint256 i = 0; i < dev.length; i++) {
+            if (
+                keccak256(bytes(dev[i].path)) ==
+                keccak256(bytes("artifacts/foundry/mip-e00.sol/mipe00.json"))
+            ) {
+                sawE00 = true;
+                assertEq(dev[i].id, 0, "mip-e00 id");
+                assertEq(dev[i].governor, "MultichainGovernorV2", "governor");
+                assertEq(dev[i].proposalType, "HybridProposalV2", "ptype");
+                assertEq(bytes(dev[i].envPath).length, 0, "mip-e00 envPath");
+            }
+        }
+        assertTrue(sawE00, "mip-e00 should be in development");
+    }
+
+    function test_descriptionUriAbsentByDefault() public {
+        // no entry currently carries descriptionUri => empty string
+        assertEq(
+            map.getProposalDescriptionUri(
+                "artifacts/foundry/mip-e00.sol/mipe00.json"
+            ),
+            ""
+        );
+    }
+}

--- a/test/utils/ProposalMap.sol
+++ b/test/utils/ProposalMap.sol
@@ -25,6 +25,12 @@ contract ProposalMap is Script {
 
     mapping(string path => uint256) private proposalPathToIndex;
 
+    /// @notice optional IPFS description URI (e.g. ipfs://<cid>) keyed by the
+    /// prefixed artifact path that runProposal receives. Sourced from the
+    /// optional `descriptionUri` field in mips.json. Absent => "" => the
+    /// proposal falls back to its raw markdown description.
+    mapping(string path => string) private proposalPathToUri;
+
     constructor() {
         string memory data = vm.readFile(
             string(
@@ -32,16 +38,64 @@ contract ProposalMap is Script {
             )
         );
 
-        bytes memory parsedJson = vm.parseJson(data);
+        // Parse entries one-by-one instead of abi.decode'ing the whole array
+        // into ProposalFields[]. The `descriptionUri` field is OPTIONAL (present
+        // on only some entries), and forge's whole-file parse silently
+        // misaligns every field of any entry that carries an extra key. Reading
+        // each field by its explicit JSON path is immune to that, and lets the
+        // optional key simply be absent. The loop terminates when an index is
+        // out of bounds (keyExistsJson returns false rather than reverting).
+        uint256 i = 0;
+        while (
+            vm.keyExistsJson(
+                data,
+                string.concat(".[", vm.toString(i), "].path")
+            )
+        ) {
+            _addProposalFromJson(data, i);
+            i++;
+        }
+    }
 
-        ProposalFields[] memory jsonProposals = abi.decode(
-            parsedJson,
-            (ProposalFields[])
+    /// @notice read a single mips.json entry by index and register it
+    function _addProposalFromJson(string memory data, uint256 index) internal {
+        string memory base = string.concat(".[", vm.toString(index), "]");
+
+        ProposalFields memory proposal;
+        proposal.envPath = _readEnvPath(data, base);
+        proposal.governor = data.readString(string.concat(base, ".governor"));
+        proposal.id = data.readUint(string.concat(base, ".id"));
+        proposal.path = data.readString(string.concat(base, ".path"));
+        proposal.proposalType = data.readString(
+            string.concat(base, ".proposalType")
         );
 
-        for (uint256 i = 0; i < jsonProposals.length; i++) {
-            addProposal(jsonProposals[i]);
+        addProposal(proposal);
+
+        // optional IPFS description URI — keyed by the prefixed artifact path so
+        // runProposal can look it up directly
+        string memory uriKey = string.concat(base, ".descriptionUri");
+        if (vm.keyExistsJson(data, uriKey)) {
+            proposalPathToUri[
+                string(abi.encodePacked("artifacts/foundry/", proposal.path))
+            ] = data.readString(uriKey);
         }
+    }
+
+    /// @notice read an entry's env path, tolerating the historical
+    /// `envpath`/`envPath` casing drift in mips.json
+    function _readEnvPath(
+        string memory data,
+        string memory base
+    ) internal view returns (string memory) {
+        string memory key = string.concat(base, ".envpath");
+        if (!vm.keyExistsJson(data, key)) {
+            key = string.concat(base, ".envPath");
+            if (!vm.keyExistsJson(data, key)) {
+                return "";
+            }
+        }
+        return data.readString(key);
     }
 
     function addProposal(ProposalFields memory proposal) public {
@@ -84,6 +138,14 @@ contract ProposalMap is Script {
     ) public view returns (uint256 proposalId, string memory envPath) {
         ProposalFields memory proposal = proposals[proposalPathToIndex[path]];
         return (proposal.id, proposal.envPath);
+    }
+
+    /// @notice optional IPFS description URI for a (prefixed artifact) path;
+    /// empty string when the mips.json entry has no `descriptionUri`
+    function getProposalDescriptionUri(
+        string memory path
+    ) public view returns (string memory) {
+        return proposalPathToUri[path];
     }
 
     function getAllProposalsInDevelopment()
@@ -215,6 +277,10 @@ contract ProposalMap is Script {
 
         proposal = Proposal(deployCode(proposalPath));
         vm.makePersistent(address(proposal));
+
+        // inject the optional pinned IPFS description URI (no-op / falls back to
+        // raw markdown when the entry has no descriptionUri in mips.json)
+        proposal.setProposalDescriptionUri(proposalPathToUri[proposalPath]);
 
         vm.selectFork(proposal.primaryForkId());
 


### PR DESCRIPTION
## What & why

`MultichainGovernorV2.propose()` takes a `string descriptionUri` argument (V1 used `description`). Today the tooling shoves the **entire description markdown** into that slot, so the full text lands in calldata + on-chain storage. That bloats `propose()` — which matters for Moonbeam's **2²⁴ per-tx gas cap** — and isn't what the V2 parameter was designed for.

This PR adds an **optional** step: pin a proposal's description `.md` to IPFS (Pinata), record `ipfs://<cid>` in `mips.json`, and have the proposal framework emit that URI as `descriptionUri` instead of the raw markdown. When no hash is present it **falls back to the markdown**, so existing proposals, tests, and CI are unaffected and never depend on Pinata.

## How it works (end to end)

```
proposal .md changes
   │
   ▼
[CI] pin-proposal-description.yml  ──>  script/proposals/pin-descriptions.sh
   │     pins the .md to Pinata (JWT), writes ipfs://<cid> into that
   │     proposal's mips.json entry (descriptionUri), commits back to the PR
   ▼
mips.json:  { ..., "path": "mip-e00.sol/mipe00.json", "descriptionUri": "ipfs://bafy…" }
   │
   ▼
[Solidity] ProposalMap parses the optional descriptionUri and, in runProposal(),
           calls proposal.setProposalDescriptionUri(uri) before simulate()
   │
   ▼
HybridProposalV2._proposeDescription()  →  ipfs://<cid>  (else raw markdown)
           used in getCalldata() (submission) and the in-fork simulation
   │
   ▼
MultichainGovernorV2.propose(targets, values, calldatas, "ipfs://<cid>", true)
```

Both the **real submission calldata** (`script/CalldataPrinting.s.sol` → `printCalldata`) and the **simulation** (`PostProposalCheck`) flow through `ProposalMap.runProposal`, so both pick up the URI from the single injection point.

## Pieces

| Area | Change |
|------|--------|
| `proposals/Proposal.sol` | `setProposalDescriptionUri(string)` — virtual **no-op** (V1 / other types ignore it). |
| `proposals/proposalTypes/HybridProposalV2.sol` | `PROPOSAL_DESCRIPTION_URI` + setter; `_proposeDescription()` resolver; used in `getCalldata()` and the sim. |
| `test/utils/ProposalMap.sol` | Per-element `mips.json` parse + optional `descriptionUri`; inject via the setter in `runProposal`. |
| `script/proposals/pin-descriptions.sh` + `make pin-descriptions` | Resolve changed `.md` → entry, pin to Pinata (JWT), write `ipfs://<cid>`. |
| `.github/workflows/pin-proposal-description.yml` | Auto-pin + commit on `proposals/mips/**/*.md` change. |
| `test/unit/*` | Unit tests for the resolver and the `mips.json` parse. |

## Design choices

- **V2 only.** V2's parameter is literally `descriptionUri`; V1's is `description` (semantically full text), so V1 stays on raw markdown.
- **Optional field in `mips.json`, no edits to existing entries** (as requested). This forced a real change: forge's whole-file `abi.decode(vm.parseJson(...), (ProposalFields[]))` **silently corrupts** any entry that carries an extra key (the extra key sorts in and shifts every field — verified with a spike). So `ProposalMap` now reads each entry field-by-field via `vm.keyExistsJson` + `stdJson`, which makes `descriptionUri` cleanly optional and also removes the old alphabetical-struct-order footgun. The `envpath`/`envPath` casing drift is handled explicitly.
- **Fallback to markdown** keeps everything backwards compatible and means tests never need Pinata.
- **CI auto-pins and commits, only on `.md` change** (as requested). Triggers on `proposals/mips/**/*.md`; processes only `id: 0` (not-yet-submitted) proposals — a submitted proposal's `descriptionUri` is already immutable on-chain.
- **Idempotent.** Pinata is content-addressed: unchanged markdown re-pins to the same CID → no `mips.json` diff → no commit → no loop. Writes in place to preserve `mips.json`'s tracked file mode.
- **Auth: Pinata JWT** (`Authorization: Bearer`). URI format: **`ipfs://<cid>`** (your frontend's existing `ipfs://` gateway helpers resolve it).

## Setup required

- Add repo secret **`PINATA_JWT`**.
- Optional: **`PIN_BOT_TOKEN`** (PAT) for checkout/push. A push made with the default `GITHUB_TOKEN` does **not** retrigger other workflows, so the calldata-printing job won't auto-rerun on the bot's commit; with a PAT the `descriptionUri` commit retriggers CI so the printed calldata reflects the URI in the same PR. Without it, the URI still lands in `mips.json` — just regenerate calldata after the commit. Fork PRs are skipped (no secret access).

## Testing

- ✅ `forge build` (full) — no ripple from the `Proposal` base-class change across ~140 proposals.
- ✅ Unit: `_proposeDescription()` resolver (URI when set, markdown when unset/empty) and `ProposalMap` per-element parse (reads the real `mips.json`: `mip-x57` id 167, `mip-e00` in-dev V2, optional `descriptionUri`).
- ✅ `pin-descriptions.sh` dry-run: resolves `mip-e00` → entry, writes a minimal one-line diff, idempotent, preserves file mode, skips non-proposal `.md`.
- ✅ Workflow YAML validated; `jq --indent 4` round-trips `mips.json` with a 0-line diff (clean edits).
- ⏳ **On-fork end-to-end** (governor actually receiving `ipfs://…` as `descriptionUri` in simulate + printed calldata) runs in the **CI integration matrix** — it needs RPC secrets, so it couldn't be exercised locally.

## Notes / follow-ups

- Running a proposal standalone via `forge script proposals/mips/.../mip-xNN.sol` bypasses `ProposalMap`, so it falls back to markdown; the authoritative calldata (`CalldataPrinting.s.sol`) goes through `ProposalMap` and gets the URI.
- First real consumer: pin `mip-e00`'s description (`PINATA_JWT=… make pin-descriptions FILES=proposals/mips/mip-e00/MIP-E00.md`) — not done here since this env has no Pinata creds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
