### PR TITLE
feat(rewards-v2): generic size-driven action batching in template

### DIFF
--- a/.claude/rules/proposals.md
+++ b/.claude/rules/proposals.md
@@ -89,3 +89,17 @@
   into TG, a bridge sized only for the net balance will revert on the first
   transfer with `ERC20: transfer amount exceeds balance`. Trace TG
   inflow/outflow step-by-step when rebalancing bridge amounts across split MIPs.
+- `RewardsDistributionV2Template` (Ethereum-hub rewards, the current template)
+  auto-batches a large epoch: `chunkCount`/`chunkActions` split an oversized
+  per-chain wormhole bundle across multiple VAAs, and `batchProposeSplits`
+  submits the proposal in several init+append `propose()` calls, all sized from
+  the encoded calldata. A new rewards MIP does NOT need to hand-tune chunk
+  boundaries the way MIP-X59 did (`BASE_CHUNK_BOUNDARY`, manual `chunkCount`
+  overrides) — inherit the template and it computes a submittable split. Only
+  override the `virtual` budgets `maxChunkPayloadBytes()` (default 11KB, per-VAA
+  gov-action payload) / `maxProposeCallBytes()` (default 12KB, per-`propose()`
+  call — gas-bound, not a protocol cap) if a chain's gas ceiling differs. The
+  chunker never splits a dependent group (reduce→transfer reserve pair,
+  multiRewarder approve→notify, merkle approve→accept→create) across VAAs; new
+  dependent action sequences must call `_markAtomicGroup` in build so the
+  chunker keeps them in one VAA.

