### PR TITLE
Overpay-tolerant onchain-quote bridge + MIP-X62 upgrade

### DIFF
--- a/.claude/rules/proposals.md
+++ b/.claude/rules/proposals.md
@@ -65,6 +65,12 @@
   redeploy + rewire via `setFeed`. `*_ORACLE_PROXY` keys are upgradeable
   `ChainlinkOEVMorphoWrapper` (Morpho-Blue) — upgrade impl behind the proxy via
   `ProxyAdmin.upgrade`.
+- `WormholeBridgeAdapter` proxy admin differs by chain: `PROXY_ADMIN` on
+  Ethereum, `MRD_PROXY_ADMIN` on Base/Optimism, `MOONBEAM_PROXY_ADMIN` on
+  Moonbeam. Do NOT assume `MRD_PROXY_ADMIN` everywhere — on Ethereum it resolves
+  to a different, unrelated admin and a `ProxyAdmin.upgrade` call silently
+  delegates to the impl and reverts. Confirm by reading the ERC1967 admin slot
+  (`cast storage <proxy> 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103 --rpc-url <chain>`).
 - For wrapper redeploys, follow MIP-X43's archive-then-promote pattern:
   `addAddress("<name>_OEV_WRAPPER_DEPRECATED_VN", oldAddr)` then
   `changeAddress("<name>_OEV_WRAPPER", newAddr, true)` to atomically swap the

