### PR TITLE
fix(templates): stop MarketUpdateV2 from touching the deprecated Moonbeam fork

### DIFF
--- a/proposals/templates/MarketUpdateV2.sol
+++ b/proposals/templates/MarketUpdateV2.sol
@@ -9,6 +9,7 @@ import "@forge-std/StdJson.sol";
 
 import "@protocol/utils/ChainIds.sol";
 
+import {etch} from "@proposals/utils/PrecompileEtching.sol";
 import {Networks} from "@proposals/utils/Networks.sol";
 import {JumpRateModel} from "@protocol/irm/JumpRateModel.sol";
 import {HybridProposalV2} from "@proposals/proposalTypes/HybridProposalV2.sol";
@@ -58,6 +59,11 @@ contract MarketUpdateV2Template is
         private _markets;
     mapping(uint256 chainId => EnumerableSet.Bytes32Set models)
         private _irModels;
+
+    /// @notice true when the proposal JSON carries a 1284 block; gates every
+    /// touch of fork id 0, which may be a placeholder when the Moonbeam RPC
+    /// is unreachable
+    bool internal _hasMoonbeamActions;
 
     constructor() {
         bytes memory proposalDescription = abi.encodePacked(
@@ -112,22 +118,33 @@ contract MarketUpdateV2Template is
     function initProposal(Addresses addresses) public override {
         string memory encodedJson = vm.readFile(vm.envString("JSON_PATH"));
 
-        // Moonbeam is fully deprecated: no new market updates target it, and
-        // fork id 0 may be a placeholder stood up when the Moonbeam RPC is
-        // unreachable, so never touch that fork. Fail loudly if a proposal
-        // JSON still carries a 1284 block instead of silently dropping it.
-        require(
-            !vm.keyExistsJson(
-                encodedJson,
-                string.concat(".", vm.toString(MOONBEAM_CHAIN_ID))
-            ),
-            "MarketUpdateV2: Moonbeam is deprecated"
-        );
+        // Moonbeam is wound down: most proposals no longer carry a 1284
+        // block, and fork id 0 may be the placeholder stood up when the
+        // Moonbeam RPC is unreachable. Only touch that fork when this
+        // proposal actually has Moonbeam updates, and fail loudly (via the
+        // shared ChainIds message) if it does but the fork is not real.
+        // Mirrors RewardsDistributionV2.initProposal.
+        _hasMoonbeamActions = vm.keyExistsJson(encodedJson, ".1284");
 
+        if (_hasMoonbeamActions) {
+            ChainIds.requireMoonbeamFork();
+
+            // the xcUSDT/xcUSDC/xcDOT precompile mocks only exist on
+            // Moonbeam, so the etch must run on that fork (the primary fork
+            // is Ethereum)
+            vm.selectFork(MOONBEAM_FORK_ID);
+            etch(vm, addresses);
+        }
+
+        // the Moonbeam skips below are defense in depth here and in
+        // validate() (_saveChainMarketUpdate/_saveIRModels/_validateChain all
+        // early-return on a missing JSON key before selecting a fork), but
+        // load-bearing in deploy() and build(), whose helpers select the fork
+        // unconditionally.
         for (uint256 i = 0; i < networks.length; i++) {
             uint256 chainId = networks[i].chainId;
 
-            if (chainId == MOONBEAM_CHAIN_ID) {
+            if (chainId == MOONBEAM_CHAIN_ID && !_hasMoonbeamActions) {
                 continue;
             }
 
@@ -140,7 +157,7 @@ contract MarketUpdateV2Template is
         for (uint256 i = 0; i < networks.length; i++) {
             uint256 chainId = networks[i].chainId;
 
-            if (chainId == MOONBEAM_CHAIN_ID) {
+            if (chainId == MOONBEAM_CHAIN_ID && !_hasMoonbeamActions) {
                 continue;
             }
 
@@ -152,7 +169,7 @@ contract MarketUpdateV2Template is
         for (uint256 i = 0; i < networks.length; i++) {
             uint256 chainId = networks[i].chainId;
 
-            if (chainId == MOONBEAM_CHAIN_ID) {
+            if (chainId == MOONBEAM_CHAIN_ID && !_hasMoonbeamActions) {
                 continue;
             }
 
@@ -164,7 +181,7 @@ contract MarketUpdateV2Template is
         for (uint256 i = 0; i < networks.length; i++) {
             uint256 chainId = networks[i].chainId;
 
-            if (chainId == MOONBEAM_CHAIN_ID) {
+            if (chainId == MOONBEAM_CHAIN_ID && !_hasMoonbeamActions) {
                 continue;
             }
 

--- a/proposals/templates/MarketUpdateV2.sol
+++ b/proposals/templates/MarketUpdateV2.sol
@@ -9,7 +9,6 @@ import "@forge-std/StdJson.sol";
 
 import "@protocol/utils/ChainIds.sol";
 
-import {etch} from "@proposals/utils/PrecompileEtching.sol";
 import {Networks} from "@proposals/utils/Networks.sol";
 import {JumpRateModel} from "@protocol/irm/JumpRateModel.sol";
 import {HybridProposalV2} from "@proposals/proposalTypes/HybridProposalV2.sol";
@@ -113,13 +112,24 @@ contract MarketUpdateV2Template is
     function initProposal(Addresses addresses) public override {
         string memory encodedJson = vm.readFile(vm.envString("JSON_PATH"));
 
-        // the xcUSDT/xcUSDC/xcDOT precompile mocks only exist on Moonbeam,
-        // so the etch must run on that fork (the primary fork is Ethereum)
-        vm.selectFork(MOONBEAM_FORK_ID);
-        etch(vm, addresses);
+        // Moonbeam is fully deprecated: no new market updates target it, and
+        // fork id 0 may be a placeholder stood up when the Moonbeam RPC is
+        // unreachable, so never touch that fork. Fail loudly if a proposal
+        // JSON still carries a 1284 block instead of silently dropping it.
+        require(
+            !vm.keyExistsJson(
+                encodedJson,
+                string.concat(".", vm.toString(MOONBEAM_CHAIN_ID))
+            ),
+            "MarketUpdateV2: Moonbeam is deprecated"
+        );
 
         for (uint256 i = 0; i < networks.length; i++) {
             uint256 chainId = networks[i].chainId;
+
+            if (chainId == MOONBEAM_CHAIN_ID) {
+                continue;
+            }
 
             _saveChainMarketUpdate(addresses, chainId, encodedJson);
             _saveIRModels(chainId, encodedJson);
@@ -129,6 +139,11 @@ contract MarketUpdateV2Template is
     function deploy(Addresses addresses, address deployer) public override {
         for (uint256 i = 0; i < networks.length; i++) {
             uint256 chainId = networks[i].chainId;
+
+            if (chainId == MOONBEAM_CHAIN_ID) {
+                continue;
+            }
+
             _deployIRModels(addresses, deployer, chainId);
         }
     }
@@ -136,6 +151,11 @@ contract MarketUpdateV2Template is
     function build(Addresses addresses) public virtual override {
         for (uint256 i = 0; i < networks.length; i++) {
             uint256 chainId = networks[i].chainId;
+
+            if (chainId == MOONBEAM_CHAIN_ID) {
+                continue;
+            }
+
             _buildChainActions(addresses, chainId);
         }
     }
@@ -143,6 +163,11 @@ contract MarketUpdateV2Template is
     function validate(Addresses addresses, address) public virtual override {
         for (uint256 i = 0; i < networks.length; i++) {
             uint256 chainId = networks[i].chainId;
+
+            if (chainId == MOONBEAM_CHAIN_ID) {
+                continue;
+            }
+
             _validateChain(addresses, chainId);
         }
     }


### PR DESCRIPTION
## Summary

Moonbeam is wound down, and since 8040e9e7 fork id 0 may be a dead placeholder when the Moonbeam RPC is unreachable. `MarketUpdateV2Template.initProposal` still ran `vm.selectFork(MOONBEAM_FORK_ID)` unconditionally to etch the xcUSDT/xcUSDC/xcDOT precompile mocks, so every market-update simulation broke against a dead Moonbeam endpoint (against the placeholder, the etch reverts with `Address: xcUSDT not set on chain: 1` — the `Addresses` chain restrictions catch the mismatch).

Mirrors the `RewardsDistributionV2.initProposal` gate (same lineage, 8040e9e7):

- Detect a `1284` block in the proposal JSON (`_hasMoonbeamActions`); only then `ChainIds.requireMoonbeamFork()`, select fork 0, and etch the precompile mocks
- Skip chain 1284 in the `initProposal`/`deploy`/`build`/`validate` network loops when the JSON has no `1284` block (load-bearing in `deploy`/`build`, whose helpers select the fork unconditionally; defense in depth in `initProposal`/`validate`)
- A proposal that *does* carry Moonbeam actions still runs against a working RPC, and fails loudly through the shared `ChainIds` message against the placeholder — so a final Moonbeam decommission proposal remains possible through this template

## Verification

- `forge build` green, prettier clean
- Full e02 simulation (`DO_DEPLOY` → `DO_VALIDATE`) passes end to end with the Moonbeam fork standing as a placeholder (no working `MOONBEAM_RPC_URL`)
- Negative test: a JSON with a `"1284"` block + placeholder fork reverts with `ChainIds: this proposal has Moonbeam actions but the Moonbeam fork is unavailable (RPC unreachable). Set a working MOONBEAM_RPC_URL.`
- Subclasses (`mip-x60`/`x61`/`x63`) do not override `initProposal`, so they inherit the gate; their JSONs target only 8453/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011a1CK5Wxp6CoR7sNcBzETi
