### PR TITLE
Updates Foundation multisig to new WELL treasury address

### DIFF
--- a/chains/1.json
+++ b/chains/1.json
@@ -385,7 +385,7 @@
         "name": "MWETH_IMPLEMENTATION"
     },
     {
-        "addr": "0xE6d2687d6e4576560592C7E0c4e1a13672a24541",
+        "addr": "0xa20864B193A8146dE8c97F2a4CeBea0305Ca30f0",
         "isContract": true,
         "name": "FOUNDATION_MULTISIG"
     },


### PR DESCRIPTION
## Summary

Updates the Ethereum mainnet `FOUNDATION_MULTISIG` entry in `chains/1.json` to the Moonwell Foundation WELL Treasury address.

- Old: `0xE6d2687d6e4576560592C7E0c4e1a13672a24541`
- New: `0xa20864B193A8146dE8c97F2a4CeBea0305Ca30f0`

## Notes

- Registry-only change — one address in `chains/1.json`. No contract or proposal logic is modified.
- Scope is Ethereum (chain 1) only. The `FOUNDATION_MULTISIG` entries in `chains/8453.json` (Base) and `WELL_FOUNDATION_MULTISIG` in `chains/1284.json` (Moonbeam) are untouched.
- On Ethereum, `FOUNDATION_MULTISIG` is the WELL source for hub rewards MIPs (e.g. the `transferFrom` in `mip-x59`/`mip-x62`) and the recipient in `mip-x61`. Future proposals resolving this key via `addresses.getAddress("FOUNDATION_MULTISIG")` will now point at the new treasury, so the treasury must hold/approve the WELL those proposals move.

---

## Checklist

**General**

- [ ] `forge build` clean (no new warnings) — n/a, no Solidity changed
- [ ] `forge test` passing locally — n/a, no tests added or modified
- [ ] `npm run lint` / `npm run prettier` — n/a, JSON registry entry only
- [ ] `make slither` reviewed — n/a, no Solidity changed
- [ ] Ran `@security-auditor` agent — n/a, no contracts added or modified
- [ ] All CI checks green

**If this PR adds a new MIP**

n/a — no new MIP.

**If this PR modifies existing protocol state** (oracle swaps, proxy upgrades, IRM changes, comptroller config)

n/a — address registry only, no on-chain state change.