--- a/proposals/mips/mip-x62/mip-x62.sol
+++ b/proposals/mips/mip-x62/mip-x62.sol
@@ -1,0 +1,321 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+
+import "@forge-std/Test.sol";
+
+import {ITransparentUpgradeableProxy} from "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
+import {IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+import {WormholeBridgeAdapter} from "@protocol/xWELL/WormholeBridgeAdapter.sol";
+import {HybridProposalV2} from "@proposals/proposalTypes/HybridProposalV2.sol";
+import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
+import {BASE_FORK_ID, OPTIMISM_FORK_ID, ETHEREUM_FORK_ID, BASE_WORMHOLE_CHAIN_ID, OPTIMISM_WORMHOLE_CHAIN_ID, ChainIds} from "@utils/ChainIds.sol";
+
+/// @title MIP-X62: Upgrade WormholeBridgeAdapter to overpay-tolerant onchain quoting
+/// @notice Deploys a fresh WormholeBridgeAdapter implementation on Base,
+///         Optimism, and Ethereum, then upgrades the WORMHOLE_BRIDGE_ADAPTER_PROXY
+///         behind each chain's ProxyAdmin. The new implementation relaxes the
+///         onchain-quoter bridge path from requiring `msg.value == quote` to
+///         `msg.value >= quote`, refunding any surplus to the caller. This lets
+///         a caller that cannot predict the exact cost up front (e.g. a
+///         governance proposal whose live quote drifts during the ~5-day voting
+///         window) overfund with a buffer and be charged only the live quote.
+///
+///         Moonbeam is intentionally excluded: it has no onchain quoter
+///         (`executorQuoterRouter == address(0)`), so the relaxed path is inert
+///         there and its adapter is left on its current implementation.
+contract mipx62 is HybridProposalV2 {
+    using ChainIds for uint256;
+
+    string public constant override name = "MIP-X62";
+
+    /// @notice key for the new implementation deployed by this proposal
+    string internal constant IMPL_KEY = "WORMHOLE_BRIDGE_ADAPTER_IMPL_V7";
+
+    /// @notice destination chain used for the validation bridge() call.
+    /// On Base we bridge to OP; on OP and Ethereum we bridge to Base.
+    uint16 internal constant _BASE_DST_WH_ID = OPTIMISM_WORMHOLE_CHAIN_ID;
+    uint16 internal constant _OP_DST_WH_ID = BASE_WORMHOLE_CHAIN_ID;
+    uint16 internal constant _ETH_DST_WH_ID = BASE_WORMHOLE_CHAIN_ID;
+
+    /// @notice mocked-user bridge amount used in `validate()`
+    uint256 internal constant BRIDGE_AMOUNT = 1e18;
+
+    /// @notice surplus the validation bridge over-sends above the live quote;
+    /// the new implementation must refund exactly this back to the caller.
+    uint256 internal constant OVERPAY = 0.01 ether;
+
+    /// @notice pre-upgrade snapshot of storage-backed adapter state, keyed by
+    /// fork id. Captured in afterDeploy() (before simulate() runs the upgrade)
+    /// and asserted unchanged in validate(). The fix adds no storage, so an
+    /// impl swap must leave every one of these untouched.
+    struct AdapterSnapshot {
+        address quoterAddress;
+        address executorQuoterRouter;
+        address executor;
+        uint96 gasLimit;
+    }
+
+    mapping(uint256 forkId => AdapterSnapshot) internal snapshots;
+
+    constructor() {
+        bytes memory proposalDescription = abi.encodePacked(
+            vm.readFile("./proposals/mips/mip-x62/x62.md")
+        );
+
+        _setProposalDescription(proposalDescription);
+
+        nonce = 2;
+    }
+
+    function primaryForkId() public pure override returns (uint256) {
+        return ETHEREUM_FORK_ID;
+    }
+
+    /// @notice the ProxyAdmin that owns the WormholeBridgeAdapter proxy on a
+    /// given chain. On Base and Optimism it is MRD_PROXY_ADMIN; on Ethereum the
+    /// proxy is owned by the generic PROXY_ADMIN (MRD_PROXY_ADMIN resolves to a
+    /// different, unrelated admin on Ethereum).
+    function _proxyAdminKey(
+        uint256 forkId
+    ) internal pure returns (string memory) {
+        if (forkId == ETHEREUM_FORK_ID) {
+            return "PROXY_ADMIN";
+        }
+        return "MRD_PROXY_ADMIN";
+    }
+
+    /// @notice run() override mirroring the multi-chain deploy pattern (see
+    /// mip-x53). The base HybridProposalV2 run() wraps deploy()+afterDeploy() in
+    /// a single broadcast, but `vm.selectFork` is disallowed mid-broadcast and
+    /// this proposal must switch forks to deploy on / snapshot every chain.
+    /// Instead, deploy() broadcasts per-fork internally and afterDeploy() (a
+    /// read-only snapshot) runs outside any broadcast.
+    function run() public override {
+        primaryForkId().createForksAndSelect();
+
+        Addresses addresses = new Addresses();
+        vm.makePersistent(address(addresses));
+
+        vm.selectFork(primaryForkId());
+
+        setProposalDescriptionUri(_resolveProposalDescriptionUri(this.name()));
+
+        initProposal(addresses);
+
+        (, address deployerAddress, ) = vm.readCallers();
+
+        if (DO_DEPLOY) deploy(addresses, deployerAddress);
+        if (DO_AFTER_DEPLOY) afterDeploy(addresses, deployerAddress);
+        if (DO_BUILD) build(addresses);
+        if (DO_RUN) simulate(addresses, deployerAddress);
+        if (DO_TEARDOWN) teardown(addresses, deployerAddress);
+        if (DO_VALIDATE) validate(addresses, deployerAddress);
+        if (DO_PRINT) {
+            printProposalActionSteps();
+
+            addresses.removeAllRestrictions();
+            printCalldata(addresses);
+
+            _printAddressesChanges(addresses);
+        }
+    }
+
+    /// @notice deploy a fresh WormholeBridgeAdapter implementation on each
+    /// quoter-enabled chain. Inert until governance points the proxy at it.
+    /// Broadcasts per-fork: selectFork happens outside the broadcast window.
+    function deploy(Addresses addresses, address) public override {
+        uint256[3] memory forks = [
+            BASE_FORK_ID,
+            OPTIMISM_FORK_ID,
+            ETHEREUM_FORK_ID
+        ];
+
+        for (uint256 i = 0; i < forks.length; i++) {
+            vm.selectFork(forks[i]);
+            if (!addresses.isAddressSet(IMPL_KEY)) {
+                vm.startBroadcast();
+                address impl = address(new WormholeBridgeAdapter());
+                vm.stopBroadcast();
+                addresses.addAddress(IMPL_KEY, impl);
+            }
+        }
+
+        vm.selectFork(primaryForkId());
+    }
+
+    /// @notice snapshot pre-upgrade adapter state on each chain so validate()
+    /// can prove the implementation swap left storage untouched. Runs before
+    /// build()/simulate().
+    function afterDeploy(Addresses addresses, address) public override {
+        _snapshot(addresses, BASE_FORK_ID);
+        _snapshot(addresses, OPTIMISM_FORK_ID);
+        _snapshot(addresses, ETHEREUM_FORK_ID);
+
+        vm.selectFork(primaryForkId());
+    }
+
+    function _snapshot(Addresses addresses, uint256 forkId) internal {
+        vm.selectFork(forkId);
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY")
+        );
+        snapshots[forkId] = AdapterSnapshot({
+            quoterAddress: adapter.quoterAddress(),
+            executorQuoterRouter: address(adapter.executorQuoterRouter()),
+            executor: address(adapter.executor()),
+            gasLimit: adapter.gasLimit()
+        });
+    }
+
+    function build(Addresses addresses) public override {
+        _pushUpgrade(addresses, BASE_FORK_ID, "Base");
+        _pushUpgrade(addresses, OPTIMISM_FORK_ID, "Optimism");
+        _pushUpgrade(addresses, ETHEREUM_FORK_ID, "Ethereum");
+
+        vm.selectFork(primaryForkId());
+    }
+
+    /// @notice push the ProxyAdmin.upgrade action for one chain. The active
+    /// fork determines the ActionType the HybridProposalV2 framework assigns.
+    function _pushUpgrade(
+        Addresses addresses,
+        uint256 forkId,
+        string memory chainName
+    ) internal {
+        vm.selectFork(forkId);
+        _pushAction(
+            addresses.getAddress(_proxyAdminKey(forkId)),
+            abi.encodeWithSignature(
+                "upgrade(address,address)",
+                addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY"),
+                addresses.getAddress(IMPL_KEY)
+            ),
+            string.concat(
+                "Upgrade WormholeBridgeAdapter on ",
+                chainName,
+                " to the overpay-tolerant implementation"
+            )
+        );
+    }
+
+    function teardown(Addresses addresses, address) public pure override {}
+
+    function validate(Addresses addresses, address) public override {
+        _validateChain(addresses, BASE_FORK_ID, "Base", _BASE_DST_WH_ID);
+        _validateChain(addresses, OPTIMISM_FORK_ID, "Optimism", _OP_DST_WH_ID);
+        _validateChain(addresses, ETHEREUM_FORK_ID, "Ethereum", _ETH_DST_WH_ID);
+
+        vm.selectFork(primaryForkId());
+    }
+
+    /// @notice per-chain validation: implementation upgraded, storage state
+    /// preserved, live quote positive, and an overpaying bridge() that must
+    /// succeed and refund the surplus (the behavior this proposal ships).
+    function _validateChain(
+        Addresses addresses,
+        uint256 forkId,
+        string memory chainName,
+        uint16 dstWormholeId
+    ) internal {
+        vm.selectFork(forkId);
+
+        WormholeBridgeAdapter adapter = WormholeBridgeAdapter(
+            addresses.getAddress("WORMHOLE_BRIDGE_ADAPTER_PROXY")
+        );
+
+        /// 1. implementation upgraded to the new impl behind the proxy admin
+        address proxyAdmin = addresses.getAddress(_proxyAdminKey(forkId));
+        address actualImpl = ProxyAdmin(proxyAdmin).getProxyImplementation(
+            ITransparentUpgradeableProxy(address(adapter))
+        );
+        assertEq(
+            actualImpl,
+            addresses.getAddress(IMPL_KEY),
+            string.concat(chainName, ": adapter not upgraded to new impl")
+        );
+
+        /// 2. storage-backed state unchanged by the swap
+        AdapterSnapshot memory snap = snapshots[forkId];
+        assertEq(
+            adapter.quoterAddress(),
+            snap.quoterAddress,
+            string.concat(chainName, ": quoterAddress changed by upgrade")
+        );
+        assertEq(
+            address(adapter.executorQuoterRouter()),
+            snap.executorQuoterRouter,
+            string.concat(chainName, ": executorQuoterRouter changed")
+        );
+        assertEq(
+            address(adapter.executor()),
+            snap.executor,
+            string.concat(chainName, ": executor changed")
+        );
+        assertEq(
+            adapter.gasLimit(),
+            snap.gasLimit,
+            string.concat(chainName, ": gasLimit changed by upgrade")
+        );
+        assertTrue(
+            address(adapter.wormhole()) != address(0),
+            string.concat(chainName, ": wormhole core not set")
+        );
+
+        /// 3. live onchain quote is positive (path is usable on this chain)
+        uint256 cost = adapter.bridgeCost(dstWormholeId);
+        assertGt(cost, 0, string.concat(chainName, ": bridgeCost returned 0"));
+
+        /// 4. overpaying bridge() succeeds, burns tokens, and refunds surplus
+        _runOverpayBridge(addresses, adapter, chainName, dstWormholeId, cost);
+    }
+
+    /// @notice fund a synthetic user with xWELL + (cost + OVERPAY) native, then
+    /// bridge over-sending the surplus. The new implementation must accept
+    /// `msg.value > cost`, burn the tokens, and refund exactly OVERPAY.
+    function _runOverpayBridge(
+        Addresses addresses,
+        WormholeBridgeAdapter adapter,
+        string memory chainName,
+        uint16 dstWormholeId,
+        uint256 cost
+    ) internal {
+        address user = address(0xBEEF);
+        IERC20 xWell = IERC20(addresses.getAddress("xWELL_PROXY"));
+
+        /// mint synthetic xWELL (deal adjusts balance + totalSupply)
+        deal(address(xWell), user, BRIDGE_AMOUNT, true);
+
+        /// fund the user with the live quote plus a surplus buffer
+        vm.deal(user, cost + OVERPAY);
+
+        uint256 userTokenBefore = xWell.balanceOf(user);
+        uint256 totalSupplyBefore = xWell.totalSupply();
+
+        vm.startPrank(user);
+        xWell.approve(address(adapter), BRIDGE_AMOUNT);
+        adapter.bridge{value: cost + OVERPAY}(
+            uint256(dstWormholeId),
+            BRIDGE_AMOUNT,
+            user
+        );
+        vm.stopPrank();
+
+        assertEq(
+            userTokenBefore - xWell.balanceOf(user),
+            BRIDGE_AMOUNT,
+            string.concat(chainName, ": user xWELL not burned by bridge()")
+        );
+        assertEq(
+            totalSupplyBefore - xWell.totalSupply(),
+            BRIDGE_AMOUNT,
+            string.concat(chainName, ": xWELL totalSupply not reduced")
+        );
+        assertEq(
+            user.balance,
+            OVERPAY,
+            string.concat(chainName, ": surplus not refunded to caller")
+        );
+    }
+}

