### PR TITLE
fix(proposals): emit cross-chain VAA from Ethereum MultichainGovernorV2

### DIFF
--- a/proposals/proposalTypes/HybridProposal.sol
+++ b/proposals/proposalTypes/HybridProposal.sol
@@ -812,24 +812,25 @@ abstract contract HybridProposal is
             payloads
         );
 
-        /// allow querying of Moonbeam
-        addresses.addRestriction(block.chainid.toMoonbeamChainId());
+        /// Governance lives on Ethereum (MultichainGovernorV2): cross-chain
+        /// governance messages originate from the MultichainGovernorV2 on Ethereum,
+        /// so the simulated VAA must be emitted from that governor for the
+        /// TemporalGovernor trusted-sender check to pass.
+        uint256 governorChainId = block.chainid.toEthereumChainId();
+
+        /// allow querying of Ethereum (governance hub)
+        addresses.addRestriction(governorChainId);
 
         bytes32 governor = addresses
-            .getAddress(
-                "MULTICHAIN_GOVERNOR_PROXY",
-                block.chainid.toMoonbeamChainId()
-            )
+            .getAddress("MULTICHAIN_GOVERNOR_V2_PROXY", governorChainId)
             .toBytes();
 
-        /// disallow querying of Moonbeam
+        /// disallow querying of Ethereum
         addresses.removeRestriction();
 
         bytes memory vaa = generateVAA(
             uint32(block.timestamp),
-            /// we can hardcode this wormhole chainID because all proposals
-            /// should come from Moonbeam
-            MOONBEAM_WORMHOLE_CHAIN_ID,
+            ETHEREUM_WORMHOLE_CHAIN_ID,
             governor,
             payload
         );


### PR DESCRIPTION
## Problem

Every multichain proposal that uses `HybridProposal` (the MarketUpdate template and ~100 MIPs) reverts during simulation with:

```
revert: TemporalGovernor: Invalid Emitter Address
```

This is **not specific to any one proposal** — it reproduces identically on already-merged proposals (verified with MIP-X54). The revert happens in the generic cross-chain step (`_runExtChain` → `TemporalGovernor.queueProposal`), before any proposal-specific action executes.

## Root cause

Governance lives on **Ethereum** (`MultichainGovernorV2`). The Base and Optimism `TemporalGovernor`s were reconfigured on-chain to trust the **Ethereum** governor and to **stop trusting the Moonbeam** governor. Verified on-chain:

| Temporal Governor | trusts ETH gov `0x8769B70a…` (wh chain 2) | trusts Moonbeam gov `0x9A8464…` (wh chain 16) |
| --- | --- | --- |
| Base `0x8b6218…` | ✅ true | ❌ false |
| Optimism `0x17C9ba…` | ✅ true | ❌ false |

The trust flip happened ~11 days ago (Base `isTrustedSender(16, moonbeamGov)` was `true` at block ≤46,466,209 and `false` from ≥46,481,834).

But `HybridProposal._runExtChain` still built the simulated VAA with the **Moonbeam** governor as emitter (`MOONBEAM_WORMHOLE_CHAIN_ID`), so the temporal governors reject it. `HybridProposalV2` already does this correctly; the old `HybridProposal` was never updated.

## Fix

`_runExtChain` now emits the VAA from `MULTICHAIN_GOVERNOR_V2_PROXY` on Ethereum (`ETHEREUM_WORMHOLE_CHAIN_ID`), matching `HybridProposalV2`. The Moonbeam emitter is removed.

## Verification

MIP-X54 (a representative multichain MarketUpdate proposal), run via `source proposals/mips/mip-x54/x54.sh && forge script proposals/templates/MarketUpdate.sol`:

- **Before:** `Error: script failed: revert: TemporalGovernor: Invalid Emitter Address`
- **After:** `Script ran successfully.` (proposes → delivers VAA from the Ethereum governor → Base TG accepts → market updates execute → validate passes → calldata printed)

Both Base and Optimism temporal governors confirmed trusting the Ethereum governor on-chain, so both legs of multichain proposals are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