--- a/proposals/mips/mip-x59/mip-x59.sol
+++ b/proposals/mips/mip-x59/mip-x59.sol
@@ -77,7 +77,12 @@ contract mipx59 is RewardsDistributionV2Template {
         uint256 index
     ) public view override returns (ProposalAction[] memory chunk) {
         if (actionType != ActionType.Base) {
-            return super.chunkActions(actionType, index);
+            // chunkCount(non-Base) is pinned to 1 above, so return the FULL
+            // bundle explicitly. Delegating to super would land on the
+            // template's size-driven slicer, which could partition
+            // differently and silently drop the actions past its first
+            // slice (chunkCount/chunkActions must always agree).
+            return getActionsByType(actionType);
         }
 
         ProposalAction[] memory baseActions = getActionsByType(ActionType.Base);

--- a/proposals/proposalTypes/HybridProposalV2.sol
+++ b/proposals/proposalTypes/HybridProposalV2.sol
@@ -287,6 +287,9 @@ abstract contract HybridProposalV2 is
     /// bundle across multiple governor actions (each chunk becomes its own
     /// publishMessage call / VAA) so the proposal can be submitted in parts
     /// via the governor's init + append propose() batching.
+    /// @dev chunkCount and chunkActions describe one partition and MUST be
+    /// overridden together: a chunkCount that disagrees with the slices
+    /// chunkActions returns silently drops or duplicates actions.
     function chunkCount(ActionType) public view virtual returns (uint256) {
         return 1;
     }
@@ -296,6 +299,7 @@ abstract contract HybridProposalV2 is
     /// splitting dependent action sequences (e.g. reduce -> approve -> repay)
     /// across chunks, since each chunk executes as an independent temporal
     /// governor proposal on the destination chain.
+    /// @dev MUST be overridden together with chunkCount — see chunkCount.
     function chunkActions(
         ActionType actionType,
         uint256 index
@@ -834,19 +838,19 @@ abstract contract HybridProposalV2 is
         if (actions.proposalActionTypeCount(ActionType.Moonbeam) != 0) {
             vm.selectFork(MOONBEAM_FORK_ID);
             vm.warp(blockTimestamp);
-            _runExtChain(addresses, actions.filter(ActionType.Moonbeam));
+            _runExtChainChunks(addresses, ActionType.Moonbeam);
         }
 
         if (actions.proposalActionTypeCount(ActionType.Base) != 0) {
             vm.selectFork(BASE_FORK_ID);
             vm.warp(blockTimestamp);
-            _runExtChain(addresses, actions.filter(ActionType.Base));
+            _runExtChainChunks(addresses, ActionType.Base);
         }
 
         if (actions.proposalActionTypeCount(ActionType.Optimism) != 0) {
             vm.selectFork(OPTIMISM_FORK_ID);
             vm.warp(blockTimestamp);
-            _runExtChain(addresses, actions.filter(ActionType.Optimism));
+            _runExtChainChunks(addresses, ActionType.Optimism);
         }
 
         blockTimestamp = block.timestamp;
@@ -1128,6 +1132,22 @@ abstract contract HybridProposalV2 is
         _verifyMTokensPostRun();
 
         addresses.removeRestriction();
+    }
+
+    /// @notice run a chain's actions chunk by chunk in REVERSE chunk order.
+    /// Chunks execute on the destination chain as independent temporal
+    /// governor proposals with no ordering guarantee, so any hidden
+    /// cross-chunk dependency (e.g. an earlier chunk funding a balance a
+    /// later chunk spends) must make the simulation FAIL rather than pass by
+    /// silently riding the build order. Single-chunk proposals (the default
+    /// chunkCount of 1) execute exactly as before.
+    function _runExtChainChunks(
+        Addresses addresses,
+        ActionType actionType
+    ) internal {
+        for (uint256 c = chunkCount(actionType); c > 0; c--) {
+            _runExtChain(addresses, chunkActions(actionType, c - 1));
+        }
     }
 
     /// @notice Runs the proposal actions on an external chain (Moonbeam, Base, Optimism)

--- a/proposals/templates/RewardsDistributionV2.sol
+++ b/proposals/templates/RewardsDistributionV2.sol
@@ -196,6 +196,18 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
     /// read by the generic chunker in _computeChunkStarts.
     mapping(uint8 => mapping(uint256 => bool)) private _unsafeCut;
 
+    /// @notice per-ActionType 1-based per-type index of the first
+    /// withdrawWell action whose destination is the TEMPORAL_GOVERNOR
+    /// (0 = none). Later same-chain actions (multiRewarder approvals, merkle
+    /// campaign spends) may rely on that withdrawal replenishing the TG
+    /// balance, and chunks execute as unordered independent VAAs — so the
+    /// whole span from that withdrawal to the end of the chain's bundle is
+    /// marked atomic by _markTgWellSpan at the end of the chain build. If the
+    /// resulting region exceeds maxChunkPayloadBytes() the chunker fails
+    /// loudly: restructure the epoch (e.g. bridge the full TG outflow and
+    /// point withdrawWell elsewhere) or raise the budget.
+    mapping(uint8 => uint256) private _tgWellSpanStart;
+
     constructor() {
         bytes memory proposalDescription = abi.encodePacked(
             vm.readFile(vm.envString("DESCRIPTION_PATH"))
@@ -633,6 +645,9 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
     /// maxChunkPayloadBytes() rides a single VAA (return 1). Ethereum actions
     /// are local governor actions (never wormhole-bundled), so they are never
     /// chunked.
+    /// @dev chunkCount and chunkActions share one partition computation and
+    /// MUST be overridden together — overriding only one desynchronizes the
+    /// chunk count from the slices and silently drops or duplicates actions.
     function chunkCount(
         ActionType actionType
     ) public view virtual override returns (uint256) {
@@ -651,6 +666,7 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
     /// @notice the actions belonging to chunk `index` of `actionType`,
     /// partitioned so each chunk encodes within maxChunkPayloadBytes() and no
     /// dependent action group straddles two chunks.
+    /// @dev MUST be overridden together with chunkCount — see chunkCount.
     function chunkActions(
         ActionType actionType,
         uint256 index
@@ -697,11 +713,29 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
         uint256 acc = PROPOSE_CALL_OVERHEAD +
             _roundUp32(bytes(_proposeDescription()).length);
 
+        // an unpinned raw-markdown description can alone exceed the call
+        // budget, making the init call unfixably oversized (no split can
+        // shrink it). Warn loudly during simulation/printing so the author
+        // pins the description to IPFS (descriptionUri) before submission.
+        if (acc > budget) {
+            console.log(
+                "WARNING: proposal description alone exceeds maxProposeCallBytes; pin the description to IPFS (descriptionUri) before submission"
+            );
+        }
+
         for (uint256 i = 0; i < n; i++) {
             // per governor action in the propose() arrays: target (32) +
             // value (32) + payload offset (32) + payload length (32) + the
             // padded payload bytes
             uint256 contrib = 128 + _roundUp32(lens[i]);
+
+            // a single governor action that cannot fit a propose() call even
+            // alone can never be submitted within budget — fail loudly
+            // instead of emitting an oversized call silently
+            require(
+                PROPOSE_CALL_OVERHEAD + contrib <= budget,
+                "RewardsDistribution: single governor action exceeds maxProposeCallBytes"
+            );
 
             if (i > 0 && acc + contrib > budget) {
                 tmp[count++] = i;
@@ -790,6 +824,21 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
             }
 
             prevBoundary = b;
+        }
+
+        // an indivisible unit (atomic region or single action) larger than
+        // the budget cannot be partitioned — fail loudly instead of silently
+        // emitting an over-budget chunk that cascades into an over-budget
+        // propose() call. Restructure the epoch (smaller atomic regions,
+        // bridge the full TG outflow instead of relying on withdrawWell) or
+        // raise maxChunkPayloadBytes().
+        for (uint256 k = 0; k < count; k++) {
+            require(
+                _chunkEncodedSize(
+                    _sliceActions(a, tmp[k], k + 1 < count ? tmp[k + 1] : len)
+                ) <= budget,
+                "RewardsDistribution: atomic action region exceeds maxChunkPayloadBytes"
+            );
         }
 
         starts = new uint256[](count);
@@ -1654,24 +1703,14 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
         }
 
         // withdraw WELL from the Market Reserve ERC20 Holding Deposit contract
-        for (uint256 i = 0; i < spec.withdrawWell.length; i++) {
-            _pushAction(
-                addresses.getAddress("RESERVE_WELL_HOLDING_DEPOSIT"),
-                abi.encodeWithSignature(
-                    "withdrawERC20Token(address,address,uint256)",
-                    addresses.getAddress("GOVTOKEN"),
-                    addresses.getAddress(spec.withdrawWell[i].to),
-                    spec.withdrawWell[i].amount
-                ),
-                string.concat(
-                    "Withdraw ",
-                    vm.toString(spec.withdrawWell[i].amount / 1e18),
-                    " WELL ",
-                    " from the WELL Reserve Holding Deposit Contract on Moonbeam"
-                ),
-                ActionType.Moonbeam
-            );
-        }
+        // (the active fork is Moonbeam, so the 3-arg _pushAction inside the
+        // helper resolves to ActionType.Moonbeam)
+        _buildWithdrawWellActions(
+            addresses,
+            MOONBEAM_CHAIN_ID,
+            spec.withdrawWell,
+            "GOVTOKEN"
+        );
 
         for (uint256 i = 0; i < spec.setRewardSpeed.length; i++) {
             SetRewardSpeed memory setRewardSpeed = spec.setRewardSpeed[i];
@@ -1728,6 +1767,10 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
                 ActionType.Moonbeam
             );
         }
+
+        // must run after every Moonbeam action has been pushed (see
+        // _tgWellSpanStart)
+        _markTgWellSpan(MOONBEAM_CHAIN_ID);
     }
 
     function _buildExternalChainActions(
@@ -1908,59 +1951,59 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
         }
 
         // withdraw reserves from the Market Reserve ERC20 Holding Deposit contract
-        for (uint256 i = 0; i < spec.withdrawWell.length; i++) {
-            _pushAction(
-                addresses.getAddress("RESERVE_WELL_HOLDING_DEPOSIT"),
-                abi.encodeWithSignature(
-                    "withdrawERC20Token(address,address,uint256)",
-                    addresses.getAddress("xWELL_PROXY"),
-                    addresses.getAddress(spec.withdrawWell[i].to),
-                    spec.withdrawWell[i].amount
-                ),
-                string.concat(
-                    "Withdraw ",
-                    vm.toString(spec.withdrawWell[i].amount / 1e18),
-                    " WELL ",
-                    " from the WELL Reserve Holding Deposit Contract on ",
-                    _chainId.chainIdToName()
-                )
-            );
-        }
-
-        // initiateSale sizes each sale from the automation contract's balance
-        // at execution time, so the transferReserves region that funds those
-        // contracts and the initiateSale calls themselves must ride a single
-        // VAA — the nested call threads the region's start index through
-        // without a caller local (this function is at the stack limit)
-        _buildInitSaleActions(
+        _buildWithdrawWellActions(
             addresses,
             _chainId,
-            spec.initSale,
-            _buildTransferReserveActions(
-                addresses,
-                _chainId,
-                spec.transferReserves
-            )
+            spec.withdrawWell,
+            "xWELL_PROXY"
+        );
+
+        _buildReserveAutomationActions(
+            addresses,
+            _chainId,
+            spec.transferReserves,
+            spec.initSale
         );
 
         _buildMultiRewarderActions(addresses, _chainId, spec.multiRewarder);
 
         _buildMerkleCampaignActions(addresses, _chainId, spec.merkleCampaigns);
+
+        // must run after every action of this chain has been pushed: marks
+        // the span from the first withdrawWell(to = TEMPORAL_GOVERNOR) to the
+        // end of the bundle as atomic (see _tgWellSpanStart)
+        _markTgWellSpan(_chainId);
     }
 
-    /// @notice build the reduce -> transfer reserve pairs for a chain. Each
-    /// pair is an atomic group (the transfer spends the reduced reserves), so
-    /// its interior boundary is marked to keep it inside a single VAA.
-    /// @return regionStart the per-type action index where this region begins,
-    /// consumed by _buildInitSaleActions to extend the atomic region over the
-    /// initiateSale calls that depend on the transferred reserves
-    function _buildTransferReserveActions(
+    /// @notice build the reserve automation actions for a chain laid out PER
+    /// MARKET: each market's reduce -> transfer pair is immediately followed
+    /// by the initiateSale of the automation contract it funds, and the
+    /// 2-or-3-action group is marked atomic. initiateSale computes
+    /// periodSaleAmount from the automation contract's reserveAsset balance
+    /// AT EXECUTION TIME (and reverts when it is zero), while chunks execute
+    /// as independent temporal governor proposals with no ordering guarantee
+    /// — so a market's funding and its sale must ride a single VAA. The
+    /// per-market layout keeps each atomic group small, letting the chunker
+    /// cut BETWEEN markets instead of carrying one indivisible region that
+    /// grows with the market count. initiateSale calls for contracts not
+    /// funded by this epoch's transferReserves (selling a pre-existing
+    /// balance) are appended afterwards as independent single actions.
+    function _buildReserveAutomationActions(
         Addresses addresses,
         uint256 _chainId,
-        TransferReserves[] memory transferReserves
-    ) private returns (uint256 regionStart) {
+        TransferReserves[] memory transferReserves,
+        InitSale memory initSale
+    ) private {
         ActionType t = _actionTypeForChain(_chainId);
-        regionStart = actions.proposalActionTypeCount(t);
+
+        // whether this epoch initiates sales at all (same validity condition
+        // the JSON parser uses)
+        bool hasSales = initSale.auctionPeriod != 0 ||
+            initSale.reserveAutomationContracts.length > 0;
+
+        bool[] memory saleBuilt = new bool[](
+            initSale.reserveAutomationContracts.length
+        );
 
         for (uint256 i = 0; i < transferReserves.length; i++) {
             uint256 grpStart = actions.proposalActionTypeCount(t);
@@ -2011,66 +2054,140 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
                 )
             );
 
-            _markAtomicGroup(t, grpStart, 2);
+            // the initiateSale of the automation contract this transfer
+            // funds joins the market's atomic group
+            if (hasSales) {
+                for (
+                    uint256 j = 0;
+                    j < initSale.reserveAutomationContracts.length;
+                    j++
+                ) {
+                    if (
+                        !saleBuilt[j] &&
+                        addresses.getAddress(
+                            initSale.reserveAutomationContracts[j]
+                        ) ==
+                        addresses.getAddress(transferReserves[i].to)
+                    ) {
+                        saleBuilt[j] = true;
+                        _pushInitiateSale(addresses, _chainId, initSale, j);
+                    }
+                }
+            }
+
+            _markAtomicGroup(
+                t,
+                grpStart,
+                actions.proposalActionTypeCount(t) - grpStart
+            );
+        }
+
+        // sales of pre-existing balances (no transferReserves funding this
+        // epoch): independent single actions, safe to cut around
+        if (hasSales) {
+            for (
+                uint256 j = 0;
+                j < initSale.reserveAutomationContracts.length;
+                j++
+            ) {
+                if (!saleBuilt[j]) {
+                    _pushInitiateSale(addresses, _chainId, initSale, j);
+                }
+            }
         }
     }
 
-    /// @notice build the initiateSale actions for a chain's reserve
-    /// automation contracts. initiateSale computes periodSaleAmount from the
-    /// automation contract's reserveAsset balance AT EXECUTION TIME and
-    /// reverts when it is zero — but chunks execute as independent temporal
-    /// governor proposals with no ordering guarantee on the destination
-    /// chain. A chunk boundary between a market's reserve transfer and its
-    /// initiateSale could therefore initialize a sale against a zero or
-    /// partial balance. The whole [regionStart, end) region — the
-    /// transferReserves pairs plus every initiateSale — is marked atomic so
-    /// the chunker keeps it in one VAA.
-    function _buildInitSaleActions(
+    /// @notice push a single initiateSale action for the automation contract
+    /// at `index` of initSale.reserveAutomationContracts
+    function _pushInitiateSale(
         Addresses addresses,
         uint256 _chainId,
         InitSale memory initSale,
-        uint256 regionStart
+        uint256 index
     ) private {
-        // Process initSale only if it exists in the JSON and has valid data
-        if (
-            initSale.auctionPeriod == 0 &&
-            initSale.reserveAutomationContracts.length == 0
-        ) {
-            return;
-        }
+        address reserveAutomationContract = addresses.getAddress(
+            initSale.reserveAutomationContracts[index]
+        );
 
-        for (
-            uint256 i = 0;
-            i < initSale.reserveAutomationContracts.length;
-            i++
-        ) {
-            address reserveAutomationContract = addresses.getAddress(
-                initSale.reserveAutomationContracts[i]
-            );
+        _pushAction(
+            reserveAutomationContract,
+            abi.encodeWithSignature(
+                "initiateSale(uint256,uint256,uint256,uint256,uint256)",
+                initSale.delay,
+                initSale.auctionPeriod,
+                initSale.miniAuctionPeriod,
+                initSale.periodMaxDiscount,
+                initSale.periodStartingPremium
+            ),
+            string.concat(
+                "Init reserve sale for ",
+                vm.getLabel(reserveAutomationContract),
+                " on ",
+                _chainId.chainIdToName()
+            )
+        );
+    }
+
+    /// @notice build the withdrawWell actions for a chain, recording the
+    /// first withdrawal whose destination is the TEMPORAL_GOVERNOR in
+    /// _tgWellSpanStart so _markTgWellSpan can protect every later action
+    /// that may spend the replenished TG balance (see _tgWellSpanStart).
+    /// @param tokenName the registry key of the withdrawn token: xWELL_PROXY
+    /// on external chains, GOVTOKEN on Moonbeam
+    function _buildWithdrawWellActions(
+        Addresses addresses,
+        uint256 _chainId,
+        WithdrawWell[] memory withdrawWells,
+        string memory tokenName
+    ) private {
+        ActionType t = _actionTypeForChain(_chainId);
+
+        for (uint256 i = 0; i < withdrawWells.length; i++) {
+            if (
+                _tgWellSpanStart[uint8(t)] == 0 &&
+                addresses.isAddressSet("TEMPORAL_GOVERNOR") &&
+                addresses.getAddress(withdrawWells[i].to) ==
+                addresses.getAddress("TEMPORAL_GOVERNOR")
+            ) {
+                _tgWellSpanStart[uint8(t)] =
+                    actions.proposalActionTypeCount(t) +
+                    1;
+            }
 
             _pushAction(
-                reserveAutomationContract,
+                addresses.getAddress("RESERVE_WELL_HOLDING_DEPOSIT"),
                 abi.encodeWithSignature(
-                    "initiateSale(uint256,uint256,uint256,uint256,uint256)",
-                    initSale.delay,
-                    initSale.auctionPeriod,
-                    initSale.miniAuctionPeriod,
-                    initSale.periodMaxDiscount,
-                    initSale.periodStartingPremium
+                    "withdrawERC20Token(address,address,uint256)",
+                    addresses.getAddress(tokenName),
+                    addresses.getAddress(withdrawWells[i].to),
+                    withdrawWells[i].amount
                 ),
                 string.concat(
-                    "Init reserve sale for ",
-                    vm.getLabel(reserveAutomationContract),
-                    " on ",
+                    "Withdraw ",
+                    vm.toString(withdrawWells[i].amount / 1e18),
+                    " WELL ",
+                    " from the WELL Reserve Holding Deposit Contract on ",
                     _chainId.chainIdToName()
                 )
             );
         }
+    }
 
+    /// @notice mark the span from the first withdrawWell(to = TG) action to
+    /// the end of the chain's bundle as atomic. Must run after every action
+    /// of the chain has been pushed. No-op when the chain has no TG-bound
+    /// withdrawal. If the span exceeds maxChunkPayloadBytes() the chunker
+    /// fails loudly at simulation/print time (see _computeChunkStarts).
+    function _markTgWellSpan(uint256 _chainId) private {
         ActionType t = _actionTypeForChain(_chainId);
-        uint256 regionEnd = actions.proposalActionTypeCount(t);
-        if (regionEnd > regionStart) {
-            _markAtomicGroup(t, regionStart, regionEnd - regionStart);
+        uint256 start = _tgWellSpanStart[uint8(t)];
+        if (start == 0) {
+            return;
+        }
+
+        uint256 end = actions.proposalActionTypeCount(t);
+        if (end > start - 1) {
+            _markAtomicGroup(t, start - 1, end - (start - 1));
         }
     }
 

--- a/proposals/templates/RewardsDistributionV2.sol
+++ b/proposals/templates/RewardsDistributionV2.sol
@@ -1950,19 +1950,25 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
             );
         }
 
-        // withdraw reserves from the Market Reserve ERC20 Holding Deposit contract
-        _buildWithdrawWellActions(
-            addresses,
-            _chainId,
-            spec.withdrawWell,
-            "xWELL_PROXY"
-        );
-
         _buildReserveAutomationActions(
             addresses,
             _chainId,
             spec.transferReserves,
             spec.initSale
+        );
+
+        // withdraw WELL from the Market Reserve ERC20 Holding Deposit
+        // contract. Built AFTER the reserve automation region on purpose:
+        // the TG-WELL atomic span runs from the first withdrawWell(to = TG)
+        // to the end of the bundle, and the reserve region never touches TG
+        // WELL — building it first keeps it out of the span, so the span
+        // only covers the WELL-spending multiRewarder/merkle actions and
+        // stays well under the chunk budget.
+        _buildWithdrawWellActions(
+            addresses,
+            _chainId,
+            spec.withdrawWell,
+            "xWELL_PROXY"
         );
 
         _buildMultiRewarderActions(addresses, _chainId, spec.multiRewarder);
@@ -2063,12 +2069,20 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
                     j++
                 ) {
                     if (
-                        !saleBuilt[j] &&
                         addresses.getAddress(
                             initSale.reserveAutomationContracts[j]
-                        ) ==
-                        addresses.getAddress(transferReserves[i].to)
+                        ) == addresses.getAddress(transferReserves[i].to)
                     ) {
+                        // a second transferReserves funding the same
+                        // automation contract would leave the already-built
+                        // initiateSale sized without it (the sale snapshots
+                        // its balance at execution time) — fail loudly. The
+                        // worker emits exactly one transferReserves per
+                        // market; merge the amounts if that ever changes.
+                        require(
+                            !saleBuilt[j],
+                            "RewardsDistribution: multiple transferReserves fund one automation contract"
+                        );
                         saleBuilt[j] = true;
                         _pushInitiateSale(addresses, _chainId, initSale, j);
                     }
@@ -2139,7 +2153,7 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
         uint256 _chainId,
         WithdrawWell[] memory withdrawWells,
         string memory tokenName
-    ) private {
+    ) internal {
         ActionType t = _actionTypeForChain(_chainId);
 
         for (uint256 i = 0; i < withdrawWells.length; i++) {
@@ -2154,6 +2168,10 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
                     1;
             }
 
+            // ActionType passed explicitly (instead of the fork-derived
+            // 3-arg _pushAction) so this path also runs in fork-less unit
+            // tests; in production builds the active fork always matches
+            // _chainId, so behaviour is identical
             _pushAction(
                 addresses.getAddress("RESERVE_WELL_HOLDING_DEPOSIT"),
                 abi.encodeWithSignature(
@@ -2168,7 +2186,8 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
                     " WELL ",
                     " from the WELL Reserve Holding Deposit Contract on ",
                     _chainId.chainIdToName()
-                )
+                ),
+                t
             );
         }
     }