--- a/proposals/mips/mip-x62/x62.md
+++ b/proposals/mips/mip-x62/x62.md
@@ -1,0 +1,58 @@
+# MIP-X62: Upgrade WormholeBridgeAdapter to overpay-tolerant onchain quoting
+
+## Summary
+
+This proposal upgrades the `WormholeBridgeAdapter` implementation on **Base**,
+**Optimism**, and **Ethereum** to a version that tolerates overpayment on the
+onchain-quoter bridge path.
+
+The current implementation requires the native value sent with a bridge call to
+exactly equal the live quote (`msg.value == quote`). The new implementation
+relaxes this to `msg.value >= quote`: it charges the live quote, forwards the
+quote to the executor, and refunds any surplus back to the caller.
+
+## Motivation
+
+The onchain-quoter path re-computes the bridge cost at execution time, so a
+caller is never charged a stale price. However, the strict equality check makes
+the path unusable for any caller that cannot predict the exact cost when the
+transaction is constructed. The clearest example is a Moonwell governance
+proposal that bridges WELL across chains: roughly five days elapse between
+proposal creation and execution, during which the live quote can drift. With the
+strict check, the proposal must hit the cost exactly or it reverts.
+
+By accepting `msg.value >= quote` and refunding the surplus, a proposal (or any
+caller) can over-fund with a safety buffer, be charged only the live quote, and
+receive the remainder back.
+
+## Networks
+
+- **Base** — upgrade `WORMHOLE_BRIDGE_ADAPTER_PROXY` implementation.
+- **Optimism** — upgrade `WORMHOLE_BRIDGE_ADAPTER_PROXY` implementation.
+- **Ethereum** — upgrade `WORMHOLE_BRIDGE_ADAPTER_PROXY` implementation.
+
+**Moonbeam is intentionally excluded.** Moonbeam has no onchain quoter
+(`executorQuoterRouter == address(0)`), so the relaxed onchain-quoter path is
+inert there. Its adapter is left on its current implementation.
+
+## Changes
+
+For each of the three chains, governance calls `ProxyAdmin.upgrade` to point the
+bridge adapter proxy at a freshly deployed implementation. This is a pure
+implementation swap:
+
+- No new storage variables, structs, or layout changes — safe for the existing
+  upgradeable proxies.
+- The signed-quote bridge path, `bridgeCost`, `executeVAAv1`, and the
+  `xWELLRouter` are unchanged.
+
+## Validation
+
+On each chain the proposal verifies, against a mainnet fork, that:
+
+1. the proxy now points at the newly deployed implementation;
+2. pre-upgrade storage-backed state (`quoterAddress`, `executorQuoterRouter`,
+   `executor`, `gasLimit`) is unchanged by the swap;
+3. the live `bridgeCost` is positive; and
+4. an overpaying `bridge()` call succeeds, burns the bridged tokens, reduces
+   total supply, and refunds the exact surplus to the caller.

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -1,5 +1,12 @@
 [
     {
+        "envpath": "",
+        "governor": "MultichainGovernorV2",
+        "id": 0,
+        "path": "mip-x62.sol/mipx62.json",
+        "proposalType": "HybridProposalV2"
+    },
+    {
         "envpath": "proposals/mips/mip-x60/x60.sh",
         "governor": "MultichainGovernorV2",
         "id": 175,

--- a/proposals/mips/mips.json
+++ b/proposals/mips/mips.json
@@ -4,7 +4,8 @@
         "governor": "MultichainGovernorV2",
         "id": 0,
         "path": "mip-x62.sol/mipx62.json",
-        "proposalType": "HybridProposalV2"
+        "proposalType": "HybridProposalV2",
+        "descriptionUri": "ipfs://bafkreifnmyzj6w7a2ip4vfudpx6x64e2gl52q2ghvlow5yjyztd4nh6ray"
     },
     {
         "envpath": "proposals/mips/mip-x60/x60.sh",

--- a/src/xWELL/WormholeBridgeAdapter.sol
+++ b/src/xWELL/WormholeBridgeAdapter.sol
@@ -386,15 +386,15 @@ contract WormholeBridgeAdapter is
             "WormholeBridge: onchain quoting not available, use bridge with signedQuote"
         );
         uint16 targetChainId = targetChain.toUint16();
+        require(
+            targetAddress[targetChainId] != address(0),
+            "WormholeBridge: invalid target chain"
+        );
         uint256 cost = bridgeCost(targetChainId);
         require(cost != 0, "WormholeBridge: quote unavailable");
         require(
             msg.value >= cost,
             "WormholeBridge: insufficient value for quote"
-        );
-        require(
-            targetAddress[targetChainId] != address(0),
-            "WormholeBridge: invalid target chain"
         );
 
         /// user must burn xERC20 tokens first

--- a/src/xWELL/WormholeBridgeAdapter.sol
+++ b/src/xWELL/WormholeBridgeAdapter.sol
@@ -387,7 +387,11 @@ contract WormholeBridgeAdapter is
         );
         uint16 targetChainId = targetChain.toUint16();
         uint256 cost = bridgeCost(targetChainId);
