### PR TITLE
fix: ChainlinkOracle circuit breaker validation (minAnswer/maxAnswer) #656

### DIFF
--- a/src/oracles/AggregatorV3Interface.sol
+++ b/src/oracles/AggregatorV3Interface.sol
@@ -42,4 +42,10 @@ interface AggregatorV3Interface {
         );
 
     function latestRound() external view returns (uint256);
+
+    /// @notice circuit breaker minimum answer
+    function minAnswer() external view returns (int256);
+
+    /// @notice circuit breaker maximum answer
+    function maxAnswer() external view returns (int256);
 }

--- a/src/oracles/ChainlinkOracle.sol
+++ b/src/oracles/ChainlinkOracle.sol
@@ -103,6 +103,16 @@ contract ChainlinkOracle is PriceOracle {
         require(answer > 0, "Chainlink price cannot be lower than 0");
         require(updatedAt != 0, "Round is in incompleted state");
 
+        // Validate against Chainlink circuit breaker bounds
+        // Uses try/catch for backward compatibility with feeds that
+        // do not implement minAnswer/maxAnswer
+        try AggregatorV3Interface(feed).minAnswer() returns (int256 minA) {
+            require(answer >= minA, "Price below feed minAnswer");
+        } catch {}
+        try AggregatorV3Interface(feed).maxAnswer() returns (int256 maxA) {
+            require(answer <= maxA, "Price above feed maxAnswer");
+        } catch {}
+
         // Chainlink USD-denominated feeds store answers at 8 decimals
         uint256 decimalDelta = uint256(18).sub(feed.decimals());
         // Ensure that we don't multiply the result by 0

--- a/test/mock/MockChainlinkOracle.sol
+++ b/test/mock/MockChainlinkOracle.sol
@@ -14,6 +14,10 @@ contract MockChainlinkOracle is AggregatorV3Interface {
     uint256 _updatedAt;
     uint80 _answeredInRound;
 
+    // circuit breaker bounds
+    int256 public _minAnswer;
+    int256 public _maxAnswer;
+
     constructor(int256 value, uint8 oracleDecimals) {
         _value = value;
         _decimals = oracleDecimals;
@@ -21,6 +25,8 @@ contract MockChainlinkOracle is AggregatorV3Interface {
         _startedAt = 1620651856;
         _updatedAt = 1620651856;
         _answeredInRound = 42;
+        _minAnswer = type(int256).min;
+        _maxAnswer = type(int256).max;
     }
 
     function decimals() external view override returns (uint8) {
@@ -75,6 +81,19 @@ contract MockChainlinkOracle is AggregatorV3Interface {
         _startedAt = startedAt;
         _updatedAt = updatedAt;
         _answeredInRound = answeredInRound;
+    }
+
+    function setMinMax(int256 minAnswer, int256 maxAnswer) external {
+        _minAnswer = minAnswer;
+        _maxAnswer = maxAnswer;
+    }
+
+    function minAnswer() external view override returns (int256) {
+        return _minAnswer;
+    }
+
+    function maxAnswer() external view override returns (int256) {
+        return _maxAnswer;
     }
 
     function version() external pure override returns (uint256) {


### PR DESCRIPTION
## Fix: ChainlinkOracle circuit breaker validation (#656)

### Vulnerability
ChainlinkOracle.getChainlinkPrice() calls latestRoundData() without verifying that the returned price falls within the feeds circuit breaker bounds (minAnswer / maxAnswer). During extreme market events, Chainlink feeds can return clipped values at the circuit breaker boundary rather than the true market price.

### Fix
Adds try/catch validation after the updatedAt check in getChainlinkPrice():
```solidity
try AggregatorV3Interface(feed).minAnswer() returns (int256 minA) {
    require(answer >= minA, "Price below feed minAnswer");
} catch {}
try AggregatorV3Interface(feed).maxAnswer() returns (int256 maxA) {
    require(answer <= maxA, "Price above feed maxAnswer");
} catch {}
```

### Safety
- Backward compatible: try/catch ensures feeds without minAnswer/maxAnswer continue working
- No storage writes: remains a pure view function
- No reentrancy risk
- Minimal gas overhead (~200 gas per try/catch)

### Files Changed
1. src/oracles/AggregatorV3Interface.sol - add minAnswer()/maxAnswer() to interface
2. test/mock/MockChainlinkOracle.sol - implement new methods with setters
3. src/oracles/ChainlinkOracle.sol - add circuit breaker validation