@@ -2178,7 +2197,7 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
     /// of the chain has been pushed. No-op when the chain has no TG-bound
     /// withdrawal. If the span exceeds maxChunkPayloadBytes() the chunker
     /// fails loudly at simulation/print time (see _computeChunkStarts).
-    function _markTgWellSpan(uint256 _chainId) private {
+    function _markTgWellSpan(uint256 _chainId) internal {
         ActionType t = _actionTypeForChain(_chainId);
         uint256 start = _tgWellSpanStart[uint8(t)];
         if (start == 0) {

--- a/proposals/templates/RewardsDistributionV2.sol
+++ b/proposals/templates/RewardsDistributionV2.sol
@@ -24,7 +24,7 @@ import {xWELLBridgeFeePayer} from "@protocol/xWELL/xWELLBridgeFeePayer.sol";
 import {ComptrollerInterfaceV1} from "@protocol/views/ComptrollerInterfaceV1.sol";
 import {MultiRewardDistributor} from "@protocol/rewards/MultiRewardDistributor.sol";
 import {IMultiRewardDistributor} from "@protocol/rewards/IMultiRewardDistributor.sol";
-import {ActionType} from "@proposals/proposalTypes/IProposal.sol";
+import {ActionType, ProposalAction} from "@proposals/proposalTypes/IProposal.sol";
 import {HybridProposalV2} from "@proposals/proposalTypes/HybridProposalV2.sol";
 import {MultiRewardDistributorCommon} from "@protocol/rewards/MultiRewardDistributorCommon.sol";
 import {IERC20Metadata as IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -187,6 +187,14 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
 
     /// @notice Track reserve automation contract balances before proposal execution
     mapping(address => uint256) public reserveAutomationBalancesBefore;
+
+    /// @notice per-ActionType map of per-type action indices where a chunk
+    /// boundary is FORBIDDEN because cutting there would split a dependent
+    /// action sequence (a reduce->transfer reserve pair, a multiRewarder
+    /// approve->notify group, or an approve->accept->create merkle triple)
+    /// across two wormhole VAAs. Populated during build by _markAtomicGroup;
+    /// read by the generic chunker in _computeChunkStarts.
+    mapping(uint8 => mapping(uint256 => bool)) private _unsafeCut;
 
     constructor() {
         bytes memory proposalDescription = abi.encodePacked(
@@ -572,6 +580,274 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
                 vm.selectFork(networks[i].forkId);
                 _validateExternalChainActions(addresses, chainId);
             }
+        }
+    }
+
+    /// -----------------------------------------------------
+    /// -----------------------------------------------------
+    /// -------------- Generic action batching --------------
+    /// -----------------------------------------------------
+    /// -----------------------------------------------------
+    ///
+    /// A full rewards epoch can encode to tens of KB across 100+ actions,
+    /// which is far too large to submit in a single MultichainGovernorV2
+    /// propose() call (propose() SSTOREs every action's calldata, so the
+    /// binding limit is gas, not a protocol constant). The base
+    /// HybridProposalV2 exposes three hooks for splitting the submission —
+    /// chunkCount / chunkActions (split an oversized per-chain wormhole bundle
+    /// across multiple VAAs) and batchProposeSplits (submit the proposal in
+    /// several init + append propose() calls). Prior rewards MIPs (e.g. x59)
+    /// hand-tuned these per JSON. This template computes them automatically
+    /// from the encoded size of the actions, so future rewards MIPs inherit a
+    /// submittable split with no manual boundary tuning.
+
+    /// @notice max encoded byte size of a single chain's per-chunk temporal
+    /// governor payload (one wormhole publishMessage governor action). A chain
+    /// whose bundled actions exceed this is split into more chunks. Kept below
+    /// maxProposeCallBytes() so any single chunk always fits in one propose()
+    /// call. Virtual so a MIP can tune it without reimplementing the chunker.
+    function maxChunkPayloadBytes() public view virtual returns (uint256) {
+        return 11_000;
+    }
+
+    /// @notice max total calldata (bytes) of a single propose() submission.
+    /// ~12KB keeps a submission comfortably under the Ethereum block gas limit
+    /// given propose() stores every action's calldata. Virtual so a MIP can
+    /// tune it without reimplementing the packer.
+    function maxProposeCallBytes() public view virtual returns (uint256) {
+        return 12_000;
+    }
+
+    /// @notice fixed per-call abi overhead accounted for when packing propose()
+    /// calls: selector, the five argument heads, three array length words, the
+    /// finalize bool and a short IPFS description URI. Production descriptions
+    /// are pinned to a short URI, so a small constant is sufficient.
+    uint256 private constant PROPOSE_CALL_OVERHEAD = 512;
+
+    /// @notice number of wormhole publishMessage chunks a chain's bundle is
+    /// split into. Size-driven: a chain whose actions encode within
+    /// maxChunkPayloadBytes() rides a single VAA (return 1). Ethereum actions
+    /// are local governor actions (never wormhole-bundled), so they are never
+    /// chunked.
+    function chunkCount(
+        ActionType actionType
+    ) public view virtual override returns (uint256) {
+        if (actionType == ActionType.Ethereum) {
+            return 1;
+        }
+
+        ProposalAction[] memory a = getActionsByType(actionType);
+        if (a.length == 0) {
+            return 1;
+        }
+
+        return _computeChunkStarts(actionType, a).length;
+    }
+
+    /// @notice the actions belonging to chunk `index` of `actionType`,
+    /// partitioned so each chunk encodes within maxChunkPayloadBytes() and no
+    /// dependent action group straddles two chunks.
+    function chunkActions(
+        ActionType actionType,
+        uint256 index
+    ) public view virtual override returns (ProposalAction[] memory) {
+        if (actionType == ActionType.Ethereum) {
+            return super.chunkActions(actionType, index);
+        }
+
+        ProposalAction[] memory a = getActionsByType(actionType);
+        uint256[] memory starts = _computeChunkStarts(actionType, a);
+        require(index < starts.length, "chunkActions: index out of range");
+
+        uint256 start = starts[index];
+        uint256 end = index + 1 < starts.length ? starts[index + 1] : a.length;
+
+        return _sliceActions(a, start, end);
+    }
+
+    /// @notice governor-action indices at which the proposal is split into
+    /// successive propose() calls, each within maxProposeCallBytes(). Greedily
+    /// packs the ordered governor actions (every Ethereum action, then the
+    /// Moonbeam / Base / Optimism chunks — matching getTargetsPayloadsValues
+    /// order) into as few calls as fit. Empty => a single propose() call.
+    function batchProposeSplits()
+        public
+        view
+        virtual
+        override
+        returns (uint256[] memory)
+    {
+        uint256[] memory lens = _governorActionPayloadSizes();
+        uint256 n = lens.length;
+
+        uint256[] memory tmp = new uint256[](n);
+        uint256 count = 0;
+        uint256 budget = maxProposeCallBytes();
+        uint256 acc = PROPOSE_CALL_OVERHEAD;
+
+        for (uint256 i = 0; i < n; i++) {
+            // per governor action in the propose() arrays: target (32) +
+            // value (32) + payload offset (32) + payload length (32) + the
+            // padded payload bytes
+            uint256 contrib = 128 + _roundUp32(lens[i]);
+
+            if (i > 0 && acc + contrib > budget) {
+                tmp[count++] = i;
+                acc = PROPOSE_CALL_OVERHEAD;
+            }
+
+            acc += contrib;
+        }
+
+        uint256[] memory splits = new uint256[](count);
+        for (uint256 i = 0; i < count; i++) {
+            splits[i] = tmp[i];
+        }
+
+        return splits;
+    }
+
+    /// @notice governor-action payload byte lengths in getTargetsPayloadsValues
+    /// order: every Ethereum action individually, then one entry per chunk for
+    /// Moonbeam, Base and Optimism (only for chains that have actions).
+    function _governorActionPayloadSizes()
+        private
+        view
+        returns (uint256[] memory lens)
+    {
+        lens = new uint256[](allActionTypesCount());
+        uint256 idx = 0;
+
+        ProposalAction[] memory eth = getActionsByType(ActionType.Ethereum);
+        for (uint256 i = 0; i < eth.length; i++) {
+            lens[idx++] = eth[i].data.length;
+        }
+
+        ActionType[3] memory bundled = [
+            ActionType.Moonbeam,
+            ActionType.Base,
+            ActionType.Optimism
+        ];
+        for (uint256 b = 0; b < bundled.length; b++) {
+            if (getActionsByType(bundled[b]).length == 0) {
+                continue;
+            }
+
+            uint256 chunks = chunkCount(bundled[b]);
+            for (uint256 c = 0; c < chunks; c++) {
+                lens[idx++] = _chunkEncodedSize(chunkActions(bundled[b], c));
+            }
+        }
+    }
+
+    /// @notice minimum chunk start indices (per-type) that partition `a` so
+    /// each chunk encodes within maxChunkPayloadBytes(), cutting only at safe
+    /// boundaries (never inside a dependent action group). starts[0] == 0
+    /// always; chunk k spans [starts[k], starts[k + 1]) with the last chunk
+    /// running to a.length. Deterministic, so chunkCount and chunkActions agree.
+    function _computeChunkStarts(
+        ActionType actionType,
+        ProposalAction[] memory a
+    ) private view returns (uint256[] memory starts) {
+        uint256 len = a.length;
+        uint256[] memory tmp = new uint256[](len == 0 ? 1 : len);
+        uint256 count = 0;
+        tmp[count++] = 0;
+
+        uint256 budget = maxChunkPayloadBytes();
+        uint256 chunkStart = 0;
+        uint256 prevBoundary = 0;
+
+        for (uint256 b = 1; b <= len; b++) {
+            // a cut before index b is allowed unless it splits a group; the
+            // final boundary (b == len) is always allowed
+            bool allowed = b == len || !_unsafeCut[uint8(actionType)][b];
+            if (!allowed) {
+                continue;
+            }
+
+            // if extending the current chunk to include the unit
+            // [prevBoundary, b) overflows the budget, close the chunk at
+            // prevBoundary and start a fresh one with this unit
+            if (
+                prevBoundary > chunkStart &&
+                _chunkEncodedSize(_sliceActions(a, chunkStart, b)) > budget
+            ) {
+                tmp[count++] = prevBoundary;
+                chunkStart = prevBoundary;
+            }
+
+            prevBoundary = b;
+        }
+
+        starts = new uint256[](count);
+        for (uint256 i = 0; i < count; i++) {
+            starts[i] = tmp[i];
+        }
+    }
+
+    /// @notice abi-encoded byte length of the wormhole publishMessage calldata
+    /// that bundles `a` into one temporal governor VAA (the governor-action
+    /// payload). The temporal governor address does not affect the encoded
+    /// size, so a placeholder keeps this a pure size computation.
+    function _chunkEncodedSize(
+        ProposalAction[] memory a
+    ) internal view returns (uint256) {
+        address[] memory targets = new address[](a.length);
+        uint256[] memory values = new uint256[](a.length);
+        bytes[] memory payloads = new bytes[](a.length);
+
+        for (uint256 i = 0; i < a.length; i++) {
+            targets[i] = a[i].target;
+            values[i] = a[i].value;
+            payloads[i] = a[i].data;
+        }
+
+        return
+            abi
+                .encodeWithSignature(
+                    "publishMessage(uint32,bytes,uint8)",
+                    nonce,
+                    abi.encode(address(1), targets, values, payloads),
+                    consistencyLevel
+                )
+                .length;
+    }
+
+    function _sliceActions(
+        ProposalAction[] memory a,
+        uint256 start,
+        uint256 end
+    ) private pure returns (ProposalAction[] memory out) {
+        out = new ProposalAction[](end - start);
+        for (uint256 i = start; i < end; i++) {
+            out[i - start] = a[i];
+        }
+    }
+
+    function _roundUp32(uint256 x) private pure returns (uint256) {
+        return ((x + 31) / 32) * 32;
+    }
+
+    function _actionTypeForChain(
+        uint256 _chainId
+    ) private pure returns (ActionType) {
+        if (_chainId == MOONBEAM_CHAIN_ID) return ActionType.Moonbeam;
+        if (_chainId == BASE_CHAIN_ID) return ActionType.Base;
+        if (_chainId == OPTIMISM_CHAIN_ID) return ActionType.Optimism;
+        return ActionType.Ethereum;
+    }
+
+    /// @notice mark the interior boundaries of a `groupLen`-action dependent
+    /// sequence (starting at per-type index `start`) as forbidden chunk cut
+    /// points, so the chunker keeps the whole group inside a single VAA.
+    function _markAtomicGroup(
+        ActionType actionType,
+        uint256 start,
+        uint256 groupLen
+    ) internal {
+        for (uint256 k = 1; k < groupLen; k++) {
+            _unsafeCut[uint8(actionType)][start + k] = true;
         }
     }
 
@@ -1639,53 +1915,11 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
             );
         }
 
-        for (uint256 i = 0; i < spec.transferReserves.length; i++) {
-            IERC20 underlying = IERC20(
-                MErc20(addresses.getAddress(spec.transferReserves[i].market))
-                    .underlying()
-            );
-
-            _pushAction(
-                addresses.getAddress(spec.transferReserves[i].market),
-                abi.encodeWithSignature(
-                    "_reduceReserves(uint256)",
-                    spec.transferReserves[i].amount
-                ),
-                string.concat(
-                    "Withdraw ",
-                    vm.toString(
-                        spec.transferReserves[i].amount / underlying.decimals()
-                    ),
-                    " ",
-                    underlying.symbol(),
-                    " from ",
-                    spec.transferReserves[i].market,
-                    " on ",
-                    _chainId.chainIdToName()
-                )
-            );
-
-            _pushAction(
-                address(underlying),
-                abi.encodeWithSignature(
-                    "transfer(address,uint256)",
-                    addresses.getAddress(spec.transferReserves[i].to),
-                    spec.transferReserves[i].amount
-                ),
-                string.concat(
-                    "Transfer ",
-                    vm.toString(
-                        spec.transferReserves[i].amount / underlying.decimals()
-                    ),
-                    " ",
-                    underlying.symbol(),
-                    " to ",
-                    spec.transferReserves[i].to,
-                    " on ",
-                    _chainId.chainIdToName()
-                )
-            );
-        }
+        _buildTransferReserveActions(
+            addresses,
+            _chainId,
+            spec.transferReserves
+        );
 
         // Process initSale if it exists in the JSON and has valid data
         if (
@@ -1727,8 +1961,86 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
             }
         }
 