-        require(msg.value == cost, "WormholeBridge: cost not equal to quote");
+        require(cost != 0, "WormholeBridge: quote unavailable");
+        require(
+            msg.value >= cost,
+            "WormholeBridge: insufficient value for quote"
+        );
         require(
             targetAddress[targetChainId] != address(0),
             "WormholeBridge: invalid target chain"
@@ -426,6 +430,12 @@ contract WormholeBridgeAdapter is
             requestBytes,
             relayInstructions
         );
+
+        uint256 refund = msg.value - cost;
+        if (refund != 0) {
+            (bool success, ) = msg.sender.call{value: refund}("");
+            require(success, "WormholeBridge: refund failed");
+        }
 
         emit TokensSent(targetChainId, to, amount);
     }

--- a/src/xWELL/WormholeBridgeAdapter.sol
+++ b/src/xWELL/WormholeBridgeAdapter.sol
@@ -431,6 +431,10 @@ contract WormholeBridgeAdapter is
             relayInstructions
         );
 
+        /// refund any surplus above the live quote back to the caller. This is
+        /// the last external interaction (after burn + publish + request), and a
+        /// re-entrant bridge() call would carry msg.value == 0, failing the
+        /// `msg.value >= cost` floor — so no reentrancy guard is required.
         uint256 refund = msg.value - cost;
         if (refund != 0) {
             (bool success, ) = msg.sender.call{value: refund}("");

--- a/test/integration/xWELL/WormholeBridgeAdapterIntegration.t.sol
+++ b/test/integration/xWELL/WormholeBridgeAdapterIntegration.t.sol
@@ -364,7 +364,7 @@ contract WormholeBridgeAdapterIntegrationTest is PostProposalCheck {
                 "WormholeBridge: onchain quoting not available, use bridge with signedQuote"
             );
         } else {
-            vm.expectRevert("WormholeBridge: cost not equal to quote");
+            vm.expectRevert("WormholeBridge: insufficient value for quote");
         }
         adapter.bridge{value: 0}(uint256(sourceWormholeChainId), amount, user);
         vm.stopPrank();

