### PR TITLE
MIP-E01: native ETH redeem/borrow for Ethereum MOONWELL_WETH

### DIFF
--- a/chains/1.json
+++ b/chains/1.json
@@ -358,5 +358,15 @@
         "addr": "0x86A1f72ffEAfd397eAd099a5A359Fe81749351B5",
         "isContract": true,
         "name": "CHAINLINK_CBBTC_USD_OEV_WRAPPER"
+    },
+    {
+        "addr": "0x4605dA8b6B0d8d8aC4389606eA135e27b61DA2f6",
+        "isContract": true,
+        "name": "WETH_UNWRAPPER"
+    },
+    {
+        "addr": "0x9b1eeac01DED2155D93A23E9Dd5E99954f1021fe",
+        "isContract": true,
+        "name": "MWETH_IMPLEMENTATION"
     }
 ]

--- a/proposals/mips/mip-e01/MIP-E01.md
+++ b/proposals/mips/mip-e01/MIP-E01.md
@@ -1,18 +1,14 @@
-# MIP-E01: Moonwell WETH Market Improvement (Ethereum)
+# MIP-E01: Moonwell WETH Market Improvement
 
 ## Summary
 
-MIP-E01 enhances the user experience of the WETH market on Moonwell's Ethereum
+This MIP enhances the user experience of the WETH market on Moonwell's Ethereum
 deployment. Today, users who redeem their mWETH or borrow from the WETH market
 receive Wrapped ETH (WETH) rather than native ETH, forcing them to manually
 unwrap before using their funds elsewhere in the Ethereum ecosystem. This
 proposal points the WETH market's logic contract at an `MWethDelegate`
 implementation so that redemptions and borrows pay out raw ETH directly, as part
 of the same transaction.
-
-Native ETH deposits and repayments are already supported on Ethereum through the
-`WETHRouter` contract deployed in MIP-E00; MIP-E01 completes the experience by
-adding the redeem and borrow side.
 
 ## Motivation
 
@@ -37,11 +33,6 @@ is executed:
 2. **MWethDelegate Contract:** A new logic contract for the WETH market that
    overrides `doTransferOut` to route the underlying WETH through the
    `WethUnwrapper` before it reaches the user.
-3. **Set Implementation:** The Multichain Governor (the admin of the Ethereum
-   WETH market, established in MIP-E00) calls `_setImplementation` on the WETH
-   `MErc20Delegator`, repointing it from the standard delegate to the new
-   `MWethDelegate`. The market's admin, underlying, reserves, and all market
-   state are unchanged — only the logic contract is swapped.
 
 The `MWethDelegate` and `WethUnwrapper` contracts are the same designs already
 audited and deployed on Base as part of MIP-B02. Moonwell's audit reports are
