### PR TITLE
feat(rewards): allow zeroing Moonbeam safety-module emission

### DIFF
--- a/proposals/templates/RewardsDistribution.sol
+++ b/proposals/templates/RewardsDistribution.sol
@@ -168,6 +168,13 @@ contract RewardsDistributionTemplate is HybridProposal, Networks {
 
     JsonSpecMoonbeam moonbeamActions;
 
+    /// @notice when true, the Moonbeam safety-module emission is configured
+    /// even when stkWellEmissionsPerSecond is 0, letting a MIP intentionally
+    /// zero the emission. Parsed optionally from the ".1284.setStkWellEmissions"
+    /// JSON key; absent/false preserves the legacy "0 == skip" behavior that
+    /// split MIPs (e.g. x51b/x51c) rely on to avoid re-configuring Moonbeam.
+    bool public moonbeamSetStkWellEmissions;
+
     uint256 chainId;
     uint256 startTimeStamp;
     uint256 endTimeStamp;
@@ -550,6 +557,17 @@ contract RewardsDistributionTemplate is HybridProposal, Networks {
 
         moonbeamActions.stkWellEmissionsPerSecond = spec
             .stkWellEmissionsPerSecond;
+
+        // optional flag: when present and true, the Moonbeam safety-module
+        // emission is configured even if it is 0 (intentional zeroing). Absent
+        // key keeps the legacy "0 == skip" behavior.
+        string memory setStkWellKey = string.concat(
+            chain,
+            ".setStkWellEmissions"
+        );
+        if (vm.keyExistsJson(data, setStkWellKey)) {
+            moonbeamSetStkWellEmissions = vm.parseJsonBool(data, setStkWellKey);
+        }
 
         uint256 totalEpochRewards = 0;
 
@@ -1267,7 +1285,7 @@ contract RewardsDistributionTemplate is HybridProposal, Networks {
             );
         }
 
-        if (spec.stkWellEmissionsPerSecond > 0) {
+        if (spec.stkWellEmissionsPerSecond > 0 || moonbeamSetStkWellEmissions) {
             address safetyModule = addresses.getAddress("STK_GOVTOKEN_PROXY");
             uint128[] memory emissionPerSecond = new uint128[](1);
             emissionPerSecond[0] = spec.stkWellEmissionsPerSecond.toUint128();
@@ -1857,7 +1875,10 @@ contract RewardsDistributionTemplate is HybridProposal, Networks {
         }
 
         {
-            if (spec.stkWellEmissionsPerSecond > 0) {
+            if (
+                spec.stkWellEmissionsPerSecond > 0 ||
+                moonbeamSetStkWellEmissions
+            ) {
                 address stkGovToken = addresses.getAddress(
                     "STK_GOVTOKEN_PROXY"
                 );


### PR DESCRIPTION
## Problem

The `RewardsDistributionTemplate` gates the Moonbeam safety-module `configureAssets` call on `stkWellEmissionsPerSecond > 0`. So when the reward automation emits `0` to zero out the Moonbeam safety module, the template **skips** the call entirely — the on-chain emission keeps its previous non-zero value. There is no way to intentionally set it to `0`.

Naively flipping the gate to `>= 0` is unsafe: `0` is a load-bearing **skip sentinel**. Split MIPs emit `1284 -> 0` precisely so they *don't* re-configure Moonbeam (the real value is carried by exactly one split, e.g. x51a). A blanket flip would make x51b/x51c emit `configureAssets(0)` and silently zero the emission x51a just set.

## Fix

Introduce an opt-in boolean flag so "set to zero" and "skip" are distinct signals:

- **`bool public moonbeamSetStkWellEmissions`** — new storage flag.
- Parsed **optionally** from the `.1284.setStkWellEmissions` JSON key via `keyExistsJson`/`parseJsonBool` (defaults `false`). Parsed separately rather than added to `JsonSpecMoonbeam`, because the Moonbeam path is the only one doing a whole-struct `abi.decode(parseJson(...))` — adding a struct field would break every existing Moonbeam JSON that lacks the key.
- Build gate (`_buildMoonbeamActions`) and validate gate (`_validateMoonbeam`) become `stkWellEmissionsPerSecond > 0 || moonbeamSetStkWellEmissions`.

## Safety / scope

- **Backward compatible by construction:** no existing JSON sets the key → flag is `false` → `|| false` short-circuits to the original `> 0` condition. Existing behavior is unchanged.
- **Split MIPs unaffected:** x51b/x51c don't set the flag, so they still skip Moonbeam and can't re-zero what x51a sets.
- **Scoped to Moonbeam only.** External-chain/Base gates (`_buildExternalChainActions`, external validate) are untouched — Base must never configure its safety module.

## Follow-up (separate repo)

To actually zero the Moonbeam safety module in a given month, the **moonwell-reward-automation** worker must emit `"setStkWellEmissions": true` in the `.1284` section. Emitting `0` alone is now (correctly) still treated as skip.

## Verification

- `forge build` passes.
- New "set to 0" path is not yet exercised by any committed JSON (no consuming MIP authored in this PR). Recommend adding a focused integration assertion (`stkWell.assets(...) == 0`) when the consuming MIP lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)