--- a/test/unit/WormholeBridgeAdapter.t.sol
+++ b/test/unit/WormholeBridgeAdapter.t.sol
@@ -636,6 +636,39 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         );
     }
 
+    function testBridgeOutExactPaySucceedsNoRefund() public {
+        _setupBridgeOut();
+
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        uint256 messageFee = mockCoreBridge.mockMessageFee();
+        vm.deal(address(this), cost);
+
+        wormholeBridgeAdapterProxy.bridge{value: cost}(chainId, amount, to);
+
+        assertEq(address(this).balance, 0, "no refund expected on exact pay");
+        assertEq(
+            mockExecutorQuoterRouter.lastRequestValue(),
+            cost - messageFee,
+            "router must receive quote net of message fee"
+        );
+    }
+
+    function testBridgeOutRevertsInsufficientValue() public {
+        _setupBridgeOut();
+
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        vm.deal(address(this), cost);
+
+        vm.expectRevert("WormholeBridge: insufficient value for quote");
+        wormholeBridgeAdapterProxy.bridge{value: cost - 1}(chainId, amount, to);
+    }
+
     function testBridgeOutFailsIncorrectTargetChain() public {
         vm.expectRevert("WormholeBridge: invalid target chain");
         wormholeBridgeAdapterProxy.bridge{value: 0}(chainId + 1, amount, to);

--- a/test/unit/WormholeBridgeAdapter.t.sol
+++ b/test/unit/WormholeBridgeAdapter.t.sol
@@ -43,6 +43,9 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
 
     event GasLimitUpdated(uint96 oldGasLimit, uint96 newGasLimit);
 
+    /// @notice allow this test contract to receive ETH refunds from the adapter
+    receive() external payable {}
+
     /// state variables
     address to;
     uint256 amount;
@@ -90,6 +93,18 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         );
 
         wormholeBridgeAdapterProxy.executeVAAv1(encodedVaa);
+    }
+
+    /// @notice build burn buffer + give this contract xWELL to bridge out
+    /// mirrors the setup proven in testBridgeOutSucceeds
+    function _setupBridgeOut() internal {
+        amount = externalChainBufferCap / 2;
+        to = address(this);
+        _bridgeInViaVaa(0);
+
+        amount = externalChainBufferCap;
+        _lockboxCanMintTo(address(this), uint112(amount));
+        xwellProxy.approve(address(wormholeBridgeAdapterProxy), amount);
     }
 
     /// --------------------------------------------------------
@@ -584,15 +599,41 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
     /// ------------------- Bridge Out Tests -------------------
     /// --------------------------------------------------------
 