-        for (uint256 i = 0; i < spec.multiRewarder.length; i++) {
-            MultiRewarder memory multiRewarder = spec.multiRewarder[i];
+        _buildMultiRewarderActions(addresses, _chainId, spec.multiRewarder);
+
+        _buildMerkleCampaignActions(addresses, _chainId, spec.merkleCampaigns);
+    }
+
+    /// @notice build the reduce -> transfer reserve pairs for a chain. Each
+    /// pair is an atomic group (the transfer spends the reduced reserves), so
+    /// its interior boundary is marked to keep it inside a single VAA.
+    function _buildTransferReserveActions(
+        Addresses addresses,
+        uint256 _chainId,
+        TransferReserves[] memory transferReserves
+    ) private {
+        ActionType t = _actionTypeForChain(_chainId);
+
+        for (uint256 i = 0; i < transferReserves.length; i++) {
+            uint256 grpStart = actions.proposalActionTypeCount(t);
+
+            IERC20 underlying = IERC20(
+                MErc20(addresses.getAddress(transferReserves[i].market))
+                    .underlying()
+            );
+
+            _pushAction(
+                addresses.getAddress(transferReserves[i].market),
+                abi.encodeWithSignature(
+                    "_reduceReserves(uint256)",
+                    transferReserves[i].amount
+                ),
+                string.concat(
+                    "Withdraw ",
+                    vm.toString(
+                        transferReserves[i].amount / underlying.decimals()
+                    ),
+                    " ",
+                    underlying.symbol(),
+                    " from ",
+                    transferReserves[i].market,
+                    " on ",
+                    _chainId.chainIdToName()
+                )
+            );
+
+            _pushAction(
+                address(underlying),
+                abi.encodeWithSignature(
+                    "transfer(address,uint256)",
+                    addresses.getAddress(transferReserves[i].to),
+                    transferReserves[i].amount
+                ),
+                string.concat(
+                    "Transfer ",
+                    vm.toString(
+                        transferReserves[i].amount / underlying.decimals()
+                    ),
+                    " ",
+                    underlying.symbol(),
+                    " to ",
+                    transferReserves[i].to,
+                    " on ",
+                    _chainId.chainIdToName()
+                )
+            );
+
+            _markAtomicGroup(t, grpStart, 2);
+        }
+    }
+
+    /// @notice build the multiRewarder (optional addReward) -> approve ->
+    /// notifyRewardAmount groups for a chain. notify pulls the approved reward
+    /// tokens, so each group is atomic and kept inside a single VAA.
+    function _buildMultiRewarderActions(
+        Addresses addresses,
+        uint256 _chainId,
+        MultiRewarder[] memory multiRewarders
+    ) private {
+        ActionType t = _actionTypeForChain(_chainId);
+
+        for (uint256 i = 0; i < multiRewarders.length; i++) {
+            MultiRewarder memory multiRewarder = multiRewarders[i];
 
             address distributor = addresses.getAddress(
                 multiRewarder.distributor
@@ -1740,6 +2052,8 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
             address vault = addresses.getAddress(multiRewarder.vault);
 
             uint256 duration = multiRewarder.duration;
+
+            uint256 grpStart = actions.proposalActionTypeCount(t);
 
             if (vm.envOr("FORCE_ADD_REWARD", false)) {
                 _pushAction(
@@ -1826,11 +2140,29 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
                     multiRewarder.vault
                 )
             );
-        }
 
-        // Process Merkle campaigns
-        for (uint256 i = 0; i < spec.merkleCampaigns.length; i++) {
-            MekleCampaign memory campaign = spec.merkleCampaigns[i];
+            _markAtomicGroup(
+                t,
+                grpStart,
+                actions.proposalActionTypeCount(t) - grpStart
+            );
+        }
+    }
+
+    /// @notice build the merkle campaign approve -> acceptConditions ->
+    /// createCampaign triples for a chain. The triple is atomic and kept
+    /// inside a single VAA.
+    function _buildMerkleCampaignActions(
+        Addresses addresses,
+        uint256 _chainId,
+        MekleCampaign[] memory merkleCampaigns
+    ) private {
+        ActionType t = _actionTypeForChain(_chainId);
+
+        for (uint256 i = 0; i < merkleCampaigns.length; i++) {
+            MekleCampaign memory campaign = merkleCampaigns[i];
+
+            uint256 grpStart = actions.proposalActionTypeCount(t);
 
             address rewardTokenAddress = addresses.getAddress(
                 campaign.rewardToken
@@ -1889,6 +2221,8 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
                     vm.toString(campaign.amount)
                 )
             );
+
+            _markAtomicGroup(t, grpStart, 3);
         }
     }
 

