### PR TITLE
fix: enforce ERC20 return checks and cache storage reads in Comptroller, MErc20, MultiRewardDistributor, xWELLRouter

### DIFF
--- a/src/Comptroller.sol
+++ b/src/Comptroller.sol
@@ -1037,7 +1037,8 @@ contract Comptroller is
     }
 
     function _addMarketInternal(address mToken) internal {
-        for (uint i = 0; i < allMarkets.length; i++) {
+        uint256 numMarkets = allMarkets.length;
+        for (uint i = 0; i < numMarkets; i++) {
             require(allMarkets[i] != MToken(mToken), "market already added");
         }
         allMarkets.push(MToken(mToken));
@@ -1255,9 +1256,9 @@ contract Comptroller is
         IERC20 token = IERC20(_tokenAddress);
         // Similar to mTokens, if this is uint.max that means "transfer everything"
         if (_amount == type(uint).max) {
-            token.transfer(admin, token.balanceOf(address(this)));
+            require(token.transfer(admin, token.balanceOf(address(this))), "transfer failed");
         } else {
-            token.transfer(admin, _amount);
+            require(token.transfer(admin, _amount), "transfer failed");
         }
     }
 

--- a/src/MErc20.sol
+++ b/src/MErc20.sol
@@ -184,6 +184,7 @@ contract MErc20 is MToken, MErc20Interface {
         );
         uint256 balance = token.balanceOf(address(this));
         token.transfer(admin, balance);
+        require(token.balanceOf(address(this)) == 0, "sweepToken: transfer must move all tokens");
     }
 
     /**

--- a/src/rewards/MultiRewardDistributor.sol
+++ b/src/rewards/MultiRewardDistributor.sol
@@ -206,7 +206,8 @@ contract MultiRewardDistributor is
         );
 
         // Pop out the MarketConfigs to return them
-        for (uint256 index = 0; index < configs.length; index++) {
+        uint256 configsLength = configs.length;
+        for (uint256 index = 0; index < configsLength; index++) {
             MarketEmissionConfig storage emissionConfig = configs[index];
             outputMarketConfigs[index] = emissionConfig.config;
         }
@@ -278,7 +279,8 @@ contract MultiRewardDistributor is
             })
         });
 
-        for (uint256 index = 0; index < configs.length; index++) {
+        uint256 configsLength = configs.length;
+        for (uint256 index = 0; index < configsLength; index++) {
             MarketEmissionConfig storage emissionConfig = configs[index];
 
             // Calculate our new global supply index
@@ -416,7 +418,8 @@ contract MultiRewardDistributor is
         ];
 
         // Sanity check to ensure that the emission token doesn't already exist in a config
-        for (uint256 index = 0; index < configs.length; index++) {
+        uint256 configsLength = configs.length;
+        for (uint256 index = 0; index < configsLength; index++) {
             MarketEmissionConfig storage mTokenConfig = configs[index];
             require(
                 mTokenConfig.config.emissionToken != _emissionToken,
@@ -981,7 +984,8 @@ contract MultiRewardDistributor is
         MarketEmissionConfig[] storage configs = marketConfigs[
             address(_mToken)
         ];
-        for (uint256 index = 0; index < configs.length; index++) {
+        uint256 configsLength = configs.length;
+        for (uint256 index = 0; index < configsLength; index++) {
             MarketEmissionConfig storage emissionConfig = configs[index];
             if (emissionConfig.config.emissionToken == _emissionToken) {
                 return emissionConfig;
@@ -1007,7 +1011,8 @@ contract MultiRewardDistributor is
         uint256 totalMTokens = MTokenInterface(_mToken).totalSupply();
 
         // Iterate over all market configs and update their indexes + timestamps
-        for (uint256 index = 0; index < configs.length; index++) {
+        uint256 supplyConfigsLength = configs.length;
+        for (uint256 index = 0; index < supplyConfigsLength; index++) {
             MarketEmissionConfig storage emissionConfig = configs[index];
 
             // Go calculate our new values
@@ -1051,7 +1056,8 @@ contract MultiRewardDistributor is
         uint256 supplierTokens = _mToken.balanceOf(_supplier);
 
         // Iterate over all market configs and update their indexes + timestamps
-        for (uint256 index = 0; index < configs.length; index++) {
+        uint256 supplyConfigsLength = configs.length;
+        for (uint256 index = 0; index < supplyConfigsLength; index++) {
             MarketEmissionConfig storage emissionConfig = configs[index];
 
             uint256 totalRewardsOwed = calculateSupplyRewardsForUser(
@@ -1110,7 +1116,8 @@ contract MultiRewardDistributor is
         uint256 totalBorrows = MToken(_mToken).totalBorrows();
 
         // Iterate over all market configs and update their indexes + timestamps
-        for (uint256 index = 0; index < configs.length; index++) {
+        uint256 borrowConfigsLength = configs.length;
+        for (uint256 index = 0; index < borrowConfigsLength; index++) {
             MarketEmissionConfig storage emissionConfig = configs[index];
 
             // Go calculate our new borrow index
@@ -1161,7 +1168,8 @@ contract MultiRewardDistributor is
         });
 
         // Iterate over all market configs and update their indexes + timestamps
-        for (uint256 index = 0; index < configs.length; index++) {
+        uint256 borrowConfigsLength = configs.length;
+        for (uint256 index = 0; index < borrowConfigsLength; index++) {
             MarketEmissionConfig storage emissionConfig = configs[index];
 
             // Go calculate the total outstanding rewards for this user

--- a/src/xWELL/xWELLRouter.sol
+++ b/src/xWELL/xWELLRouter.sol
@@ -107,7 +107,7 @@ contract xWELLRouter {
         well.safeTransferFrom(msg.sender, address(this), amount);
 
         /// approve the lockbox to spend the WELL
-        well.approve(address(lockbox), amount);
+        well.safeApprove(address(lockbox), amount);
 
         /// deposit the WELL into the lockbox, which credits the router contract the xWELL
         lockbox.deposit(amount);
@@ -116,7 +116,7 @@ contract xWELLRouter {
         uint256 xwellAmount = xwell.balanceOf(address(this));
 
         /// approve the wormhole bridge to spend the xWELL
-        xwell.approve(address(wormholeBridge), xwellAmount);
+        ERC20(address(xwell)).safeApprove(address(wormholeBridge), xwellAmount);
 
         /// bridge the xWELL to the base chain
         wormholeBridge.bridge{value: bridgeCostGlmr}(


### PR DESCRIPTION
## Bug Fixes

### 1. Comptroller._rescueFunds - Unchecked token.transfer() return value
token.transfer(admin, amount) return value was ignored. Tokens that return false on failure silently succeed without moving tokens.

Fix: Wrapped both branches in require().

### 2. MErc20.sweepToken - No post-transfer verification
Uses EIP20NonStandardInterface (no bool return), so failures with tokens returning false are invisible.

Fix: Added balance check after transfer.

### 3. xWELLRouter - Raw .approve() without SafeERC20
Lines 110 and 119 used raw .approve() despite SafeERC20 being imported.

Fix: Replaced with safeApprove().

## Gas Optimizations

### 4. MultiRewardDistributor - SLOAD cache in 8 loops
Cached configs.length in memory across all 8 loop locations (getConfigsForMarket, getOutstandingRewardsForUser, _addEmissionConfig, fetchConfigByEmissionToken, updateMarketSupplyIndexInternal, disburseSupplierRewardsInternal, updateMarketBorrowIndexInternal, disburseBorrowerRewardsInternal).

### 5. Comptroller._addMarketInternal - SLOAD cache
Cached allMarkets.length in memory.

## Testing
forge build - compiles clean.
forge test --match-contract Comptroller - all tests pass.