-    function testBridgeOutFailsIncorrectCost() public {
+    function testBridgeOutOverpaySucceedsAndRefunds() public {
+        _setupBridgeOut();
+
         mockExecutorQuoterRouter.setQuote(0.001 ether);
         mockCoreBridge.setMessageFee(0.0001 ether);
 
         uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
-        vm.deal(address(this), cost + 1);
+        uint256 messageFee = mockCoreBridge.mockMessageFee();
+        uint256 overpay = 0.0005 ether;
+        vm.deal(address(this), cost + overpay);
 
-        vm.expectRevert("WormholeBridge: cost not equal to quote");
-        wormholeBridgeAdapterProxy.bridge{value: cost + 1}(chainId, amount, to);
+        vm.expectEmit(
+            true,
+            true,
+            true,
+            true,
+            address(wormholeBridgeAdapterProxy)
+        );
+        emit TokensSent(chainId, to, amount);
+        wormholeBridgeAdapterProxy.bridge{value: cost + overpay}(
+            chainId,
+            amount,
+            to
+        );
+
+        assertEq(
+            address(this).balance,
+            overpay,
+            "surplus should be refunded to caller"
+        );
+        assertEq(
+            mockExecutorQuoterRouter.lastRequestValue(),
+            cost - messageFee,
+            "router must receive exactly quote net of message fee"
+        );
     }
 
     function testBridgeOutFailsIncorrectTargetChain() public {

--- a/test/unit/WormholeBridgeAdapter.t.sol
+++ b/test/unit/WormholeBridgeAdapter.t.sol
@@ -669,6 +669,20 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         wormholeBridgeAdapterProxy.bridge{value: cost - 1}(chainId, amount, to);
     }
 
+    function testBridgeOutRevertsQuoteUnavailable() public {
+        _setupBridgeOut();
+
+        /// no setQuote / no setMessageFee => bridgeCost == 0
+        assertEq(
+            wormholeBridgeAdapterProxy.bridgeCost(chainId),
+            0,
+            "precondition: quote should be zero"
+        );
+
+        vm.expectRevert("WormholeBridge: quote unavailable");
+        wormholeBridgeAdapterProxy.bridge{value: 0}(chainId, amount, to);
+    }
+
     function testBridgeOutFailsIncorrectTargetChain() public {
         vm.expectRevert("WormholeBridge: invalid target chain");
         wormholeBridgeAdapterProxy.bridge{value: 0}(chainId + 1, amount, to);

--- a/test/unit/WormholeBridgeAdapter.t.sol
+++ b/test/unit/WormholeBridgeAdapter.t.sol
@@ -715,16 +715,26 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
     }
 
     function testBridgeOutFailsNoApproval() public {
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        vm.deal(address(this), cost);
+
         vm.expectRevert("ERC20: insufficient allowance");
-        wormholeBridgeAdapterProxy.bridge{value: 0}(chainId, amount, to);
+        wormholeBridgeAdapterProxy.bridge{value: cost}(chainId, amount, to);
     }
 
     function testBridgeOutFailsNotEnoughBalance() public {
         deal(address(xwellProxy), address(this), amount - 1);
         xwellProxy.approve(address(wormholeBridgeAdapterProxy), amount);
 
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        vm.deal(address(this), cost);
+
         vm.expectRevert("ERC20: burn amount exceeds balance");
-        wormholeBridgeAdapterProxy.bridge{value: 0}(chainId, amount, to);
+        wormholeBridgeAdapterProxy.bridge{value: cost}(chainId, amount, to);
     }
 
     function testBridgeOutFailsNotEnoughBuffer() public {
@@ -735,8 +745,13 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         amount = externalChainBufferCap;
         xwellProxy.approve(address(wormholeBridgeAdapterProxy), amount);
 
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        vm.deal(address(this), cost);
+
         vm.expectRevert("RateLimited: buffer cap overflow");
-        wormholeBridgeAdapterProxy.bridge{value: 0}(chainId, amount + 1, to);
+        wormholeBridgeAdapterProxy.bridge{value: cost}(chainId, amount + 1, to);
     }
 
     function testBridgeOutSucceeds() public {
@@ -748,6 +763,11 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         _lockboxCanMintTo(address(this), uint112(amount));
         xwellProxy.approve(address(wormholeBridgeAdapterProxy), amount);
 
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        vm.deal(address(this), cost);
+
         vm.expectEmit(
             true,
             true,
@@ -756,7 +776,7 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
             address(wormholeBridgeAdapterProxy)
         );
         emit TokensSent(chainId, to, amount);
-        wormholeBridgeAdapterProxy.bridge{value: 0}(chainId, amount, to);
+        wormholeBridgeAdapterProxy.bridge{value: cost}(chainId, amount, to);
     }
 
     /// --------------------------------------------------------

--- a/test/unit/WormholeBridgeAdapter.t.sol
+++ b/test/unit/WormholeBridgeAdapter.t.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.8.19;
 
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 import "@forge-std/Test.sol";
 
@@ -683,6 +684,31 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
         wormholeBridgeAdapterProxy.bridge{value: 0}(chainId, amount, to);
     }
 
+    function testBridgeOutRevertsWhenRefundRejected() public {
+        /// build burn buffer (buffer is global to the adapter, not per-user)
+        amount = externalChainBufferCap / 2;
+        to = address(this);
+        _bridgeInViaVaa(0);
+
+        RejectingReceiver bridger = new RejectingReceiver(
+            wormholeBridgeAdapterProxy,
+            IERC20(address(xwellProxy))
+        );
+
+        uint256 outAmount = externalChainBufferCap;
+        _lockboxCanMintTo(address(bridger), uint112(outAmount));
+
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        uint256 value = cost + 1; // overpay forces the refund path
+        vm.deal(address(bridger), value);
+
+        vm.expectRevert("WormholeBridge: refund failed");
+        bridger.doBridge{value: value}(chainId, outAmount, address(this));
+    }
+
     function testBridgeOutFailsIncorrectTargetChain() public {
         vm.expectRevert("WormholeBridge: invalid target chain");
         wormholeBridgeAdapterProxy.bridge{value: 0}(chainId + 1, amount, to);
@@ -827,5 +853,30 @@ contract WormholeBridgeAdapterUnitTest is BaseTest {
             to,
             signedQuote
         );
+    }
+}
+
+/// @notice bridges out via the adapter but reverts on any ETH refund,
+/// used to test the "refund failed" path
+contract RejectingReceiver {
+    WormholeBridgeAdapter public immutable adapter;
+    IERC20 public immutable token;
+
+    constructor(WormholeBridgeAdapter _adapter, IERC20 _token) {
+        adapter = _adapter;
+        token = _token;
+    }
+
+    function doBridge(
+        uint16 dstChainId,
+        uint256 amount,
+        address to
+    ) external payable {
+        token.approve(address(adapter), amount);
+        adapter.bridge{value: msg.value}(dstChainId, amount, to);
+    }
+
+    receive() external payable {
+        revert("reject");
     }
 }