@@ -52,11 +43,4 @@ available [here](https://docs.moonwell.fi/moonwell/protocol-information/audits).
 - **Yes:** Support enabling native ETH redemptions and borrows on the Ethereum
   WETH market.
 - **No:** Keep the status quo (redemptions and borrows paid out in WETH).
-
-## Conclusion
-
-MIP-E01 streamlines the WETH market on Moonwell's Ethereum deployment by
-deploying the `MWethDelegate` and `WethUnwrapper` contracts and repointing the
-WETH market's logic contract. Together with the native-ETH deposit and repay
-support already live via the `WETHRouter`, this gives Ethereum users a complete
-native-ETH experience for the WETH market.
+- **Abstain:** Remain neutral.

--- a/proposals/mips/mip-e01/MIP-E01.md
+++ b/proposals/mips/mip-e01/MIP-E01.md
@@ -1,0 +1,62 @@
+# MIP-E01: Moonwell WETH Market Improvement (Ethereum)
+
+## Summary
+
+MIP-E01 enhances the user experience of the WETH market on Moonwell's Ethereum
+deployment. Today, users who redeem their mWETH or borrow from the WETH market
+receive Wrapped ETH (WETH) rather than native ETH, forcing them to manually
+unwrap before using their funds elsewhere in the Ethereum ecosystem. This
+proposal points the WETH market's logic contract at an `MWethDelegate`
+implementation so that redemptions and borrows pay out raw ETH directly, as part
+of the same transaction.
+
+Native ETH deposits and repayments are already supported on Ethereum through the
+`WETHRouter` contract deployed in MIP-E00; MIP-E01 completes the experience by
+adding the redeem and borrow side.
+
+## Motivation
+
+This proposal brings the Ethereum WETH market in line with the existing Base
+deployment (MIP-B02) and delivers two user-facing improvements:
+
+1. **Redemptions and borrows in native ETH:** Users redeeming mWETH and
+   borrowers drawing from the WETH market will receive raw ETH directly,
+   eliminating the manual unwrap step.
+2. **Integrated WETH unwrapping:** A dedicated `WethUnwrapper` contract converts
+   WETH to ETH transparently and forwards it to the end user as part of the
+   protocol's existing transfer-out flow.
+
+## Implementation Details
+
+Two contracts are deployed as part of this proposal, and one governance action
+is executed:
+
+1. **WethUnwrapper Contract:** A minimal, immutable contract that receives WETH
+   from the WETH market, calls `withdraw` to convert it to raw ETH, and forwards
+   the ETH to the recipient. It only accepts ETH from the WETH contract.
+2. **MWethDelegate Contract:** A new logic contract for the WETH market that
+   overrides `doTransferOut` to route the underlying WETH through the
+   `WethUnwrapper` before it reaches the user.
+3. **Set Implementation:** The Multichain Governor (the admin of the Ethereum
+   WETH market, established in MIP-E00) calls `_setImplementation` on the WETH
+   `MErc20Delegator`, repointing it from the standard delegate to the new
+   `MWethDelegate`. The market's admin, underlying, reserves, and all market
+   state are unchanged — only the logic contract is swapped.
+
+The `MWethDelegate` and `WethUnwrapper` contracts are the same designs already
+audited and deployed on Base as part of MIP-B02. Moonwell's audit reports are
+available [here](https://docs.moonwell.fi/moonwell/protocol-information/audits).
+
+## Voting Options
+
+- **Yes:** Support enabling native ETH redemptions and borrows on the Ethereum
+  WETH market.
+- **No:** Keep the status quo (redemptions and borrows paid out in WETH).
+
+## Conclusion
+
+MIP-E01 streamlines the WETH market on Moonwell's Ethereum deployment by
+deploying the `MWethDelegate` and `WethUnwrapper` contracts and repointing the
+WETH market's logic contract. Together with the native-ETH deposit and repay
+support already live via the `WETHRouter`, this gives Ethereum users a complete
+native-ETH experience for the WETH market.

--- a/proposals/mips/mip-e01/mip-e01.sol
+++ b/proposals/mips/mip-e01/mip-e01.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.19;
 
 import "@forge-std/Test.sol";
 
+import {MToken} from "@protocol/MToken.sol";
 import {Configs} from "@proposals/Configs.sol";
 import {WETHRouter} from "@protocol/router/WETHRouter.sol";
 import {ETHEREUM_FORK_ID} from "@utils/ChainIds.sol";
@@ -31,6 +32,14 @@ export DO_VALIDATE=true
 
 contract mipe01 is HybridProposalV2, Configs {
     string public constant override name = "MIP-E01";
+
+    /// @notice pre-swap snapshots of storage-backed market state, captured in
+    /// afterDeploy() (which runs before simulate() executes the implementation
+    /// swap) and asserted unchanged in validate(). The MWethDelegate swap only
+    /// overrides doTransferOut and adds an immutable, so neither value should
+    /// move — this guards against an accidental storage reset during the swap.
+    uint256 public preSwapExchangeRateStored;
+    uint256 public preSwapTotalReserves;
 
     constructor() {
         bytes memory proposalDescription = abi.encodePacked(
@@ -65,6 +74,15 @@ contract mipe01 is HybridProposalV2, Configs {
 
             addresses.addAddress("MWETH_IMPLEMENTATION", address(mWethLogic));
         }
+    }
+
+    /// @notice snapshot pre-swap market state on the Ethereum fork (impl is still
+    /// the stock MErc20Delegate here) so validate() can assert the swap left
+    /// storage-backed values untouched. Runs before build()/simulate().
+    function afterDeploy(Addresses addresses, address) public override {
+        MToken mWeth = MToken(addresses.getAddress("MOONWELL_WETH"));
+        preSwapExchangeRateStored = mWeth.exchangeRateStored();
+        preSwapTotalReserves = mWeth.totalReserves();
     }
 
     function build(Addresses addresses) public override {
@@ -153,5 +171,20 @@ contract mipe01 is HybridProposalV2, Configs {
             addresses.getAddress("MULTICHAIN_GOVERNOR_V2_PROXY"),
             "MOONWELL_WETH admin changed"
         ); /// ensure the MultichainGovernorV2 is still admin
+
+        /// the implementation swap must leave storage-backed market state
+        /// untouched — exchangeRate and reserves are read from the same slots
+        /// before (afterDeploy) and after the swap, so they must be identical.
+        MToken mWethToken = MToken(addresses.getAddress("MOONWELL_WETH"));
+        assertEq(
+            mWethToken.exchangeRateStored(),
+            preSwapExchangeRateStored,
+            "exchangeRateStored changed by implementation swap"
+        );
+        assertEq(
+            mWethToken.totalReserves(),
+            preSwapTotalReserves,
+            "totalReserves changed by implementation swap"
+        );
     }
 }

--- a/proposals/mips/mip-e01/mip-e01.sol
+++ b/proposals/mips/mip-e01/mip-e01.sol
@@ -1,0 +1,157 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+
+import "@forge-std/Test.sol";
+
+import {Configs} from "@proposals/Configs.sol";
+import {WETHRouter} from "@protocol/router/WETHRouter.sol";
+import {ETHEREUM_FORK_ID} from "@utils/ChainIds.sol";
+import {WethUnwrapper} from "@protocol/WethUnwrapper.sol";
+import {MWethDelegate} from "@protocol/MWethDelegate.sol";
+import {HybridProposalV2} from "@proposals/proposalTypes/HybridProposalV2.sol";
+import {MErc20Delegator} from "@protocol/MErc20Delegator.sol";
+import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
+
+/// @notice MIP-E01 — enable native ETH redeem/borrow on the Ethereum MOONWELL_WETH market.
+/// Points the WETH mToken delegator implementation at MWethDelegate, which overrides
+/// `doTransferOut` to forward the underlying WETH to a WethUnwrapper that withdraws raw
+/// ETH and sends it to the user. Deposit and repay in native ETH already work via the
+/// WETH_ROUTER deployed in MIP-E00; this proposal completes the redeem/borrow side.
+///
+/// how to generate calldata / run a standalone simulation against a mainnet fork:
+/*
+export DO_DEPLOY=true
+export DO_AFTER_DEPLOY=false
+export DO_BUILD=true
+export DO_RUN=true
+export DO_TEARDOWN=false
+export DO_VALIDATE=true
+*/
+/// forge script proposals/mips/mip-e01/mip-e01.sol:mipe01 --rpc-url ethereum -vvv
+
+contract mipe01 is HybridProposalV2, Configs {
+    string public constant override name = "MIP-E01";
+
+    constructor() {
+        bytes memory proposalDescription = abi.encodePacked(
+            vm.readFile("./proposals/mips/mip-e01/MIP-E01.md")
+        );
+
+        _setProposalDescription(proposalDescription);
+
+        nonce = 2;
+    }
+
+    function primaryForkId() public pure override returns (uint256) {
+        return ETHEREUM_FORK_ID;
+    }
+
+    /// @notice deploy the WethUnwrapper and the MWethDelegate logic contract on Ethereum.
+    /// Both are inert until governance points the WETH market at the new implementation
+    /// in build().
+    function deploy(Addresses addresses, address) public override {
+        if (!addresses.isAddressSet("WETH_UNWRAPPER")) {
+            WethUnwrapper unwrapper = new WethUnwrapper(
+                addresses.getAddress("WETH")
+            );
+
+            addresses.addAddress("WETH_UNWRAPPER", address(unwrapper));
+        }
+
+        if (!addresses.isAddressSet("MWETH_IMPLEMENTATION")) {
+            MWethDelegate mWethLogic = new MWethDelegate(
+                addresses.getAddress("WETH_UNWRAPPER")
+            );
+
+            addresses.addAddress("MWETH_IMPLEMENTATION", address(mWethLogic));
+        }
+    }
+
+    function build(Addresses addresses) public override {
+        /// point the WETH mToken to the new MWethDelegate logic contract.
+        /// MOONWELL_WETH.admin() is MULTICHAIN_GOVERNOR_V2_PROXY on Ethereum
+        /// (transferred to the governor in MIP-E00), which is the executor of
+        /// this HybridProposalV2 — so the admin-gated _setImplementation call
+        /// succeeds.
+        _pushAction(
+            addresses.getAddress("MOONWELL_WETH"),
+            abi.encodeWithSignature(
+                "_setImplementation(address,bool,bytes)",
+                addresses.getAddress("MWETH_IMPLEMENTATION"),
+                true,
+                ""
+            ),
+            "Point Moonwell WETH (Ethereum) to the MWethDelegate logic contract"
+        );
+    }
+
+    function teardown(Addresses addresses, address) public pure override {}
+
+    /// @notice assert the WETH market is wired to the unwrapping delegate and that the
+    /// deposit-side router and admin are unchanged.
+    function validate(Addresses addresses, address) public override {
+        assertTrue(
+            addresses.getAddress("MOONWELL_WETH") != address(0),
+            "MOONWELL_WETH not set"
+        );
+        assertTrue(
+            addresses.getAddress("WETH_UNWRAPPER") != address(0),
+            "WETH_UNWRAPPER not set"
+        );
+        assertTrue(
+            addresses.getAddress("MWETH_IMPLEMENTATION") != address(0),
+            "MWETH_IMPLEMENTATION not set"
+        );
+
+        /// the unwrapper references the canonical WETH
+        assertEq(
+            WethUnwrapper(payable(addresses.getAddress("WETH_UNWRAPPER")))
+                .weth(),
+            addresses.getAddress("WETH"),
+            "WETH_UNWRAPPER weth mismatch"
+        );
+
+        /// the new delegate references the deployed unwrapper
+        assertEq(
+            MWethDelegate(addresses.getAddress("MWETH_IMPLEMENTATION"))
+                .wethUnwrapper(),
+            addresses.getAddress("WETH_UNWRAPPER"),
+            "MWETH_IMPLEMENTATION unwrapper mismatch"
+        );
+
+        /// deposit/repay-in-ETH path: WETH_ROUTER (deployed in MIP-E00) stays wired to
+        /// this market
+        assertTrue(
+            addresses.getAddress("WETH_ROUTER") != address(0),
+            "WETH_ROUTER not set"
+        );
+        WETHRouter router = WETHRouter(
+            payable(addresses.getAddress("WETH_ROUTER"))
+        );
+        assertEq(
+            address(router.weth()),
+            addresses.getAddress("WETH"),
+            "WETH_ROUTER weth not set"
+        );
+        assertEq(
+            address(router.mToken()),
+            addresses.getAddress("MOONWELL_WETH"),
+            "WETH_ROUTER mToken not set"
+        );
+
+        /// the WETH market now points to the MWethDelegate, admin unchanged
+        MErc20Delegator mWeth = MErc20Delegator(
+            payable(addresses.getAddress("MOONWELL_WETH"))
+        );
+        assertEq(
+            mWeth.implementation(),
+            addresses.getAddress("MWETH_IMPLEMENTATION"),
+            "MOONWELL_WETH implementation not correctly set"
+        );
+        assertEq(
+            mWeth.admin(),
+            addresses.getAddress("MULTICHAIN_GOVERNOR_V2_PROXY"),
+            "MOONWELL_WETH admin changed"
+        ); /// ensure the MultichainGovernorV2 is still admin
+    }
+}

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -4,7 +4,8 @@
         "governor": "MultichainGovernorV2",
         "id": 0,
         "path": "mip-e01.sol/mipe01.json",
-        "proposalType": "HybridProposalV2"
+        "proposalType": "HybridProposalV2",
+        "descriptionUri": "ipfs://bafkreibrmekm7lyfg52li5lyznrvupmab74a3kzimfcsxhweyppvhxkdbq"
     },
     {
         "envpath": "",

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -2,7 +2,7 @@
     {
         "envpath": "",
         "governor": "MultichainGovernorV2",
-        "id": 170,
+        "id": 171,
         "path": "mip-e01.sol/mipe01.json",
         "proposalType": "HybridProposalV2",
         "descriptionUri": "ipfs://bafkreidapswqy4yz5endthvzxzydxhlnzhnrpg77zah7kaa6olxn5fxkne"

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -5,7 +5,7 @@
         "id": 0,
         "path": "mip-e01.sol/mipe01.json",
         "proposalType": "HybridProposalV2",
-        "descriptionUri": "ipfs://bafkreibrmekm7lyfg52li5lyznrvupmab74a3kzimfcsxhweyppvhxkdbq"
+        "descriptionUri": "ipfs://bafkreidapswqy4yz5endthvzxzydxhlnzhnrpg77zah7kaa6olxn5fxkne"
     },
     {
         "envpath": "",

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -2,6 +2,13 @@
     {
         "envpath": "",
         "governor": "MultichainGovernorV2",
+        "id": 0,
+        "path": "mip-e01.sol/mipe01.json",
+        "proposalType": "HybridProposalV2"
+    },
+    {
+        "envpath": "",
+        "governor": "MultichainGovernorV2",
         "id": 169,
         "path": "mip-e00.sol/mipe00.json",
         "proposalType": "HybridProposalV2",

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -2,7 +2,7 @@
     {
         "envpath": "",
         "governor": "MultichainGovernorV2",
-        "id": 0,
+        "id": 170,
         "path": "mip-e01.sol/mipe01.json",
         "proposalType": "HybridProposalV2",
         "descriptionUri": "ipfs://bafkreidapswqy4yz5endthvzxzydxhlnzhnrpg77zah7kaa6olxn5fxkne"

--- a/test/integration/SupplyBorrowIntegration.t.sol
+++ b/test/integration/SupplyBorrowIntegration.t.sol
@@ -324,14 +324,10 @@ contract SupplyBorrowLiveSystem is Test, PostProposalCheck {
 
         IERC20 token = IERC20(MErc20(address(mToken)).underlying());
 
-        /// Base/Optimism back MOONWELL_WETH with MWethDelegate, which unwraps
-        /// to native ETH on borrow — so the borrower's native balance grows.
-        /// Ethereum's MIP-E00 WETH market uses the plain MErc20Delegate, which
-        /// transfers WETH ERC20 instead, leaving the native balance untouched.
-        if (
-            address(token) == addresses.getAddress("WETH") &&
-            block.chainid != ETHEREUM_CHAIN_ID
-        ) {
+        /// All chains back MOONWELL_WETH with MWethDelegate, which unwraps to
+        /// native ETH on borrow — so the borrower's native balance grows.
+        /// Ethereum joined this path in MIP-E01 (Base/Optimism via MIP-B02).
+        if (address(token) == addresses.getAddress("WETH")) {
             assertEq(
                 sender.balance - balanceBefore,
                 borrowAmount,
@@ -966,25 +962,16 @@ contract SupplyBorrowLiveSystem is Test, PostProposalCheck {
 
         mToken.redeem(type(uint256).max);
 
-        /// Base/Optimism MWethDelegate unwraps to native ETH on redeem; the
-        /// Ethereum MIP-E00 WETH market is a plain MErc20Delegate that returns
-        /// WETH ERC20 instead, so the redeemed value lands in the WETH balance
-        /// rather than the native balance.
-        if (block.chainid == ETHEREUM_CHAIN_ID) {
-            assertApproxEqRel(
-                weth.balanceOf(address(this)),
-                mintAmount,
-                1e15, /// tiny loss due to rounding down
-                "incorrect test contract weth value after redeem"
-            );
-        } else {
-            assertApproxEqRel(
-                address(this).balance,
-                mintAmount,
-                1e15, /// tiny loss due to rounding down
-                "incorrect test contract eth value after redeem"
-            );
-        }
+        /// All chains back MOONWELL_WETH with MWethDelegate, which unwraps to
+        /// native ETH on redeem — so the redeemed value lands in the native
+        /// balance. Ethereum joined this path in MIP-E01 (Base/Optimism via
+        /// MIP-B02).
+        assertApproxEqRel(
+            address(this).balance,
+            mintAmount,
+            1e15, /// tiny loss due to rounding down
+            "incorrect test contract eth value after redeem"
+        );
         assertApproxEqRel(
             startingMTokenWethBalance,
             weth.balanceOf(address(mToken)),

--- a/test/integration/WETHPostProposalCheckEthereumIntegration.t.sol
+++ b/test/integration/WETHPostProposalCheckEthereumIntegration.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+
+import {IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+import "@forge-std/Test.sol";
+
+import {MErc20} from "@protocol/MErc20.sol";
+import {MToken} from "@protocol/MToken.sol";
+import {Configs} from "@proposals/Configs.sol";
+import {WETHRouter} from "@protocol/router/WETHRouter.sol";
+import {Comptroller} from "@protocol/Comptroller.sol";
+import {WethUnwrapper} from "@protocol/WethUnwrapper.sol";
+import {MWethDelegate} from "@protocol/MWethDelegate.sol";
+import {MErc20Delegator} from "@protocol/MErc20Delegator.sol";
+import {PostProposalCheck} from "@test/integration/PostProposalCheck.sol";
+import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
+import {ETHEREUM_FORK_ID} from "@utils/ChainIds.sol";
+
+/// @notice Ethereum-fork mirror of WETHPostProposalCheck (Base). MIP-E01 is
+/// registered with id:0 in mips.json, so PostProposalCheck.setUp() auto-simulates
+/// it on the Ethereum fork — repointing MOONWELL_WETH at a freshly deployed
+/// MWethDelegate wired to a WethUnwrapper. Unlike the Base test (which manually
+/// deploys + wires the delegate because MIP-B02 is not re-simulated), these tests
+/// assert the proposal itself produced correct per-chain wiring (right WETH
+/// address, right unwrapper constructor arg) and that redeem pays out native ETH
+/// on Ethereum.
+contract WETHPostProposalCheckEthereum is Configs, PostProposalCheck {
+    Comptroller comptroller;
+    MErc20Delegator mToken;
+    WETHRouter router;
+    bool ethReceived;
+
+    function setUp() public override {
+        super.setUp();
+
+        vm.selectFork(ETHEREUM_FORK_ID);
+
+        comptroller = Comptroller(addresses.getAddress("UNITROLLER"));
+        mToken = MErc20Delegator(
+            payable(addresses.getAddress("MOONWELL_WETH"))
+        );
+        router = WETHRouter(payable(addresses.getAddress("WETH_ROUTER")));
+    }
+
+    /// @notice MIP-E01 must have repointed the Ethereum WETH market at the
+    /// MWethDelegate wired to the WETH_UNWRAPPER (which itself references WETH).
+    function testSetup() public view {
+        assertEq(
+            mToken.implementation(),
+            addresses.getAddress("MWETH_IMPLEMENTATION"),
+            "MWethDelegate not wired on Ethereum WETH market"
+        );
+        assertEq(
+            MWethDelegate(address(mToken)).wethUnwrapper(),
+            addresses.getAddress("WETH_UNWRAPPER"),
+            "unwrapper not wired on Ethereum mToken proxy"
+        );
+        assertEq(
+            WethUnwrapper(payable(addresses.getAddress("WETH_UNWRAPPER")))
+                .weth(),
+            addresses.getAddress("WETH"),
+            "unwrapper references wrong WETH on Ethereum"
+        );
+    }
+
+    function testMintMWethMTokenSucceeds() public {
+        address sender = address(this);
+        uint256 mintAmount = 100e18;
+
+        IERC20 token = IERC20(addresses.getAddress("WETH"));
+
+        uint256 startingTokenBalance = token.balanceOf(address(mToken));
+
+        vm.deal(sender, mintAmount); /// fund with raw eth
+        router.mint{value: mintAmount}(address(this)); /// ensure successful mint
+
+        assertTrue(mToken.balanceOf(sender) > 0, "mToken balance not gt 0");
+        assertEq(
+            token.balanceOf(address(mToken)) - startingTokenBalance,
+            mintAmount,
+            "underlying not sent to mToken"
+        );
+    }
+
+    function testRedeemSendsRawEthToReceiver() public {
+        testMintMWethMTokenSucceeds();
+        assertFalse(ethReceived, "should not have received eth");
+
+        uint256 redeemAmount = 100e18;
+        uint256 startingBalance = address(this).balance;
+
+        vm.warp(block.timestamp + 1000); /// accrue interest so 100 eth is redeemable
+
+        assertEq(mToken.redeemUnderlying(redeemAmount), 0, "redeem failure");
+
+        assertTrue(ethReceived, "should have received eth");
+
+        assertEq(
+            address(this).balance - startingBalance,
+            redeemAmount,
+            "incorrect eth amount after redemption"
+        );
+    }
+
+    receive() external payable {
+        ethReceived = true;
+    }
+}


### PR DESCRIPTION
## Summary

Drafts **MIP-E01**, which enables native ETH redemptions and borrows on the Ethereum `MOONWELL_WETH` market by pointing its `MErc20Delegator` implementation at a newly deployed `MWethDelegate` (which unwraps WETH → ETH on `doTransferOut` via a `WethUnwrapper`). This mirrors MIP-B02 on Base, adapted to Ethereum's `MultichainGovernorV2` governance path.

Deposit and repay in native ETH already work on Ethereum via the `WETH_ROUTER` deployed in MIP-E00 — this proposal completes the redeem/borrow side.

## Changes

- `proposals/mips/mip-e01/mip-e01.sol` — `HybridProposalV2`, `primaryForkId = ETHEREUM_FORK_ID`
  - `deploy()`: deploys `WethUnwrapper(WETH)` then `MWethDelegate(WETH_UNWRAPPER)` (unlike B02, neither pre-exists on Ethereum, so both are deployed)
  - `build()`: `MOONWELL_WETH._setImplementation(MWETH_IMPLEMENTATION, true, "")`, executed by `MULTICHAIN_GOVERNOR_V2_PROXY` (the market admin set in MIP-E00)
  - `validate()`: asserts unwrapper→WETH, delegate→unwrapper, market impl, WETH_ROUTER wiring, and admin unchanged
- `proposals/mips/mip-e01/MIP-E01.md` — proposal description
- `proposals/mips/mips.json` — registers the proposal with `id: 0` (in-development)

## Verification

- ✅ Compiles (`forge build proposals/mips/mip-e01/mip-e01.sol`)
- ✅ `mips.json` parses (`ProposalMapParse` relevant subtests pass)
- ✅ Live-state grounded: `MOONWELL_WETH.admin()` = V2 governor (so `_setImplementation` is authorized), current impl = stock delegate, underlying = WETH
- ⏳ Full multi-chain governance simulate runs in CI via `PostProposalCheck` (needs all four chain RPCs)

## Notes

- The pre-existing `test/unit/ProposalMapParse.t.sol::test_inDevelopmentIncludesMipE00` failure is **not** caused by this PR — it fails on clean `main` because MIP-E00 graduated from `id:0` to `id:169` while that characterization test still expects E00 in the `id==0` dev set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)