--- a/proposals/templates/RewardsDistributionV2.sol
+++ b/proposals/templates/RewardsDistributionV2.sol
@@ -606,6 +606,10 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
     /// whose bundled actions exceed this is split into more chunks. Kept below
     /// maxProposeCallBytes() so any single chunk always fits in one propose()
     /// call. Virtual so a MIP can tune it without reimplementing the chunker.
+    /// @dev this bounds payload BYTES, not execution gas on the destination
+    /// chain: a byte-small chunk of gas-heavy actions can still exceed a
+    /// destination per-tx cap (e.g. Moonbeam's 2^24 gas limit). Override with
+    /// a lower budget when a chain's bundle is gas-dense.
     function maxChunkPayloadBytes() public view virtual returns (uint256) {
         return 11_000;
     }
@@ -619,9 +623,9 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
     }
 
     /// @notice fixed per-call abi overhead accounted for when packing propose()
-    /// calls: selector, the five argument heads, three array length words, the
-    /// finalize bool and a short IPFS description URI. Production descriptions
-    /// are pinned to a short URI, so a small constant is sufficient.
+    /// calls: selector, the argument heads, array length words and the
+    /// finalize bool. The init call's description is charged separately from
+    /// its actual size in batchProposeSplits.
     uint256 private constant PROPOSE_CALL_OVERHEAD = 512;
 
     /// @notice number of wormhole publishMessage chunks a chain's bundle is
@@ -683,7 +687,15 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
         uint256[] memory tmp = new uint256[](n);
         uint256 count = 0;
         uint256 budget = maxProposeCallBytes();
-        uint256 acc = PROPOSE_CALL_OVERHEAD;
+
+        // the init call additionally carries the proposal description —
+        // ideally a short pinned IPFS URI, but the raw multi-KB markdown when
+        // the pin has not happened yet — so its budget is charged with the
+        // ACTUAL description size rather than assuming a short URI. Append
+        // calls (propose(uint256,...)) carry no description and reset to the
+        // fixed overhead.
+        uint256 acc = PROPOSE_CALL_OVERHEAD +
+            _roundUp32(bytes(_proposeDescription()).length);
 
         for (uint256 i = 0; i < n; i++) {
             // per governor action in the propose() arrays: target (32) +
@@ -1915,51 +1927,21 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
             );
         }
 