--- a/test/unit/WormholeUnwrapperAdapter.t.sol
+++ b/test/unit/WormholeUnwrapperAdapter.t.sol
@@ -37,6 +37,9 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
 
     event GasLimitUpdated(uint96 oldGasLimit, uint96 newGasLimit);
 
+    /// @notice allow this test contract to receive ETH refunds from the adapter
+    receive() external payable {}
+
     /// state variables
     address public to;
     uint256 public amount;
@@ -417,15 +420,47 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
     /// ------------------- Bridge Out Tests -------------------
     /// --------------------------------------------------------
 
-    function testBridgeOutFailsIncorrectCost() public {
+    function testBridgeOutOverpaySucceedsAndRefunds() public {
+        amount = externalChainBufferCap / 2;
+        to = address(this);
+        _bridgeInViaVaa(0);
+
+        amount = externalChainBufferCap;
+        _lockboxCanMintTo(address(this), uint112(amount));
+        xwellProxy.approve(address(wormholeBridgeAdapterProxy), amount);
+
         mockExecutorQuoterRouter.setQuote(0.001 ether);
         mockCoreBridge.setMessageFee(0.0001 ether);
 
         uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
-        vm.deal(address(this), cost + 1);
+        uint256 messageFee = mockCoreBridge.mockMessageFee();
+        uint256 overpay = 0.0005 ether;
+        vm.deal(address(this), cost + overpay);
 
-        vm.expectRevert("WormholeBridge: cost not equal to quote");
-        wormholeBridgeAdapterProxy.bridge{value: cost + 1}(chainId, amount, to);
+        vm.expectEmit(
+            true,
+            true,
+            true,
+            true,
+            address(wormholeBridgeAdapterProxy)
+        );
+        emit TokensSent(chainId, to, amount);
+        wormholeBridgeAdapterProxy.bridge{value: cost + overpay}(
+            chainId,
+            amount,
+            to
+        );
+
+        assertEq(
+            address(this).balance,
+            overpay,
+            "surplus should be refunded to caller"
+        );
+        assertEq(
+            mockExecutorQuoterRouter.lastRequestValue(),
+            cost - messageFee,
+            "router must receive exactly quote net of message fee"
+        );
     }
 
     function testBridgeOutFailsIncorrectTargetChain() public {
@@ -434,16 +469,26 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
     }
 
     function testBridgeOutFailsNoApproval() public {
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        vm.deal(address(this), cost);
+
         vm.expectRevert("ERC20: insufficient allowance");
-        wormholeBridgeAdapterProxy.bridge{value: 0}(chainId, amount, to);
+        wormholeBridgeAdapterProxy.bridge{value: cost}(chainId, amount, to);
     }
 
     function testBridgeOutFailsNotEnoughBalance() public {
         deal(address(xwellProxy), address(this), amount - 1);
         xwellProxy.approve(address(wormholeBridgeAdapterProxy), amount);
 
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        vm.deal(address(this), cost);
+
         vm.expectRevert("ERC20: burn amount exceeds balance");
-        wormholeBridgeAdapterProxy.bridge{value: 0}(chainId, amount, to);
+        wormholeBridgeAdapterProxy.bridge{value: cost}(chainId, amount, to);
     }
 
     function testBridgeOutFailsNotEnoughBuffer() public {
@@ -454,8 +499,13 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
         amount = externalChainBufferCap;
         xwellProxy.approve(address(wormholeBridgeAdapterProxy), amount);
 
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        vm.deal(address(this), cost);
+
         vm.expectRevert("RateLimited: buffer cap overflow");
-        wormholeBridgeAdapterProxy.bridge{value: 0}(chainId, amount + 1, to);
+        wormholeBridgeAdapterProxy.bridge{value: cost}(chainId, amount + 1, to);
     }
 
     function testBridgeOutSucceeds() public {
@@ -467,6 +517,11 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
         _lockboxCanMintTo(address(this), uint112(amount));
         xwellProxy.approve(address(wormholeBridgeAdapterProxy), amount);
 
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        vm.deal(address(this), cost);
+
         vm.expectEmit(
             true,
             true,
@@ -475,6 +530,6 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
             address(wormholeBridgeAdapterProxy)
         );
         emit TokensSent(chainId, to, amount);
-        wormholeBridgeAdapterProxy.bridge{value: 0}(chainId, amount, to);
+        wormholeBridgeAdapterProxy.bridge{value: cost}(chainId, amount, to);
     }
 }

--- a/test/unit/WormholeUnwrapperAdapter.t.sol
+++ b/test/unit/WormholeUnwrapperAdapter.t.sol
@@ -8,6 +8,7 @@ import {WormholeUnwrapperAdapter} from "@protocol/xWELL/WormholeUnwrapperAdapter
 import {WormholeTrustedSender} from "@protocol/governance/WormholeTrustedSender.sol";
 import {MockCoreBridgeForAdapter} from "@test/mock/MockCoreBridgeForAdapter.sol";
 import {MockExecutorQuoterRouter} from "@test/mock/MockExecutorQuoterRouter.sol";
+import {IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 contract WormholeUnwrapperAdapterUnitTest is BaseTest {
     /// events
@@ -463,6 +464,57 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
         );
     }
 
+    function testBridgeOutExactPaySucceedsNoRefund() public {
+        amount = externalChainBufferCap / 2;
+        to = address(this);
+        _bridgeInViaVaa(0);
+
+        amount = externalChainBufferCap;
+        _lockboxCanMintTo(address(this), uint112(amount));
+        xwellProxy.approve(address(wormholeBridgeAdapterProxy), amount);
+
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        uint256 messageFee = mockCoreBridge.mockMessageFee();
+        vm.deal(address(this), cost);
+
+        wormholeBridgeAdapterProxy.bridge{value: cost}(chainId, amount, to);
+
+        assertEq(address(this).balance, 0, "no refund expected on exact pay");
+        assertEq(
+            mockExecutorQuoterRouter.lastRequestValue(),
+            cost - messageFee,
+            "router must receive quote net of message fee"
+        );
+    }
+
+    function testBridgeOutRevertsWhenRefundRejected() public {
+        /// build burn buffer (buffer is global to the adapter, not per-user)
+        amount = externalChainBufferCap / 2;
+        to = address(this);
+        _bridgeInViaVaa(0);
+
+        RejectingReceiver bridger = new RejectingReceiver(
+            wormholeBridgeAdapterProxy,
+            IERC20(address(xwellProxy))
+        );
+
+        uint256 outAmount = externalChainBufferCap;
+        _lockboxCanMintTo(address(bridger), uint112(outAmount));
+
+        mockExecutorQuoterRouter.setQuote(0.001 ether);
+        mockCoreBridge.setMessageFee(0.0001 ether);
+
+        uint256 cost = wormholeBridgeAdapterProxy.bridgeCost(chainId);
+        uint256 value = cost + 1; // overpay forces the refund path
+        vm.deal(address(bridger), value);
+
+        vm.expectRevert("WormholeBridge: refund failed");
+        bridger.doBridge{value: value}(chainId, outAmount, address(this));
+    }
+
     function testBridgeOutFailsIncorrectTargetChain() public {
         vm.expectRevert("WormholeBridge: invalid target chain");
         wormholeBridgeAdapterProxy.bridge{value: 0}(chainId + 1, amount, to);
@@ -531,5 +583,28 @@ contract WormholeUnwrapperAdapterUnitTest is BaseTest {
         );
         emit TokensSent(chainId, to, amount);
         wormholeBridgeAdapterProxy.bridge{value: cost}(chainId, amount, to);
+    }
+}
+
+contract RejectingReceiver {
+    WormholeBridgeAdapter public immutable adapter;
+    IERC20 public immutable token;
+
+    constructor(WormholeBridgeAdapter _adapter, IERC20 _token) {
+        adapter = _adapter;
+        token = _token;
+    }
+
+    function doBridge(
+        uint16 dstChainId,
+        uint256 amount,
+        address to
+    ) external payable {
+        token.approve(address(adapter), amount);
+        adapter.bridge{value: msg.value}(dstChainId, amount, to);
+    }
+
+    receive() external payable {
+        revert("reject");
     }
 }


### PR DESCRIPTION
## Summary

Two related changes:

1. **`WormholeBridgeAdapter` fix** — relax the onchain-quoter bridge path from `msg.value == quote` to `msg.value >= quote`, refunding the surplus to the caller. This unblocks callers that cannot predict the exact cost up front (e.g. a governance proposal whose live quote drifts over the ~5-day voting window): they overfund with a buffer and are charged only the live quote.
2. **MIP-X62** — deploys a fresh adapter implementation and upgrades the proxy on **Base, Optimism, and Ethereum** to ship the fix. Moonbeam is excluded (no onchain quoter there).

## Adapter change (`src/xWELL/WormholeBridgeAdapter.sol`)

- `require(msg.value == cost)` → `require(cost != 0)` + `require(msg.value >= cost)`.
- Refund `msg.value - cost` to `msg.sender` after the execution request (`require(success)`). It is the last external interaction; a re-entrant `bridge()` carries `msg.value == 0` and fails the floor, so no reentrancy guard is added (and none would be safe to add to a live upgradeable proxy without a storage append).
- Target-chain validity check moved above `bridgeCost` so an invalid chain reverts before quoting.
- Signed-quote path, `bridgeCost`, `executeVAAv1`, and `xWELLRouter` are unchanged. No storage layout change.

## Tests

- New unit tests (overpay+refund, exact-pay no-refund, underpay revert, quote-unavailable revert, refund-rejected revert) in `WormholeBridgeAdapter.t.sol` and the inherited `WormholeUnwrapperAdapter.t.sol`.
- Pre-existing bridge-out tests updated for the non-zero-quote semantics; integration zero-value case now expects `insufficient value for quote`.
- Suites green: `WormholeBridgeAdapterUnitTest` 46, `WormholeUnwrapperAdapter` 30, `xWELLBridgeFeePayer` 8.

## MIP-X62 (`proposals/mips/mip-x62/`)

- `HybridProposalV2` / `MultichainGovernorV2`, `id:0` in `mips.json`.
- `ProxyAdmin.upgrade` per chain — `PROXY_ADMIN` on Ethereum, `MRD_PROXY_ADMIN` on Base/Optimism.
- `validate()` proves on mainnet forks: impl swapped, pre-upgrade storage preserved, `bridgeCost > 0`, and an overpaying `bridge()` succeeds + refunds the surplus.
- Standalone `forge script` (deploy→build→run→validate) passes; ~3.8M gas estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)