-        _buildTransferReserveActions(
+        // initiateSale sizes each sale from the automation contract's balance
+        // at execution time, so the transferReserves region that funds those
+        // contracts and the initiateSale calls themselves must ride a single
+        // VAA — the nested call threads the region's start index through
+        // without a caller local (this function is at the stack limit)
+        _buildInitSaleActions(
             addresses,
             _chainId,
-            spec.transferReserves
+            spec.initSale,
+            _buildTransferReserveActions(
+                addresses,
+                _chainId,
+                spec.transferReserves
+            )
         );
-
-        // Process initSale if it exists in the JSON and has valid data
-        if (
-            spec.initSale.auctionPeriod != 0 ||
-            spec.initSale.reserveAutomationContracts.length > 0
-        ) {
-            InitSale memory initSale = spec.initSale;
-
-            for (
-                uint256 i = 0;
-                i < initSale.reserveAutomationContracts.length;
-                i++
-            ) {
-                address reserveAutomationContract = addresses.getAddress(
-                    initSale.reserveAutomationContracts[i]
-                );
-
-                _pushAction(
-                    reserveAutomationContract,
-                    abi.encodeWithSignature(
-                        "initiateSale(uint256,uint256,uint256,uint256,uint256)",
-                        initSale.delay,
-                        initSale.auctionPeriod,
-                        initSale.miniAuctionPeriod,
-                        initSale.periodMaxDiscount,
-                        initSale.periodStartingPremium
-                    ),
-                    string.concat(
-                        "Init reserve sale for ",
-                        vm.getLabel(
-                            addresses.getAddress(
-                                initSale.reserveAutomationContracts[i]
-                            )
-                        ),
-                        " on ",
-                        _chainId.chainIdToName()
-                    )
-                );
-            }
-        }
 
         _buildMultiRewarderActions(addresses, _chainId, spec.multiRewarder);
 
@@ -1969,12 +1951,16 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
     /// @notice build the reduce -> transfer reserve pairs for a chain. Each
     /// pair is an atomic group (the transfer spends the reduced reserves), so
     /// its interior boundary is marked to keep it inside a single VAA.
+    /// @return regionStart the per-type action index where this region begins,
+    /// consumed by _buildInitSaleActions to extend the atomic region over the
+    /// initiateSale calls that depend on the transferred reserves
     function _buildTransferReserveActions(
         Addresses addresses,
         uint256 _chainId,
         TransferReserves[] memory transferReserves
-    ) private {
+    ) private returns (uint256 regionStart) {
         ActionType t = _actionTypeForChain(_chainId);
+        regionStart = actions.proposalActionTypeCount(t);
 
         for (uint256 i = 0; i < transferReserves.length; i++) {
             uint256 grpStart = actions.proposalActionTypeCount(t);
@@ -2026,6 +2012,65 @@ contract RewardsDistributionV2Template is HybridProposalV2, Networks {
             );
 
             _markAtomicGroup(t, grpStart, 2);
+        }
+    }
+
+    /// @notice build the initiateSale actions for a chain's reserve
+    /// automation contracts. initiateSale computes periodSaleAmount from the
+    /// automation contract's reserveAsset balance AT EXECUTION TIME and
+    /// reverts when it is zero — but chunks execute as independent temporal
+    /// governor proposals with no ordering guarantee on the destination
+    /// chain. A chunk boundary between a market's reserve transfer and its
+    /// initiateSale could therefore initialize a sale against a zero or
+    /// partial balance. The whole [regionStart, end) region — the
+    /// transferReserves pairs plus every initiateSale — is marked atomic so
+    /// the chunker keeps it in one VAA.
+    function _buildInitSaleActions(
+        Addresses addresses,
+        uint256 _chainId,
+        InitSale memory initSale,
+        uint256 regionStart
+    ) private {
+        // Process initSale only if it exists in the JSON and has valid data
+        if (
+            initSale.auctionPeriod == 0 &&
+            initSale.reserveAutomationContracts.length == 0
+        ) {
+            return;
+        }
+
+        for (
+            uint256 i = 0;
+            i < initSale.reserveAutomationContracts.length;
+            i++
+        ) {
+            address reserveAutomationContract = addresses.getAddress(
+                initSale.reserveAutomationContracts[i]
+            );
+
+            _pushAction(
+                reserveAutomationContract,
+                abi.encodeWithSignature(
+                    "initiateSale(uint256,uint256,uint256,uint256,uint256)",
+                    initSale.delay,
+                    initSale.auctionPeriod,
+                    initSale.miniAuctionPeriod,
+                    initSale.periodMaxDiscount,
+                    initSale.periodStartingPremium
+                ),
+                string.concat(
+                    "Init reserve sale for ",
+                    vm.getLabel(reserveAutomationContract),
+                    " on ",
+                    _chainId.chainIdToName()
+                )
+            );
+        }
+
+        ActionType t = _actionTypeForChain(_chainId);
+        uint256 regionEnd = actions.proposalActionTypeCount(t);
+        if (regionEnd > regionStart) {
+            _markAtomicGroup(t, regionStart, regionEnd - regionStart);
         }
     }
 

--- a/test/unit/RewardsDistributionV2Batching.t.sol
+++ b/test/unit/RewardsDistributionV2Batching.t.sol
@@ -53,11 +53,24 @@ contract RewardsBatchHarness is RewardsDistributionV2Template {
 contract RewardsDistributionV2BatchingUnitTest is Test {
     RewardsBatchHarness harness;
 
+    /// @notice short deterministic description used by propose(); mirrors a
+    /// production run where the markdown is pinned to an IPFS URI. The packer
+    /// charges the init call with the ACTUAL description size, so tests pin a
+    /// known-small one.
+    string constant DESCRIPTION_URI = "ipfs://QmTestDescriptionUri";
+
     function setUp() public {
         // the template constructor reads DESCRIPTION_PATH; point it at a real
         // file (its contents are irrelevant to the batching logic)
         vm.setEnv("DESCRIPTION_PATH", "proposals/mips/mip-x59/x59.md");
         harness = new RewardsBatchHarness();
+        harness.setProposalDescriptionUri(DESCRIPTION_URI);
+    }
+
+    /// @notice mirrors the template's init-call overhead: the fixed
+    /// PROPOSE_CALL_OVERHEAD plus the 32-byte-padded description size
+    function _initCallOverhead() internal pure returns (uint256) {
+        return 512 + ((bytes(DESCRIPTION_URI).length + 31) / 32) * 32;
     }
 
     /// @notice push `count` Base actions each carrying `size` bytes of data
@@ -215,14 +228,43 @@ contract RewardsDistributionV2BatchingUnitTest is Test {
         }
 
         uint256 splitCursor = 0;
-        uint256 acc = 512; // PROPOSE_CALL_OVERHEAD
+        // init call carries the description; append calls do not
+        uint256 acc = _initCallOverhead();
         for (uint256 i = 0; i < chunks; i++) {
             if (splitCursor < splits.length && i == splits[splitCursor]) {
-                acc = 512;
+                acc = 512; // PROPOSE_CALL_OVERHEAD
                 splitCursor++;
             }
             acc += 128 + ((lens[i] + 31) / 32) * 32;
             assertLe(acc, callBudget, "a propose() call exceeds the budget");
         }
+    }
+
+    /// the init call is charged with the ACTUAL description size: a large
+    /// unpinned markdown description forces the first split earlier than the
+    /// same actions with a short pinned URI
+    function testInitCallAccountsForDescription() public {
+        uint256 callBudget = 6_000;
+        harness.setBudgets(2_000, callBudget);
+        _pushBase(6, 700);
+
+        // short URI (set in setUp): several chunks fit in the init call
+        uint256[] memory shortSplits = harness.batchProposeSplits();
+
+        // simulate an unpinned raw markdown description close to the budget:
+        // the init call can now fit fewer (here: one) governor actions
+        harness.setProposalDescriptionUri(string(new bytes(4_500)));
+        uint256[] memory longSplits = harness.batchProposeSplits();
+
+        assertGt(
+            longSplits.length,
+            shortSplits.length,
+            "large description must force more propose() calls"
+        );
+        assertEq(
+            longSplits[0],
+            1,
+            "init call with near-budget description fits only one action"
+        );
     }
 }

--- a/test/unit/RewardsDistributionV2Batching.t.sol
+++ b/test/unit/RewardsDistributionV2Batching.t.sol
@@ -1,0 +1,228 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.19;
+
+import "@forge-std/Test.sol";
+
+import {ActionType, ProposalAction} from "@proposals/proposalTypes/IProposal.sol";
+import {RewardsDistributionV2Template} from "@proposals/templates/RewardsDistributionV2.sol";
+
+/// @notice test-only harness exposing the generic action-batching internals of
+/// RewardsDistributionV2Template so the size-driven chunker and propose()
+/// packer can be exercised with synthetic actions — no fork, no rewards JSON.
+contract RewardsBatchHarness is RewardsDistributionV2Template {
+    uint256 private _maxChunk;
+    uint256 private _maxCall;
+
+    function name() external pure override returns (string memory) {
+        return "RewardsBatchHarness";
+    }
+
+    function setBudgets(uint256 chunkBudget, uint256 callBudget) external {
+        _maxChunk = chunkBudget;
+        _maxCall = callBudget;
+    }
+
+    function maxChunkPayloadBytes() public view override returns (uint256) {
+        return _maxChunk;
+    }
+
+    function maxProposeCallBytes() public view override returns (uint256) {
+        return _maxCall;
+    }
+
+    function pushAction(
+        address target,
+        bytes memory data,
+        ActionType at
+    ) external {
+        _pushAction(target, data, at);
+    }
+
+    function markGroup(ActionType at, uint256 start, uint256 len) external {
+        _markAtomicGroup(at, start, len);
+    }
+
+    function chunkPayloadSize(
+        ActionType at,
+        uint256 index
+    ) external view returns (uint256) {
+        return _chunkEncodedSize(chunkActions(at, index));
+    }
+}
+
+contract RewardsDistributionV2BatchingUnitTest is Test {
+    RewardsBatchHarness harness;
+
+    function setUp() public {
+        // the template constructor reads DESCRIPTION_PATH; point it at a real
+        // file (its contents are irrelevant to the batching logic)
+        vm.setEnv("DESCRIPTION_PATH", "proposals/mips/mip-x59/x59.md");
+        harness = new RewardsBatchHarness();
+    }
+
+    /// @notice push `count` Base actions each carrying `size` bytes of data
+    function _pushBase(uint256 count, uint256 size) internal {
+        for (uint256 i = 0; i < count; i++) {
+            harness.pushAction(
+                address(uint160(0x1000 + i)),
+                new bytes(size),
+                ActionType.Base
+            );
+        }
+    }
+
+    /// @notice cumulative chunk start indices reconstructed from chunkActions,
+    /// so tests can reason about where the chunker cut the bundle
+    function _chunkStarts(
+        ActionType at
+    ) internal view returns (uint256[] memory starts) {
+        uint256 chunks = harness.chunkCount(at);
+        starts = new uint256[](chunks);
+        uint256 running = 0;
+        for (uint256 c = 0; c < chunks; c++) {
+            starts[c] = running;
+            running += harness.chunkActions(at, c).length;
+        }
+    }
+
+    /// a small bundle rides a single VAA and needs no batched submission
+    function testSmallBundleSingleChunkNoSplit() public {
+        harness.setBudgets(11_000, 12_000);
+        _pushBase(3, 100);
+
+        assertEq(harness.chunkCount(ActionType.Base), 1, "should be 1 chunk");
+        assertEq(
+            harness.batchProposeSplits().length,
+            0,
+            "should be a single propose call"
+        );
+
+        // the one chunk is the whole bundle, in order
+        ProposalAction[] memory chunk = harness.chunkActions(
+            ActionType.Base,
+            0
+        );
+        assertEq(chunk.length, 3, "chunk should hold all actions");
+    }
+
+    /// an oversized bundle is split into multiple chunks, each within budget,
+    /// and the chunks together reproduce the full bundle in order
+    function testOversizedBundleSplitsWithinBudget() public {
+        uint256 chunkBudget = 3_000;
+        harness.setBudgets(chunkBudget, 12_000);
+        _pushBase(9, 800);
+
+        uint256 chunks = harness.chunkCount(ActionType.Base);
+        assertGt(chunks, 1, "bundle should split into multiple chunks");
+
+        ProposalAction[] memory all = harness.getActionsByType(ActionType.Base);
+        uint256 seen = 0;
+        for (uint256 c = 0; c < chunks; c++) {
+            ProposalAction[] memory chunk = harness.chunkActions(
+                ActionType.Base,
+                c
+            );
+            // every chunk fits the budget unless it is a single indivisible unit
+            if (chunk.length > 1) {
+                assertLe(
+                    harness.chunkPayloadSize(ActionType.Base, c),
+                    chunkBudget,
+                    "multi-action chunk exceeds budget"
+                );
+            }
+            // chunks are contiguous and ordered
+            for (uint256 i = 0; i < chunk.length; i++) {
+                assertEq(
+                    chunk[i].target,
+                    all[seen].target,
+                    "chunk action out of order"
+                );
+                seen++;
+            }
+        }
+        assertEq(
+            seen,
+            all.length,
+            "chunks must cover every action exactly once"
+        );
+    }
+
+    /// a dependent action group is never split across two chunks even when the
+    /// size budget would otherwise cut inside it
+    function testAtomicGroupNeverSplit() public {
+        // one action per chunk by budget, so without protection the chunker
+        // would cut at every boundary (including inside the group)
+        harness.setBudgets(1, 12_000);
+        _pushBase(6, 200);
+
+        // mark actions [2,3] as one atomic group (interior boundary = 3)
+        harness.markGroup(ActionType.Base, 2, 2);
+
+        uint256[] memory starts = _chunkStarts(ActionType.Base);
+        for (uint256 i = 0; i < starts.length; i++) {
+            assertTrue(starts[i] != 3, "chunker cut inside an atomic group");
+        }
+
+        // actions 2 and 3 must land in the same chunk
+        uint256 chunks = harness.chunkCount(ActionType.Base);
+        bool foundPair = false;
+        uint256 running = 0;
+        for (uint256 c = 0; c < chunks; c++) {
+            uint256 len = harness.chunkActions(ActionType.Base, c).length;
+            if (running <= 2 && 3 < running + len) {
+                foundPair = true;
+            }
+            running += len;
+        }
+        assertTrue(foundPair, "atomic pair split across chunks");
+    }
+
+    /// the proposal is packed into successive propose() calls, each within the
+    /// call budget, with strictly increasing in-range split points
+    function testBatchProposeSplitsPacksWithinCallBudget() public {
+        uint256 callBudget = 6_000;
+        // keep each chunk small enough to fit a call, then force several calls
+        harness.setBudgets(2_000, callBudget);
+        _pushBase(12, 700);
+
+        uint256[] memory splits = harness.batchProposeSplits();
+        assertGt(
+            splits.length,
+            0,
+            "large proposal should batch its submission"
+        );
+
+        uint256 total = harness.allActionTypesCount();
+        for (uint256 i = 0; i < splits.length; i++) {
+            assertGt(splits[i], 0, "split index must be > 0");
+            assertLt(splits[i], total, "split index must be < action count");
+            if (i > 0) {
+                assertGt(
+                    splits[i],
+                    splits[i - 1],
+                    "splits must be strictly increasing"
+                );
+            }
+        }
+
+        // reconstruct the per-call byte size and assert each call fits the
+        // budget (mirrors getTargetsPayloadsValues ordering: no Ethereum
+        // actions here, so it is just the Base chunks)
+        uint256 chunks = harness.chunkCount(ActionType.Base);
+        uint256[] memory lens = new uint256[](chunks);
+        for (uint256 c = 0; c < chunks; c++) {
+            lens[c] = harness.chunkPayloadSize(ActionType.Base, c);
+        }
+
+        uint256 splitCursor = 0;
+        uint256 acc = 512; // PROPOSE_CALL_OVERHEAD
+        for (uint256 i = 0; i < chunks; i++) {
+            if (splitCursor < splits.length && i == splits[splitCursor]) {
+                acc = 512;
+                splitCursor++;
+            }
+            acc += 128 + ((lens[i] + 31) / 32) * 32;
+            assertLe(acc, callBudget, "a propose() call exceeds the budget");
+        }
+    }
+}

--- a/test/unit/RewardsDistributionV2Batching.t.sol
+++ b/test/unit/RewardsDistributionV2Batching.t.sol
@@ -5,6 +5,28 @@ import "@forge-std/Test.sol";
 
 import {ActionType, ProposalAction} from "@proposals/proposalTypes/IProposal.sol";
 import {RewardsDistributionV2Template} from "@proposals/templates/RewardsDistributionV2.sol";
+import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
+
+/// @notice minimal Addresses stand-in for fork-less tests: the real registry
+/// validates isContract on load, which cannot hold without a fork. Only the
+/// two entrypoints _buildWithdrawWellActions consumes are implemented.
+contract FakeAddresses {
+    mapping(bytes32 => address) private addrs;
+
+    function set(string memory name, address a) external {
+        addrs[keccak256(bytes(name))] = a;
+    }
+
+    function getAddress(string memory name) external view returns (address) {
+        address a = addrs[keccak256(bytes(name))];
+        require(a != address(0), "FakeAddresses: not set");
+        return a;
+    }
+
+    function isAddressSet(string memory name) external view returns (bool) {
+        return addrs[keccak256(bytes(name))] != address(0);
+    }
+}
 
 /// @notice test-only harness exposing the generic action-batching internals of
 /// RewardsDistributionV2Template so the size-driven chunker and propose()
@@ -47,6 +69,23 @@ contract RewardsBatchHarness is RewardsDistributionV2Template {
         uint256 index
     ) external view returns (uint256) {
         return _chunkEncodedSize(chunkActions(at, index));
+    }
+
+    /// @notice real-path entrypoints for the TG-WELL span protection: the
+    /// same _buildWithdrawWellActions / _markTgWellSpan flow a rewards build
+    /// runs, so tests exercise the production span marking rather than a
+    /// synthetic markGroup
+    function buildWithdrawWell(
+        Addresses addresses,
+        uint256 chainId,
+        WithdrawWell[] memory ws,
+        string memory tokenName
+    ) external {
+        _buildWithdrawWellActions(addresses, chainId, ws, tokenName);
+    }
+
+    function markTgSpan(uint256 chainId) external {
+        _markTgWellSpan(chainId);
     }
 
     /// @notice encoded VAA-payload size of a synthetic bundle of `count`
@@ -306,5 +345,64 @@ contract RewardsDistributionV2BatchingUnitTest is Test {
             1,
             "init call with near-budget description fits only one action"
         );
+    }
+
+    /// @notice run the REAL TG-WELL span flow (_buildWithdrawWellActions +
+    /// _markTgWellSpan): pre-span actions, a withdrawWell(to = TG), then
+    /// post-span actions
+    function _buildTgSpanBundle() internal {
+        FakeAddresses fake = new FakeAddresses();
+        fake.set("TEMPORAL_GOVERNOR", address(0xAA01));
+        fake.set("RESERVE_WELL_HOLDING_DEPOSIT", address(0xAA02));
+        fake.set("xWELL_PROXY", address(0xAA03));
+
+        // pre-span region (models transferFrom / reward-speed actions)
+        _pushBase(2, 300);
+
+        RewardsDistributionV2Template.WithdrawWell[]
+            memory ws = new RewardsDistributionV2Template.WithdrawWell[](1);
+        ws[0] = RewardsDistributionV2Template.WithdrawWell({
+            amount: 1e18,
+            to: "TEMPORAL_GOVERNOR"
+        });
+        harness.buildWithdrawWell(
+            Addresses(address(fake)),
+            8453,
+            ws,
+            "xWELL_PROXY"
+        );
+
+        // post-span region (models multiRewarder / merkle actions)
+        _pushBase(3, 300);
+
+        harness.markTgSpan(8453);
+    }
+
+    /// the production span marking keeps everything from the TG-bound
+    /// withdrawal to the end of the bundle inside one chunk
+    function testTgWellSpanMarkedOnRealBuildPath() public {
+        // budget fits the 4-action span but not the whole 6-action bundle,
+        // so the chunker must cut — and may only cut before the span
+        harness.setBudgets(harness.measureEncodedSize(5, 300), 12_000);
+        _buildTgSpanBundle();
+
+        uint256[] memory starts = _chunkStarts(ActionType.Base);
+        assertGt(starts.length, 1, "bundle should split");
+        for (uint256 i = 0; i < starts.length; i++) {
+            assertTrue(starts[i] <= 2, "chunker cut inside the TG-WELL span");
+        }
+    }
+
+    /// a TG-WELL span larger than any chunk fails loudly through the real
+    /// build path instead of shipping an unordered cross-chunk WELL flow
+    function testTgWellSpanOversizedReverts() public {
+        // budget fits two actions; the 4-action span can never fit
+        harness.setBudgets(harness.measureEncodedSize(2, 300), 12_000);
+        _buildTgSpanBundle();
+
+        vm.expectRevert(
+            "RewardsDistribution: atomic action region exceeds maxChunkPayloadBytes"
+        );
+        harness.chunkCount(ActionType.Base);
     }
 }

--- a/test/unit/RewardsDistributionV2Batching.t.sol
+++ b/test/unit/RewardsDistributionV2Batching.t.sol
@@ -48,6 +48,26 @@ contract RewardsBatchHarness is RewardsDistributionV2Template {
     ) external view returns (uint256) {
         return _chunkEncodedSize(chunkActions(at, index));
     }
+
+    /// @notice encoded VAA-payload size of a synthetic bundle of `count`
+    /// actions carrying `size` data bytes each — lets tests derive exact
+    /// budgets instead of hardcoding byte counts
+    function measureEncodedSize(
+        uint256 count,
+        uint256 size
+    ) external view returns (uint256) {
+        ProposalAction[] memory a = new ProposalAction[](count);
+        for (uint256 i = 0; i < count; i++) {
+            a[i] = ProposalAction({
+                target: address(1),
+                value: 0,
+                data: new bytes(size),
+                description: "",
+                actionType: ActionType.Base
+            });
+        }
+        return _chunkEncodedSize(a);
+    }
 }
 
 contract RewardsDistributionV2BatchingUnitTest is Test {
@@ -60,9 +80,12 @@ contract RewardsDistributionV2BatchingUnitTest is Test {
     string constant DESCRIPTION_URI = "ipfs://QmTestDescriptionUri";
 
     function setUp() public {
-        // the template constructor reads DESCRIPTION_PATH; point it at a real
-        // file (its contents are irrelevant to the batching logic)
-        vm.setEnv("DESCRIPTION_PATH", "proposals/mips/mip-x59/x59.md");
+        // the template constructor reads DESCRIPTION_PATH; point it at a
+        // tiny test-owned fixture (its contents are irrelevant here)
+        vm.setEnv(
+            "DESCRIPTION_PATH",
+            "test/unit/fixtures/rewards-description.md"
+        );
         harness = new RewardsBatchHarness();
         harness.setProposalDescriptionUri(DESCRIPTION_URI);
     }
@@ -135,14 +158,13 @@ contract RewardsDistributionV2BatchingUnitTest is Test {
                 ActionType.Base,
                 c
             );
-            // every chunk fits the budget unless it is a single indivisible unit
-            if (chunk.length > 1) {
-                assertLe(
-                    harness.chunkPayloadSize(ActionType.Base, c),
-                    chunkBudget,
-                    "multi-action chunk exceeds budget"
-                );
-            }
+            // every chunk fits the budget (over-budget indivisible units
+            // revert inside the chunker instead of being emitted)
+            assertLe(
+                harness.chunkPayloadSize(ActionType.Base, c),
+                chunkBudget,
+                "chunk exceeds budget"
+            );
             // chunks are contiguous and ordered
             for (uint256 i = 0; i < chunk.length; i++) {
                 assertEq(
@@ -163,9 +185,9 @@ contract RewardsDistributionV2BatchingUnitTest is Test {
     /// a dependent action group is never split across two chunks even when the
     /// size budget would otherwise cut inside it
     function testAtomicGroupNeverSplit() public {
-        // one action per chunk by budget, so without protection the chunker
-        // would cut at every boundary (including inside the group)
-        harness.setBudgets(1, 12_000);
+        // budget of exactly three actions: the unprotected greedy chunker
+        // would partition [0,1,2][3,4,5], cutting straight through the group
+        harness.setBudgets(harness.measureEncodedSize(3, 200), 12_000);
         _pushBase(6, 200);
 
         // mark actions [2,3] as one atomic group (interior boundary = 3)
@@ -188,6 +210,24 @@ contract RewardsDistributionV2BatchingUnitTest is Test {
             running += len;
         }
         assertTrue(foundPair, "atomic pair split across chunks");
+    }
+
+    /// an atomic region that cannot fit any chunk fails loudly instead of
+    /// being silently emitted as an over-budget chunk
+    function testOversizedAtomicRegionReverts() public {
+        // budget fits one action but not two
+        uint256 single = harness.measureEncodedSize(1, 200);
+        uint256 pair = harness.measureEncodedSize(2, 200);
+        harness.setBudgets((single + pair) / 2, 12_000);
+        _pushBase(4, 200);
+
+        // actions [1,2] are one atomic group larger than the chunk budget
+        harness.markGroup(ActionType.Base, 1, 2);
+
+        vm.expectRevert(
+            "RewardsDistribution: atomic action region exceeds maxChunkPayloadBytes"
+        );
+        harness.chunkCount(ActionType.Base);
     }
 
     /// the proposal is packed into successive propose() calls, each within the

--- a/test/unit/fixtures/rewards-description.md
+++ b/test/unit/fixtures/rewards-description.md
@@ -1,0 +1,4 @@
+# Test proposal description
+
+Tiny deterministic fixture consumed by RewardsDistributionV2Batching.t.sol via
+DESCRIPTION_PATH. Content is irrelevant to the batching logic.


### PR DESCRIPTION
## Summary

Generalizes the batch-call splitting that MIP-X59 implemented by hand into the `RewardsDistributionV2Template` itself, so future rewards MIPs inherit a submittable split with no manual boundary tuning.

A full rewards epoch can encode to tens of KB across 100+ actions — too large for a single `MultichainGovernorV2.propose()` (which SSTOREs every action's calldata; the binding limit is gas, not a protocol cap). `HybridProposalV2` exposes the split hooks (`chunkCount`/`chunkActions` for oversized per-chain wormhole bundles; `batchProposeSplits` for multi-call init+append submission). Until now each large rewards MIP hand-tuned them (e.g. X59's `BASE_CHUNK_BOUNDARY = 32`).

## What changed

- **`chunkCount` / `chunkActions`** — size-driven: a chain whose bundled actions encode within `maxChunkPayloadBytes()` rides one VAA; otherwise it splits into the minimum number of chunks that each fit, cutting only at safe boundaries. Ethereum actions are local governor actions and are never chunked.
- **`batchProposeSplits`** — greedily packs the ordered governor actions (matching `getTargetsPayloadsValues` order) into successive `propose()` calls each within `maxProposeCallBytes()`; the init call is charged with the ACTUAL description size.
- **Atomic groups** — the chunker never splits a dependent sequence across VAAs: per-market reduce→transfer→initiateSale groups, multiRewarder approve→notify groups, merkle approve→accept→create triples, and the span from the first `withdrawWell(to = TEMPORAL_GOVERNOR)` to the end of the chain's bundle (later actions may spend the replenished TG balance).
- **Loud failures** — an indivisible atomic region over `maxChunkPayloadBytes()` or a single governor action over `maxProposeCallBytes()` reverts at simulation/print time instead of silently emitting oversized chunks/calls; an unpinned multi-KB description logs a "pin to IPFS first" warning.
- **Chunk-aware simulation** — `HybridProposalV2.simulate()` now executes each chain's chunks as separate temporal governor proposals in REVERSE order, so hidden cross-chunk dependencies fail in simulation (single-chunk proposals — the default — are unaffected).
- **Budgets are `virtual`** (`maxChunkPayloadBytes()` = 11KB, `maxProposeCallBytes()` = 12KB) so a MIP can tune them without reimplementing the logic. Note: budgets bound payload bytes, not destination execution gas (e.g. Moonbeam's 2^24 per-tx cap) — override lower for gas-dense bundles.
- Extracted the dependent-group build loops into helpers (`_buildReserveAutomationActions` / `_buildWithdrawWellActions` / `_buildMultiRewarderActions` / `_buildMerkleCampaignActions`) to resolve a stack-too-deep in `_buildExternalChainActions`.

## Testing

Fork-free unit suite `test/unit/RewardsDistributionV2Batching.t.sol` (6 passing) exercises a synthetic action set:
- small bundle → 1 chunk, no batched submission
- oversized bundle → multiple chunks, each within budget (unconditional), complete and ordered
- atomic group never split across chunks
- oversized indivisible atomic region reverts loudly
- `batchProposeSplits` packs each `propose()` call within budget, splits strictly increasing and in range
- init call charged with the actual description size (large unpinned markdown forces earlier splits)

MIP-X59 is unaffected — it overrides all three hooks (its non-Base `chunkActions` now returns the full bundle explicitly instead of delegating to the generic slicer, keeping `chunkCount`/`chunkActions` in agreement).

> Note: `forge build` locally fails a pre-existing `solar` lint (`unresolved symbol IERC20` in `src/Comptroller.sol`) reproducible on clean `main`; `forge test` compiles clean. `test_inDevelopmentIncludesMipE00` is pre-existing stale (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)