### PR TITLE
Track market cash internally so donated underlying cannot bypass the supply cap

### DIFF
--- a/src/4626/LibCompound.sol
+++ b/src/4626/LibCompound.sol
@@ -25,9 +25,8 @@ library LibCompound {
             return mToken.exchangeRateStored();
         }
 
-        uint256 totalCash = MErc20(mToken.underlying()).balanceOf(
-            address(mToken)
-        );
+        /// read the market's own cash accounting so this returns the same rate the market does
+        uint256 totalCash = MToken(address(mToken)).getCash();
         uint256 borrowsPrior = mToken.totalBorrows();
         uint256 reservesPrior = mToken.totalReserves();
 

--- a/src/MErc20.sol
+++ b/src/MErc20.sol
@@ -10,6 +10,8 @@ import "./MToken.sol";
  * @author Moonwell
  */
 contract MErc20 is MToken, MErc20Interface {
+    using SafeERC20 for IERC20;
+
     /**
      * @notice Initialize the new money market
      * @param underlying_ The address of the underlying asset
@@ -198,13 +200,12 @@ contract MErc20 is MToken, MErc20Interface {
     /*** Safe Token ***/
 
     /**
-     * @notice Gets balance of this contract in terms of the underlying
-     * @dev This excludes the value of the current message, if any
-     * @return The quantity of underlying tokens owned by this contract
+     * @notice Gets the cash balance of this market in the underlying asset
+     * @dev Returns the internally tracked balance, not `underlying.balanceOf(address(this))`
+     * @return The quantity of underlying tokens this market accounts for
      */
     function getCashPrior() internal view virtual override returns (uint) {
-        EIP20Interface token = EIP20Interface(underlying);
-        return token.balanceOf(address(this));
+        return internalCash;
     }
 
     /**
@@ -254,42 +255,80 @@ contract MErc20 is MToken, MErc20Interface {
             address(this)
         );
         require(balanceAfter >= balanceBefore, "TOKEN_TRANSFER_IN_OVERFLOW");
-        return balanceAfter - balanceBefore; // underflow already checked above, just subtract
+
+        // Calculate the amount that was *actually* transferred
+        uint actualAmount = balanceAfter - balanceBefore;
+
+        internalCash += actualAmount;
+
+        return actualAmount;
     }
 
     /**
-     * @dev Similar to EIP20 transfer, except it handles a False success from `transfer` and returns an explanatory
-     *      error code rather than reverting. If caller has not called checked protocol's balance, this may revert due to
-     *      insufficient cash held in this contract. If caller has checked protocol's balance prior to this call, and verified
-     *      it is >= amount, this should not revert in normal conditions.
-     *
-     *      Note: This wrapper safely handles non-standard ERC-20 tokens that do not return a value.
-     *            See here: https://medium.com/coinmonks/missing-return-value-bug-at-least-130-tokens-affected-d67bf08521ca
+     * @dev Sends underlying out of this market. Reverts if this market does not hold
+     *      `amount`, so callers should check the market's cash first
      */
     function doTransferOut(
         address payable to,
         uint amount
     ) internal virtual override {
-        EIP20NonStandardInterface token = EIP20NonStandardInterface(underlying);
-        token.transfer(to, amount);
+        /// debit first so an amount above the tracked cash reverts on underflow
+        internalCash -= amount;
 
-        bool success;
-        assembly {
-            switch returndatasize()
-            case 0 {
-                // This is a non-standard ERC-20
-                success := not(0) // set success to true
-            }
-            case 32 {
-                // This is a compliant ERC-20
-                returndatacopy(0, 0, 32)
-                success := mload(0) // Set `success = returndata` of override external call
-            }
-            default {
-                // This is an excessively non-compliant ERC-20, revert.
-                revert(0, 0)
-            }
+        IERC20(underlying).safeTransfer(to, amount);
+    }
+
+    /**
+     * @notice Sweep surplus underlying out of this market and resync `internalCash`
+     * @dev Surplus is `underlying.balanceOf(address(this)) - internalCash`, i.e. underlying
+     *      donated straight to this market. Pass `0` to resync without moving funds. Any
+     *      surplus not swept out is counted into `internalCash`, which raises the exchange
+     *      rate.
+     *
+     *      Reverts on failure rather than returning an error code, unlike the other admin
+     *      entry points here. Pays out the underlying directly, so a WETH market's admin
+     *      receives WETH rather than the raw ETH `MWethDelegate` would unwrap to.
+     * @param transferAmount Amount of surplus underlying to send to the admin
+     */
+    function sweepTokenAndSync(uint256 transferAmount) external nonReentrant {
+        require(
+            msg.sender == admin,
+            "MErc20::sweepTokenAndSync: only admin can sweep tokens"
+        );
+
+        /// book outstanding interest at the current utilization before cash moves
+        require(
+            accrueInterest() == uint(Error.NO_ERROR),
+            "MErc20::sweepTokenAndSync: accrue interest failed"
+        );
+
+        address underlying_ = underlying;
+        uint256 cashPrior = internalCash;
+        uint256 balance = IERC20(underlying_).balanceOf(address(this));
+
+        /// the real balance can fall below the tracked cash for underlyings that are able
+        /// to shrink a holder's balance, in which case there is no surplus to sweep
+        uint256 surplus = balance > cashPrior ? balance - cashPrior : 0;
+
+        require(
+            transferAmount <= surplus,
+            "MErc20::sweepTokenAndSync: amount exceeds surplus"
+        );
+
+        if (transferAmount != 0) {
+            /// the surplus was never counted in `internalCash`, so sending it out must not
+            /// debit it either
+            IERC20(underlying_).safeTransfer(admin, transferAmount);
+
+            emit UnderlyingSwept(admin, transferAmount);
         }
-        require(success, "TOKEN_TRANSFER_OUT_FAILED");
+
+        /// re-read rather than subtract so that an underlying charging a transfer fee
+        /// still leaves the tracked cash equal to what this market actually holds
+        uint256 cashNew = IERC20(underlying_).balanceOf(address(this));
+
+        internalCash = cashNew;
+
+        emit CashSynced(cashPrior, cashNew);
     }
 }

--- a/src/MErc20Delegate.sol
+++ b/src/MErc20Delegate.sol
@@ -31,6 +31,18 @@ contract MErc20Delegate is MErc20, MDelegateInterface {
             msg.sender == admin,
             "only the admin may call _becomeImplementation"
         );
+
+        /// seed from the live balance so the exchange rate does not move at handover
+        /// a roll back and forward leaves this stale, resync with `sweepTokenAndSync(0)`
+        if (!internalCashInitialized) {
+            internalCashInitialized = true;
+
+            uint256 balance = IERC20(underlying).balanceOf(address(this));
+
+            internalCash = balance;
+
+            emit CashSynced(0, balance);
+        }
     }
 
     /**

--- a/src/MErc20Delegator.sol
+++ b/src/MErc20Delegator.sol
@@ -498,6 +498,19 @@ contract MErc20Delegator is
         );
     }
 
+    /**
+     * @notice Sweep surplus underlying out of this mToken and resync its tracked cash balance. Tokens are sent to admin
+     * @param transferAmount The amount of surplus underlying to sweep, or zero to only resync
+     */
+    function sweepTokenAndSync(uint transferAmount) external {
+        delegateToImplementation(
+            abi.encodeWithSignature(
+                "sweepTokenAndSync(uint256)",
+                transferAmount
+            )
+        );
+    }
+
     /*** Admin Functions ***/
 
     /**

--- a/src/MTokenInterfaces.sol
+++ b/src/MTokenInterfaces.sol
@@ -90,8 +90,14 @@ contract MTokenStorage {
     /// @notice Implementation address for this contract
     address public implementation;
 
+    /// @notice Tracked cash balance of this market, immune to direct underlying transfers
+    uint256 public internalCash;
+
+    /// @notice Set by the first `_becomeImplementation`, blocking later ones from reseeding `internalCash` and moving the exchange rate
+    bool public internalCashInitialized;
+
     /// @dev Room to add new storage above without caring what any contract below declares
-    uint256[45] private __gap;
+    uint256[43] private __gap;
 }
 
 abstract contract MTokenInterface is MTokenStorage {
@@ -254,6 +260,14 @@ abstract contract MTokenInterface is MTokenStorage {
 }
 
 abstract contract MErc20Interface {
+    /*** Market Events ***/
+
+    /// @notice Emitted when the tracked internal cash balance is resynced with the underlying balance this market actually holds
+    event CashSynced(uint oldInternalCash, uint newInternalCash);
+
+    /// @notice Emitted when surplus underlying, i.e. underlying donated straight to this market, is swept out
+    event UnderlyingSwept(address indexed recipient, uint amount);
+
     /*** User Interface ***/
 
     function mint(uint mintAmount) external virtual returns (uint);

--- a/src/MTokenInterfaces.sol
+++ b/src/MTokenInterfaces.sol
@@ -79,6 +79,19 @@ contract MTokenStorage {
 
     /// @notice Share of seized collateral that is added to reserves
     uint public protocolSeizeShareMantissa;
+
+    // `underlying` and `implementation` used to sit in `MErc20Storage` and
+    // `MDelegationStorage`. Merged in here so the layout `MErc20Delegator` and its
+    // delegates share lives in one contract, and new state can be appended in one place.
+
+    /// @notice Underlying asset for this MToken
+    address public underlying;
+
+    /// @notice Implementation address for this contract
+    address public implementation;
+
+    /// @dev Room to add new storage above without caring what any contract below declares
+    uint256[45] private __gap;
 }
 
 abstract contract MTokenInterface is MTokenStorage {
@@ -240,12 +253,7 @@ abstract contract MTokenInterface is MTokenStorage {
     ) external virtual returns (uint);
 }
 
-contract MErc20Storage {
-    /// @notice Underlying asset for this MToken
-    address public underlying;
-}
-
-abstract contract MErc20Interface is MErc20Storage {
+abstract contract MErc20Interface {
     /*** User Interface ***/
 
     function mint(uint mintAmount) external virtual returns (uint);
@@ -278,12 +286,7 @@ abstract contract MErc20Interface is MErc20Storage {
     function _addReserves(uint addAmount) external virtual returns (uint);
 }
 
-contract MDelegationStorage {
-    /// @notice Implementation address for this contract
-    address public implementation;
-}
-
-abstract contract MDelegatorInterface is MDelegationStorage {
+abstract contract MDelegatorInterface {
     /// @notice Emitted when implementation is changed
     event NewImplementation(
         address oldImplementation,
@@ -303,7 +306,7 @@ abstract contract MDelegatorInterface is MDelegationStorage {
     ) external virtual;
 }
 
-abstract contract MDelegateInterface is MDelegationStorage {
+abstract contract MDelegateInterface {
     /**
      * @notice Called by the delegator on a delegate to initialize it for duty
      * @dev Should revert if any issues arise which make it unfit for delegation

--- a/src/MWethDelegate.sol
+++ b/src/MWethDelegate.sol
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.19;
 
-import {SafeERC20} from "@openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
-import {IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-
 import {WethUnwrapper} from "@protocol/WethUnwrapper.sol";
 import {MErc20Delegate} from "@protocol/MErc20Delegate.sol";
 
@@ -13,8 +10,6 @@ import {MErc20Delegate} from "@protocol/MErc20Delegate.sol";
  * @author Moonwell
  */
 contract MWethDelegate is MErc20Delegate {
-    using SafeERC20 for IERC20;
-
     /// @notice the WETH unwrapper address
     address public immutable wethUnwrapper;
 
@@ -32,9 +27,10 @@ contract MWethDelegate is MErc20Delegate {
         address payable to,
         uint256 amount
     ) internal virtual override {
-        IERC20 weth = IERC20(underlying);
+        /// hand the WETH to the unwrapper through the base implementation so that
+        /// `internalCash` is debited in exactly one place
+        super.doTransferOut(payable(wethUnwrapper), amount);
 
-        weth.safeTransfer(wethUnwrapper, amount);
         WethUnwrapper(payable(wethUnwrapper)).send(to, amount); /// send to user through wethUnwrapper
     }
 }

--- a/src/OEVProtocolFeeRedeemer.sol
+++ b/src/OEVProtocolFeeRedeemer.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.19;
 
-import {MErc20Interface} from "./MTokenInterfaces.sol";
+import {MTokenInterface, MErc20Interface} from "./MTokenInterfaces.sol";
 import {EIP20Interface} from "./EIP20Interface.sol";
 import {Ownable} from "@openzeppelin-contracts/contracts/access/Ownable.sol";
 
@@ -140,7 +140,9 @@ contract OEVProtocolFeeRedeemer is Ownable {
         returns (MErc20Interface mToken, EIP20Interface underlyingToken)
     {
         mToken = MErc20Interface(_mToken);
-        underlyingToken = EIP20Interface(mToken.underlying());
+        underlyingToken = EIP20Interface(
+            MTokenInterface(_mToken).underlying()
+        );
     }
 
     /**

--- a/src/market/AutomationDeploy.sol
+++ b/src/market/AutomationDeploy.sol
@@ -1,6 +1,6 @@
 pragma solidity =0.8.19;
 
-import {MErc20Storage} from "@protocol/MTokenInterfaces.sol";
+import {MTokenInterface} from "@protocol/MTokenInterfaces.sol";
 import {ReserveAutomation} from "@protocol/market/ReserveAutomation.sol";
 import {ERC20HoldingDeposit} from "@protocol/market/ERC20HoldingDeposit.sol";
 
@@ -31,7 +31,7 @@ contract AutomationDeploy {
             "mTokenMarket must be set"
         );
         require(
-            MErc20Storage(params.mTokenMarket).underlying() ==
+            MTokenInterface(params.mTokenMarket).underlying() ==
                 params.reserveAsset,
             "reserveUnderlying must match mToken underlying"
         );

--- a/src/oracles/ChainlinkCompositeOEVWrapper.sol
+++ b/src/oracles/ChainlinkCompositeOEVWrapper.sol
@@ -6,7 +6,7 @@ import {ReentrancyGuard} from "@openzeppelin-contracts/contracts/security/Reentr
 import {SafeERC20} from "@openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {AggregatorV3Interface} from "./AggregatorV3Interface.sol";
-import {MErc20Storage, MTokenInterface, MErc20Interface} from "../MTokenInterfaces.sol";
+import {MTokenInterface, MErc20Interface} from "../MTokenInterfaces.sol";
 import {EIP20Interface} from "../EIP20Interface.sol";
 import {IChainlinkOracle} from "../interfaces/IChainlinkOracle.sol";
 
@@ -387,12 +387,12 @@ contract ChainlinkCompositeOEVWrapper is
 
         // get the loan underlying token
         EIP20Interface underlyingLoan = EIP20Interface(
-            MErc20Storage(mTokenLoan).underlying()
+            MTokenInterface(mTokenLoan).underlying()
         );
 
         // get the collateral underlying token
         EIP20Interface underlyingCollateral = EIP20Interface(
-            MErc20Storage(mTokenCollateral).underlying()
+            MTokenInterface(mTokenCollateral).underlying()
         );
 
         MTokenInterface mTokenCollateralInterface = MTokenInterface(

--- a/src/oracles/ChainlinkOEVWrapper.sol
+++ b/src/oracles/ChainlinkOEVWrapper.sol
@@ -6,7 +6,7 @@ import {ReentrancyGuard} from "@openzeppelin-contracts/contracts/security/Reentr
 import {SafeERC20} from "@openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {AggregatorV3Interface} from "./AggregatorV3Interface.sol";
-import {MErc20Storage, MTokenInterface, MErc20Interface} from "../MTokenInterfaces.sol";
+import {MTokenInterface, MErc20Interface} from "../MTokenInterfaces.sol";
 import {EIP20Interface} from "../EIP20Interface.sol";
 import {IChainlinkOracle} from "../interfaces/IChainlinkOracle.sol";
 import {IOEVWrapperFeed} from "./IOEVWrapperFeed.sol";
@@ -411,12 +411,12 @@ contract ChainlinkOEVWrapper is
 
         // get the loan underlying token (the token being repaid)
         EIP20Interface underlyingLoan = EIP20Interface(
-            MErc20Storage(mTokenLoan).underlying()
+            MTokenInterface(mTokenLoan).underlying()
         );
 
         // get the collateral underlying token (the token being seized)
         EIP20Interface underlyingCollateral = EIP20Interface(
-            MErc20Storage(mTokenCollateral).underlying()
+            MTokenInterface(mTokenCollateral).underlying()
         );
 
         MTokenInterface mTokenCollateralInterface = MTokenInterface(

--- a/src/views/BaseMoonwellViews.sol
+++ b/src/views/BaseMoonwellViews.sol
@@ -8,7 +8,7 @@ import {TokenSaleDistributorInterfaceV1} from "@protocol/views/TokenSaleDistribu
 import {SafetyModuleInterfaceV1} from "@protocol/views/SafetyModuleInterfaceV1.sol";
 import {Well} from "@protocol/governance/Well.sol";
 import {IERC20} from "@protocol/governance/IERC20.sol";
-import {MErc20Interface} from "@protocol/MTokenInterfaces.sol";
+import {MTokenInterface} from "@protocol/MTokenInterfaces.sol";
 import {UniswapV2PairInterface} from "@protocol/views/UniswapV2PairInterface.sol";
 
 /**
@@ -351,7 +351,7 @@ contract BaseMoonwellViews is Initializable {
             address underlyingToken = address(0);
             if (address(mToken) != _nativeMarket) {
                 underlyingToken = address(
-                    MErc20Interface(address(mToken)).underlying()
+                    MTokenInterface(address(mToken)).underlying()
                 );
             }
             _tokens[_currIndex] = address(mToken);

--- a/src/views/BaseMoonwellViewsMoonbeam.sol
+++ b/src/views/BaseMoonwellViewsMoonbeam.sol
@@ -8,7 +8,7 @@ import {TokenSaleDistributorInterfaceV1} from "@protocol/views/TokenSaleDistribu
 import {SafetyModuleInterfaceV1} from "@protocol/views/SafetyModuleInterfaceV1.sol";
 import {Well} from "@protocol/governance/Well.sol";
 import {IERC20} from "@protocol/governance/IERC20.sol";
-import {MErc20Interface} from "@protocol/MTokenInterfaces.sol";
+import {MTokenInterface} from "@protocol/MTokenInterfaces.sol";
 import {UniswapV2PairInterface} from "@protocol/views/UniswapV2PairInterface.sol";
 
 /**
@@ -366,7 +366,7 @@ contract BaseMoonwellViewsMoonbeam is Initializable {
             address underlyingToken = address(0);
             if (address(mToken) != _nativeMarket) {
                 underlyingToken = address(
-                    MErc20Interface(address(mToken)).underlying()
+                    MTokenInterface(address(mToken)).underlying()
                 );
             }
             _tokens[_currIndex] = address(mToken);

--- a/src/views/MoonwellViewsV1Moonriver.sol
+++ b/src/views/MoonwellViewsV1Moonriver.sol
@@ -5,7 +5,7 @@ import {MoonwellViewsV1Simple} from "@protocol/views/MoonwellViewsV1Simple.sol";
 import {Comptroller} from "@protocol/Comptroller.sol";
 import {Well} from "@protocol/governance/Well.sol";
 import {MToken} from "@protocol/MToken.sol";
-import {MErc20Interface} from "@protocol/MTokenInterfaces.sol";
+import {MTokenInterface} from "@protocol/MTokenInterfaces.sol";
 import {SafetyModuleInterfaceV1} from "@protocol/views/SafetyModuleInterfaceV1.sol";
 import {UniswapV2PairInterface} from "@protocol/views/UniswapV2PairInterface.sol";
 
@@ -117,7 +117,7 @@ contract MoonwellViewsV1Moonriver is MoonwellViewsV1Simple {
         }
         return
             _getTokenPriceFromDex(
-                MErc20Interface(address(_mToken)).underlying()
+                MTokenInterface(address(_mToken)).underlying()
             );
     }
 

--- a/test/integration/MTokenDonationSupplyCapIntegration.t.sol
+++ b/test/integration/MTokenDonationSupplyCapIntegration.t.sol
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.19;
+
+import "@forge-std/Test.sol";
+
+import {MToken} from "@protocol/MToken.sol";
+import {MErc20} from "@protocol/MErc20.sol";
+import {Comptroller} from "@protocol/Comptroller.sol";
+import {EIP20Interface} from "@protocol/EIP20Interface.sol";
+import {MErc20Delegate} from "@protocol/MErc20Delegate.sol";
+import {MWethDelegate} from "@protocol/MWethDelegate.sol";
+import {MErc20Delegator} from "@protocol/MErc20Delegator.sol";
+import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
+
+/// @notice Proves that the supply cap is not actually a cap on a live Base market, and
+///         that the upgraded market makes it one.
+///
+///         `Comptroller.mintAllowed` sizes the cap off
+///         `getCash() + totalBorrows - totalReserves`, and only mints are routed through
+///         it. While `getCash()` is `underlying.balanceOf(market)`, anyone can transfer
+///         underlying straight to a market that is already sitting at its cap and push the
+///         supplies it holds past that cap, with no mint and therefore no cap check
+///         anywhere in the path. The market ends up carrying more of the underlying than
+///         risk management sized it for, and because the donation lands in
+///         `getCash()` it also lifts the exchange rate, minting value to existing
+///         suppliers out of the donor's pocket.
+///
+///         After the upgrade `getCash()` reads `internalCash`, which only `doTransferIn`
+///         and `doTransferOut` move, so the same donation leaves both the supplies the cap
+///         governs and the exchange rate exactly where they were.
+/// @dev Run against a Base fork:
+///      `forge test --match-contract MTokenDonationSupplyCapIntegrationTest -vvv`
+contract MTokenDonationSupplyCapIntegrationTest is Test {
+    /// @dev pinned because the two live market tests below assert that the implementation
+    ///      these markets run today is the vulnerable one. Once the upgrade executes on
+    ///      Base that stops being true at head, and they would fail as if the fix were a
+    ///      regression
+    uint256 private constant FORK_BLOCK = 50_590_315;
+
+    Addresses private addresses;
+    Comptroller private comptroller;
+
+    /// @dev how much underlying the donation moves, as a multiple of the honest supply
+    ///      that fills the market to its cap
+    uint256 private constant DONATION_MULTIPLE = 5;
+
+    function setUp() public {
+        vm.createSelectFork(vm.rpcUrl("base"), FORK_BLOCK);
+
+        addresses = new Addresses();
+        comptroller = Comptroller(addresses.getAddress("UNITROLLER"));
+    }
+
+    /// ---------------------------------------------------------------------------
+    /// the vector, against the implementation that is live today
+    /// ---------------------------------------------------------------------------
+
+    function testDonationExceedsSupplyCapOnLiveUsdcMarket() public {
+        _assertDonationExceedsSupplyCap(
+            addresses.getAddress("MOONWELL_USDC"),
+            10_000e6
+        );
+    }
+
+    function testDonationExceedsSupplyCapOnLiveWethMarket() public {
+        _assertDonationExceedsSupplyCap(
+            addresses.getAddress("MOONWELL_WETH"),
+            5 ether
+        );
+    }
+
+    /// ---------------------------------------------------------------------------
+    /// the same donation, after the market is pointed at the new implementation
+    /// ---------------------------------------------------------------------------
+
+    function testDonationRespectsSupplyCapOnUpgradedUsdcMarket() public {
+        _assertDonationRespectsSupplyCapAfterUpgrade(
+            addresses.getAddress("MOONWELL_USDC"),
+            address(new MErc20Delegate()),
+            10_000e6
+        );
+    }
+
+    function testDonationRespectsSupplyCapOnUpgradedWethMarket() public {
+        _assertDonationRespectsSupplyCapAfterUpgrade(
+            addresses.getAddress("MOONWELL_WETH"),
+            address(new MWethDelegate(addresses.getAddress("WETH_UNWRAPPER"))),
+            5 ether
+        );
+    }
+
+    /// ---------------------------------------------------------------------------
+    /// scenarios
+    /// ---------------------------------------------------------------------------
+
+    /// @notice fills the market to its supply cap through the front door, confirms the cap
+    ///         is enforced against one more wei of honest supply, then walks straight past
+    ///         it with a donation
+    function _assertDonationExceedsSupplyCap(
+        address market,
+        uint256 mintAmount
+    ) private {
+        uint256 supplyCap = _fillMarketToSupplyCap(market, mintAmount);
+
+        uint256 suppliesAtCap = _totalSupplies(market);
+        uint256 exchangeRateAtCap = MErc20Delegator(payable(market))
+            .exchangeRateStored();
+        uint256 donationAmount = mintAmount * DONATION_MULTIPLE;
+
+        _donate(market, donationAmount);
+
+        /// the market now holds more of the underlying than the cap allows, and nothing
+        /// rejected it because a plain ERC-20 transfer never touches `mintAllowed`
+        assertEq(
+            _totalSupplies(market),
+            suppliesAtCap + donationAmount,
+            "donation did not land in the supplies the cap governs"
+        );
+        assertGt(
+            _totalSupplies(market),
+            supplyCap,
+            "supplies did not exceed the supply cap"
+        );
+
+        /// and the donated underlying is handed to existing suppliers through the rate
+        assertGt(
+            MErc20Delegator(payable(market)).exchangeRateStored(),
+            exchangeRateAtCap,
+            "donation did not lift the exchange rate"
+        );
+    }
+
+    /// @notice the same sequence against the upgraded implementation: the cap still binds
+    ///         honest supply, the donation no longer counts toward it, the exchange rate
+    ///         does not move, and the admin can take the donation back out
+    function _assertDonationRespectsSupplyCapAfterUpgrade(
+        address market,
+        address newImplementation,
+        uint256 mintAmount
+    ) private {
+        _upgradeAndAssertAccountingUnchanged(market, newImplementation);
+
+        uint256 supplyCap = _fillMarketToSupplyCap(market, mintAmount);
+
+        uint256 suppliesAtCap = _totalSupplies(market);
+        uint256 exchangeRateAtCap = MErc20Delegator(payable(market))
+            .exchangeRateStored();
+        uint256 donationAmount = mintAmount * DONATION_MULTIPLE;
+
+        _donate(market, donationAmount);
+
+        assertEq(
+            _totalSupplies(market),
+            suppliesAtCap,
+            "donation reached the supplies the cap governs"
+        );
+        assertLt(
+            _totalSupplies(market),
+            supplyCap,
+            "supplies exceeded the supply cap"
+        );
+        assertEq(
+            MErc20Delegator(payable(market)).exchangeRateStored(),
+            exchangeRateAtCap,
+            "donation lifted the exchange rate"
+        );
+
+        _assertAdminRecoversDonation(market, donationAmount);
+    }
+
+    /// ---------------------------------------------------------------------------
+    /// steps
+    /// ---------------------------------------------------------------------------
+
+    /// @dev pins the supply cap `mintAmount` above what the market currently supplies,
+    ///      takes that headroom with an honest mint, and checks the cap is binding
+    ///      afterwards. Returns the cap that is now in force
+    function _fillMarketToSupplyCap(
+        address market,
+        uint256 mintAmount
+    ) private returns (uint256 supplyCap) {
+        supplyCap = _setSupplyCapWithHeadroom(market, mintAmount);
+
+        assertEq(
+            _mint(market, mintAmount),
+            0,
+            "honest mint into the headroom failed"
+        );
+        assertLt(
+            _totalSupplies(market),
+            supplyCap,
+            "market was not filled to its cap"
+        );
+
+        /// the cap does bind honest supply, which is what makes the donation below a way
+        /// around it rather than a way into headroom that was there all along
+        address underlying = MErc20Delegator(payable(market)).underlying();
+        deal(underlying, address(this), 1);
+        EIP20Interface(underlying).approve(market, 1);
+
+        vm.expectRevert("market supply cap reached");
+        MErc20(market).mint(1);
+    }
+
+    /// @dev the handover seeds `internalCash` from the balance the market already holds,
+    ///      so nothing about the market's accounting moves in the upgrade transaction
+    function _upgradeAndAssertAccountingUnchanged(
+        address market,
+        address newImplementation
+    ) private {
+        MErc20Delegator delegator = MErc20Delegator(payable(market));
+
+        assertTrue(
+            delegator.implementation() != newImplementation,
+            "new implementation must differ from the live one"
+        );
+
+        uint256 cashBefore = delegator.getCash();
+        uint256 exchangeRateBefore = delegator.exchangeRateStored();
+
+        vm.prank(delegator.admin());
+        delegator._setImplementation(newImplementation, true, "");
+
+        assertTrue(
+            delegator.internalCashInitialized(),
+            "cash tracking not initialized by the upgrade"
+        );
+        assertEq(
+            delegator.internalCash(),
+            EIP20Interface(delegator.underlying()).balanceOf(market),
+            "internalCash not seeded from the underlying balance"
+        );
+        assertEq(
+            delegator.getCash(),
+            cashBefore,
+            "upgrade moved reported cash"
+        );
+        assertEq(
+            delegator.exchangeRateStored(),
+            exchangeRateBefore,
+            "upgrade moved the exchange rate"
+        );
+    }
+
+    function _assertAdminRecoversDonation(
+        address market,
+        uint256 amount
+    ) private {
+        MErc20Delegator delegator = MErc20Delegator(payable(market));
+        address underlying = delegator.underlying();
+        address admin = delegator.admin();
+
+        uint256 adminBalanceBefore = EIP20Interface(underlying).balanceOf(
+            admin
+        );
+        uint256 internalCashBefore = delegator.internalCash();
+
+        vm.prank(admin);
+        delegator.sweepTokenAndSync(amount);
+
+        assertEq(
+            EIP20Interface(underlying).balanceOf(admin) - adminBalanceBefore,
+            amount,
+            "admin did not recover the donation"
+        );
+        assertEq(
+            delegator.internalCash(),
+            internalCashBefore,
+            "sweep moved supplier cash"
+        );
+        assertEq(
+            delegator.internalCash(),
+            EIP20Interface(underlying).balanceOf(market),
+            "internalCash diverged from the balance after the sweep"
+        );
+    }
+
+    /// ---------------------------------------------------------------------------
+    /// helpers
+    /// ---------------------------------------------------------------------------
+
+    /// @dev exactly what `Comptroller.mintAllowed` measures the cap against
+    function _totalSupplies(address market) private view returns (uint256) {
+        MErc20Delegator delegator = MErc20Delegator(payable(market));
+
+        return
+            delegator.getCash() +
+            delegator.totalBorrows() -
+            delegator.totalReserves();
+    }
+
+    /// @dev pins the market's supply cap at exactly `headroom` above what it currently
+    ///      supplies, so the cap arithmetic in the assertions is exact rather than
+    ///      dependent on whatever the live cap happens to be
+    function _setSupplyCapWithHeadroom(
+        address market,
+        uint256 headroom
+    ) private returns (uint256 supplyCap) {
+        /// accrue first so `totalBorrows` and `totalReserves` do not move underneath the
+        /// cap when the next state changing call accrues for us
+        assertEq(
+            MErc20Delegator(payable(market)).accrueInterest(),
+            0,
+            "accrue interest failed"
+        );
+
+        /// `mintAllowed` requires `nextTotalSupplies < supplyCap`, so the cap is one above
+        /// the headroom that has to be usable
+        supplyCap = _totalSupplies(market) + headroom + 1;
+
+        MToken[] memory markets = new MToken[](1);
+        markets[0] = MToken(market);
+        uint256[] memory caps = new uint256[](1);
+        caps[0] = supplyCap;
+
+        vm.prank(comptroller.admin());
+        comptroller._setMarketSupplyCaps(markets, caps);
+    }
+
+    function _mint(
+        address market,
+        uint256 mintAmount
+    ) private returns (uint256) {
+        address underlying = MErc20Delegator(payable(market)).underlying();
+
+        deal(underlying, address(this), mintAmount);
+        EIP20Interface(underlying).approve(market, mintAmount);
+
+        return MErc20(market).mint(mintAmount);
+    }
+
+    /// @dev underlying transferred straight to the market, never through `doTransferIn`
+    function _donate(address market, uint256 amount) private {
+        address underlying = MErc20Delegator(payable(market)).underlying();
+        address attacker = address(0xA77ACE4);
+
+        deal(underlying, attacker, amount);
+
+        vm.prank(attacker);
+        EIP20Interface(underlying).transfer(market, amount);
+    }
+
+    /// @dev the WETH market's delegate unwraps to raw ETH on the way out
+    receive() external payable {}
+}

--- a/test/integration/MTokenStorageUpgradeIntegration.t.sol
+++ b/test/integration/MTokenStorageUpgradeIntegration.t.sol
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.19;
+
+import "@forge-std/Test.sol";
+
+import {MErc20} from "@protocol/MErc20.sol";
+import {MErc20Delegate} from "@protocol/MErc20Delegate.sol";
+import {MErc20Delegator} from "@protocol/MErc20Delegator.sol";
+import {MWethDelegate} from "@protocol/MWethDelegate.sol";
+import {EIP20Interface} from "@protocol/EIP20Interface.sol";
+import {MToken} from "@protocol/MToken.sol";
+import {Comptroller} from "@protocol/Comptroller.sol";
+import {ComptrollerInterface} from "@protocol/ComptrollerInterface.sol";
+import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
+
+/// @notice Verifies that pointing a live market at a delegate compiled from the merged
+///         `MTokenStorage` layout leaves every storage backed value reading the same.
+///         `underlying` and `implementation` moved out of `MErc20Storage` and
+///         `MDelegationStorage` into `MTokenStorage`; if that move shifted a slot, the new
+///         implementation would read different values through the delegator's storage.
+/// @dev Run against a Base fork: `forge test --match-contract MTokenStorageUpgradeIntegrationTest --fork-url base`
+contract MTokenStorageUpgradeIntegrationTest is Test {
+    Addresses private addresses;
+
+    /// @notice Every value the delegator serves out of storage, read through whichever
+    ///         implementation is currently wired in. Fields follow MTokenStorage slot
+    ///         order so a shifted slot is easy to spot from the failing assertion.
+    ///         Slot 0 `_notEntered` and slot 7 `initialExchangeRateMantissa` are internal
+    ///         with no getter; slot 19 `implementation` changes and is checked separately.
+    struct MarketState {
+        string name; // slot 1
+        string symbol; // slot 2
+        uint8 decimals; // slot 3
+        address admin; // slot 3
+        address pendingAdmin; // slot 4
+        address comptroller; // slot 5
+        address interestRateModel; // slot 6
+        uint256 reserveFactorMantissa; // slot 8
+        uint256 accrualBlockTimestamp; // slot 9
+        uint256 borrowIndex; // slot 10
+        uint256 totalBorrows; // slot 11
+        uint256 totalReserves; // slot 12
+        uint256 totalSupply; // slot 13
+        uint256 holderBalance; // slot 14, accountTokens
+        uint256 holderAllowance; // slot 15, transferAllowances
+        uint256 holderBorrow; // slot 16, accountBorrows
+        uint256 protocolSeizeShareMantissa; // slot 17
+        address underlying; // slot 18
+        uint256 exchangeRateStored; // derived from the above
+        uint256 cash; // derived from the above
+    }
+
+    function setUp() public {
+        addresses = new Addresses();
+    }
+
+    /// @notice a plain ERC-20 market, upgraded to a freshly compiled MErc20Delegate
+    function testMErc20MarketStorageSurvivesUpgrade() public {
+        _assertStorageSurvivesUpgrade(
+            addresses.getAddress("MOONWELL_USDC"),
+            address(new MErc20Delegate()),
+            1_000e6
+        );
+    }
+
+    /// @notice the WETH market, which runs its own delegate, upgraded to a freshly
+    ///         compiled MWethDelegate wired to the live unwrapper
+    function testMWethMarketStorageSurvivesUpgrade() public {
+        _assertStorageSurvivesUpgrade(
+            addresses.getAddress("MOONWELL_WETH"),
+            address(
+                new MWethDelegate(addresses.getAddress("WETH_UNWRAPPER"))
+            ),
+            1 ether
+        );
+    }
+
+    /// @notice supply and borrow so the mapping backed slots hold something, snapshot the
+    ///         market through the live implementation, swap the implementation, then read
+    ///         everything back and require it to be unchanged
+    function _assertStorageSurvivesUpgrade(
+        address market,
+        address newImplementation,
+        uint256 supplyAmount
+    ) private {
+        MErc20Delegator delegator = MErc20Delegator(payable(market));
+        address oldImplementation = delegator.implementation();
+
+        assertTrue(
+            oldImplementation != newImplementation,
+            "new implementation must differ from the live one"
+        );
+
+        _supplyAndBorrow(market, supplyAmount);
+
+        MarketState memory before = _snapshot(market);
+
+        vm.prank(delegator.admin());
+        delegator._setImplementation(newImplementation, true, "");
+
+        assertEq(
+            delegator.implementation(),
+            newImplementation,
+            "implementation not swapped"
+        );
+
+        MarketState memory afterUpgrade = _snapshot(market);
+
+        assertEq(afterUpgrade.name, before.name, "name");
+        assertEq(afterUpgrade.symbol, before.symbol, "symbol");
+        assertEq(afterUpgrade.decimals, before.decimals, "decimals");
+        assertEq(afterUpgrade.admin, before.admin, "admin");
+        assertEq(
+            afterUpgrade.pendingAdmin,
+            before.pendingAdmin,
+            "pendingAdmin"
+        );
+        assertEq(afterUpgrade.comptroller, before.comptroller, "comptroller");
+        assertEq(
+            afterUpgrade.interestRateModel,
+            before.interestRateModel,
+            "interestRateModel"
+        );
+        assertEq(
+            afterUpgrade.reserveFactorMantissa,
+            before.reserveFactorMantissa,
+            "reserveFactorMantissa"
+        );
+        assertEq(
+            afterUpgrade.accrualBlockTimestamp,
+            before.accrualBlockTimestamp,
+            "accrualBlockTimestamp"
+        );
+        assertEq(afterUpgrade.borrowIndex, before.borrowIndex, "borrowIndex");
+        assertEq(
+            afterUpgrade.totalBorrows,
+            before.totalBorrows,
+            "totalBorrows"
+        );
+        assertEq(
+            afterUpgrade.totalReserves,
+            before.totalReserves,
+            "totalReserves"
+        );
+        assertEq(afterUpgrade.totalSupply, before.totalSupply, "totalSupply");
+        assertEq(
+            afterUpgrade.holderBalance,
+            before.holderBalance,
+            "accountTokens"
+        );
+        assertEq(
+            afterUpgrade.holderAllowance,
+            before.holderAllowance,
+            "transferAllowances"
+        );
+        assertEq(
+            afterUpgrade.holderBorrow,
+            before.holderBorrow,
+            "accountBorrows"
+        );
+        assertEq(
+            afterUpgrade.protocolSeizeShareMantissa,
+            before.protocolSeizeShareMantissa,
+            "protocolSeizeShareMantissa"
+        );
+        assertEq(afterUpgrade.underlying, before.underlying, "underlying");
+        assertEq(
+            afterUpgrade.exchangeRateStored,
+            before.exchangeRateStored,
+            "exchangeRateStored"
+        );
+        assertEq(afterUpgrade.cash, before.cash, "cash");
+    }
+
+    /// @dev populates accountTokens, transferAllowances and accountBorrows for this test
+    ///      contract so the three mapping slots are not compared empty
+    function _supplyAndBorrow(address market, uint256 supplyAmount) private {
+        MErc20 mToken = MErc20(market);
+        address underlying = MErc20Delegator(payable(market)).underlying();
+
+        deal(underlying, address(this), supplyAmount);
+        EIP20Interface(underlying).approve(market, supplyAmount);
+        assertEq(mToken.mint(supplyAmount), 0, "mint failed");
+
+        /// an allowance this contract grants on the mToken itself, i.e. slot 15
+        MErc20Delegator(payable(market)).approve(address(0xdead), 1234);
+
+        address[] memory markets = new address[](1);
+        markets[0] = market;
+        ComptrollerInterface(addresses.getAddress("UNITROLLER")).enterMarkets(
+            markets
+        );
+
+        /// live markets sit at their borrow cap, so lift it for this market only. The
+        /// snapshot is taken after this, so the raised cap is common to both reads
+        Comptroller comptroller = Comptroller(
+            addresses.getAddress("UNITROLLER")
+        );
+        MToken[] memory cappedMarkets = new MToken[](1);
+        cappedMarkets[0] = MToken(market);
+        uint256[] memory caps = new uint256[](1);
+        caps[0] = type(uint256).max;
+
+        vm.prank(comptroller.admin());
+        comptroller._setMarketBorrowCaps(cappedMarkets, caps);
+
+        uint256 borrowAmount = supplyAmount / 4;
+        assertEq(mToken.borrow(borrowAmount), 0, "borrow failed");
+
+        /// at least what was borrowed, so accrued interest still passes
+        assertGe(
+            MErc20Delegator(payable(market)).borrowBalanceStored(
+                address(this)
+            ),
+            borrowAmount,
+            "borrow did not register"
+        );
+    }
+
+    function _snapshot(
+        address market
+    ) private returns (MarketState memory state) {
+        MErc20Delegator delegator = MErc20Delegator(payable(market));
+
+        state.name = delegator.name();
+        state.symbol = delegator.symbol();
+        state.decimals = delegator.decimals();
+        state.admin = delegator.admin();
+        state.pendingAdmin = delegator.pendingAdmin();
+        state.comptroller = address(delegator.comptroller());
+        state.interestRateModel = address(delegator.interestRateModel());
+        state.reserveFactorMantissa = delegator.reserveFactorMantissa();
+        state.accrualBlockTimestamp = delegator.accrualBlockTimestamp();
+        state.borrowIndex = delegator.borrowIndex();
+        state.totalBorrows = delegator.totalBorrows();
+        state.totalReserves = delegator.totalReserves();
+        state.totalSupply = delegator.totalSupply();
+        state.holderBalance = delegator.balanceOf(address(this));
+        state.holderAllowance = delegator.allowance(
+            address(this),
+            address(0xdead)
+        );
+        state.holderBorrow = delegator.borrowBalanceStored(address(this));
+        state.protocolSeizeShareMantissa = delegator
+            .protocolSeizeShareMantissa();
+        state.underlying = delegator.underlying();
+        state.exchangeRateStored = delegator.exchangeRateStored();
+        state.cash = delegator.getCash();
+    }
+
+    /// @dev the WETH market's delegate unwraps to raw ETH on the way out
+    receive() external payable {}
+}

--- a/test/integration/MTokenStorageUpgradeIntegration.t.sol
+++ b/test/integration/MTokenStorageUpgradeIntegration.t.sol
@@ -18,8 +18,12 @@ import {AllChainAddresses as Addresses} from "@proposals/Addresses.sol";
 ///         `underlying` and `implementation` moved out of `MErc20Storage` and
 ///         `MDelegationStorage` into `MTokenStorage`; if that move shifted a slot, the new
 ///         implementation would read different values through the delegator's storage.
-/// @dev Run against a Base fork: `forge test --match-contract MTokenStorageUpgradeIntegrationTest --fork-url base`
+/// @dev Run against a Base fork: `forge test --match-contract MTokenStorageUpgradeIntegrationTest`
 contract MTokenStorageUpgradeIntegrationTest is Test {
+    /// @dev pinned so the market state, and the implementation these markets run today,
+    ///      stay fixed as Base moves on
+    uint256 private constant FORK_BLOCK = 50_590_315;
+
     Addresses private addresses;
 
     /// @notice Every value the delegator serves out of storage, read through whichever
@@ -51,6 +55,8 @@ contract MTokenStorageUpgradeIntegrationTest is Test {
     }
 
     function setUp() public {
+        vm.createSelectFork(vm.rpcUrl("base"), FORK_BLOCK);
+
         addresses = new Addresses();
     }
 
@@ -68,9 +74,7 @@ contract MTokenStorageUpgradeIntegrationTest is Test {
     function testMWethMarketStorageSurvivesUpgrade() public {
         _assertStorageSurvivesUpgrade(
             addresses.getAddress("MOONWELL_WETH"),
-            address(
-                new MWethDelegate(addresses.getAddress("WETH_UNWRAPPER"))
-            ),
+            address(new MWethDelegate(addresses.getAddress("WETH_UNWRAPPER"))),
             1 ether
         );
     }
@@ -209,9 +213,7 @@ contract MTokenStorageUpgradeIntegrationTest is Test {
 
         /// at least what was borrowed, so accrued interest still passes
         assertGe(
-            MErc20Delegator(payable(market)).borrowBalanceStored(
-                address(this)
-            ),
+            MErc20Delegator(payable(market)).borrowBalanceStored(address(this)),
             borrowAmount,
             "borrow did not register"
         );

--- a/test/integration/ReserveAutomationIntegration.t.sol
+++ b/test/integration/ReserveAutomationIntegration.t.sol
@@ -6,7 +6,6 @@ import {ERC20} from "solmate/tokens/ERC20.sol";
 import "@forge-std/Test.sol";
 
 import {MErc20} from "@protocol/MErc20.sol";
-import {MErc20Storage} from "@protocol/MTokenInterfaces.sol";
 import {AutomationDeploy} from "@protocol/market/AutomationDeploy.sol";
 import {MockERC20Decimals} from "@test/mock/MockERC20Decimals.sol";
 import {ReserveAutomation} from "@protocol/market/ReserveAutomation.sol";

--- a/test/unit/MErc20InternalCash.t.sol
+++ b/test/unit/MErc20InternalCash.t.sol
@@ -1,0 +1,776 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.19;
+
+import "@forge-std/Test.sol";
+
+import {MToken} from "@protocol/MToken.sol";
+import {MErc20} from "@protocol/MErc20.sol";
+import {Comptroller} from "@protocol/Comptroller.sol";
+import {MockWeth} from "@test/mock/MockWeth.sol";
+import {MErc20Delegate} from "@protocol/MErc20Delegate.sol";
+import {MWethDelegate} from "@protocol/MWethDelegate.sol";
+import {WethUnwrapper} from "@protocol/WethUnwrapper.sol";
+import {MErc20Delegator} from "@protocol/MErc20Delegator.sol";
+import {SimplePriceOracle} from "@test/helper/SimplePriceOracle.sol";
+import {InterestRateModel} from "@protocol/irm/InterestRateModel.sol";
+import {FaucetTokenWithPermit} from "@test/helper/FaucetToken.sol";
+import {TokenErrorReporter} from "@protocol/TokenErrorReporter.sol";
+import {MultiRewardDistributor} from "@protocol/rewards/MultiRewardDistributor.sol";
+import {WhitePaperInterestRateModel} from "@protocol/irm/WhitePaperInterestRateModel.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+/// @notice Covers the cash accounting `MErc20` keeps in `internalCash`: what credits and
+///         debits it, that underlying donated straight to the market never touches it, and
+///         the `sweepTokenAndSync` admin entry point that reconciles it with the balance
+///         the market actually holds.
+contract MErc20InternalCashUnitTest is Test, TokenErrorReporter {
+    /// @dev slot of `MTokenStorage.internalCash`, confirmed by
+    ///      `forge inspect MErc20Delegate storageLayout`
+    uint256 internal constant INTERNAL_CASH_SLOT = 20;
+
+    /// @dev slot of `MTokenStorage.internalCashInitialized`
+    uint256 internal constant INTERNAL_CASH_INITIALIZED_SLOT = 21;
+
+    /// @notice mirrors `MErc20Interface.CashSynced`
+    event CashSynced(uint oldInternalCash, uint newInternalCash);
+
+    /// @notice mirrors `MErc20Interface.UnderlyingSwept`
+    event UnderlyingSwept(address indexed recipient, uint amount);
+
+    Comptroller public comptroller;
+    SimplePriceOracle public oracle;
+    FaucetTokenWithPermit public token;
+    InterestRateModel public irModel;
+    MErc20Delegate public implementation;
+    MErc20Delegator public mToken;
+
+    /// @notice a second market, so a borrower can post collateral without that collateral
+    ///         also being the cash they are trying to borrow
+    FaucetTokenWithPermit public collateralToken;
+    MErc20Delegator public mCollateral;
+
+    address public constant supplier = address(0x51);
+    address public constant borrower = address(0xB0);
+    address public constant donor = address(0xD0);
+
+    uint256 public constant supplyAmount = 100e18;
+    uint256 public constant donationAmount = 10e18;
+
+    function setUp() public {
+        comptroller = new Comptroller();
+        oracle = new SimplePriceOracle();
+        token = new FaucetTokenWithPermit(0, "Testing", 18, "TEST");
+        irModel = new WhitePaperInterestRateModel(0.1e18, 0.45e18);
+        implementation = new MErc20Delegate();
+
+        mToken = new MErc20Delegator(
+            address(token),
+            comptroller,
+            irModel,
+            1e18, /// 1:1 exchange rate keeps the arithmetic in these tests readable
+            "Test mToken",
+            "mTEST",
+            8,
+            payable(address(this)),
+            address(implementation),
+            ""
+        );
+
+        MultiRewardDistributor distributor = new MultiRewardDistributor();
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(distributor),
+            address(this),
+            abi.encodeWithSignature(
+                "initialize(address,address)",
+                address(comptroller),
+                address(this)
+            )
+        );
+        distributor = MultiRewardDistributor(address(proxy));
+
+        collateralToken = new FaucetTokenWithPermit(
+            0,
+            "Collateral",
+            18,
+            "COLL"
+        );
+        mCollateral = new MErc20Delegator(
+            address(collateralToken),
+            comptroller,
+            irModel,
+            1e18,
+            "Test collateral mToken",
+            "mCOLL",
+            8,
+            payable(address(this)),
+            address(implementation),
+            ""
+        );
+
+        comptroller._setRewardDistributor(distributor);
+        comptroller._setPriceOracle(oracle);
+
+        comptroller._supportMarket(MToken(address(mToken)));
+        oracle.setUnderlyingPrice(MToken(address(mToken)), 1e18);
+        comptroller._setCollateralFactor(MToken(address(mToken)), 0.8e18);
+
+        comptroller._supportMarket(MToken(address(mCollateral)));
+        oracle.setUnderlyingPrice(MToken(address(mCollateral)), 1e18);
+        comptroller._setCollateralFactor(MToken(address(mCollateral)), 0.8e18);
+    }
+
+    /// ---------------------------------------------------------------------------
+    /// cash tracking
+    /// ---------------------------------------------------------------------------
+
+    function testSetupMarksCashTrackingInitialized() public view {
+        assertTrue(
+            mToken.internalCashInitialized(),
+            "constructor did not initialize cash tracking"
+        );
+        assertEq(mToken.internalCash(), 0, "fresh market holds cash");
+        assertEq(mToken.getCash(), 0, "getCash does not read internalCash");
+    }
+
+    function testMintCreditsInternalCash() public {
+        _mint(supplier, supplyAmount);
+
+        assertEq(mToken.internalCash(), supplyAmount, "internalCash");
+        assertEq(mToken.getCash(), supplyAmount, "getCash");
+        assertEq(
+            token.balanceOf(address(mToken)),
+            supplyAmount,
+            "underlying balance"
+        );
+    }
+
+    function testRedeemDebitsInternalCash() public {
+        _mint(supplier, supplyAmount);
+
+        uint256 redeemAmount = supplyAmount / 4;
+
+        vm.prank(supplier);
+        assertEq(
+            mToken.redeemUnderlying(redeemAmount),
+            uint(Error.NO_ERROR),
+            "redeem failed"
+        );
+
+        assertEq(
+            mToken.internalCash(),
+            supplyAmount - redeemAmount,
+            "internalCash"
+        );
+        assertEq(
+            mToken.internalCash(),
+            token.balanceOf(address(mToken)),
+            "internalCash diverged from balance"
+        );
+    }
+
+    function testBorrowAndRepayMoveInternalCash() public {
+        _mint(supplier, supplyAmount);
+
+        uint256 borrowAmount = supplyAmount / 4;
+        _borrow(supplier, borrowAmount);
+
+        assertEq(
+            mToken.internalCash(),
+            supplyAmount - borrowAmount,
+            "internalCash after borrow"
+        );
+
+        token.allocateTo(supplier, borrowAmount);
+
+        vm.startPrank(supplier);
+        token.approve(address(mToken), borrowAmount);
+        assertEq(
+            mToken.repayBorrow(borrowAmount),
+            uint(Error.NO_ERROR),
+            "repay failed"
+        );
+        vm.stopPrank();
+
+        assertEq(
+            mToken.internalCash(),
+            supplyAmount,
+            "internalCash after repay"
+        );
+        assertEq(
+            mToken.internalCash(),
+            token.balanceOf(address(mToken)),
+            "internalCash diverged from balance"
+        );
+    }
+
+    function testAddAndReduceReservesMoveInternalCash() public {
+        _mint(supplier, supplyAmount);
+
+        uint256 reserveAmount = 5e18;
+
+        token.allocateTo(address(this), reserveAmount);
+        token.approve(address(mToken), reserveAmount);
+        assertEq(
+            mToken._addReserves(reserveAmount),
+            uint(Error.NO_ERROR),
+            "add reserves failed"
+        );
+
+        assertEq(
+            mToken.internalCash(),
+            supplyAmount + reserveAmount,
+            "internalCash after add reserves"
+        );
+
+        assertEq(
+            mToken._reduceReserves(reserveAmount),
+            uint(Error.NO_ERROR),
+            "reduce reserves failed"
+        );
+
+        assertEq(
+            mToken.internalCash(),
+            supplyAmount,
+            "internalCash after reduce reserves"
+        );
+        assertEq(
+            mToken.internalCash(),
+            token.balanceOf(address(mToken)),
+            "internalCash diverged from balance"
+        );
+    }
+
+    /// ---------------------------------------------------------------------------
+    /// donations
+    /// ---------------------------------------------------------------------------
+
+    function testDonationDoesNotMoveCashOrExchangeRate() public {
+        _mint(supplier, supplyAmount);
+
+        uint256 exchangeRateBefore = mToken.exchangeRateStored();
+
+        _donate(donationAmount);
+
+        assertEq(
+            token.balanceOf(address(mToken)),
+            supplyAmount + donationAmount,
+            "donation did not land"
+        );
+        assertEq(mToken.internalCash(), supplyAmount, "internalCash moved");
+        assertEq(mToken.getCash(), supplyAmount, "getCash moved");
+        assertEq(
+            mToken.exchangeRateStored(),
+            exchangeRateBefore,
+            "exchange rate moved"
+        );
+    }
+
+    /// @notice the donated underlying is not lendable, so a donation cannot be used to
+    ///         push borrows past what suppliers actually funded. The borrower posts
+    ///         collateral in a second market, so the only thing that can stop the borrow
+    ///         is the cash check
+    function testDonationIsNotBorrowable() public {
+        _mint(supplier, supplyAmount);
+        _donate(donationAmount);
+        _supplyCollateral(borrower, supplyAmount * 10);
+
+        address[] memory markets = new address[](1);
+        markets[0] = address(mToken);
+
+        vm.startPrank(borrower);
+        comptroller.enterMarkets(markets);
+
+        assertEq(
+            mToken.borrow(supplyAmount + 1),
+            uint(Error.TOKEN_INSUFFICIENT_CASH),
+            "donation was lent out"
+        );
+
+        assertEq(
+            mToken.borrow(supplyAmount),
+            uint(Error.NO_ERROR),
+            "borrow within internalCash failed"
+        );
+        vm.stopPrank();
+
+        assertEq(mToken.internalCash(), 0, "internalCash");
+        assertEq(
+            token.balanceOf(address(mToken)),
+            donationAmount,
+            "donation did not stay behind"
+        );
+    }
+
+    /// @notice a donation is stranded until the admin sweeps or syncs it: redeeming every
+    ///         mToken in existence leaves it sitting in the market
+    function testDonationIsNotRedeemable() public {
+        _mint(supplier, supplyAmount);
+        _donate(donationAmount);
+
+        uint256 supplierTokens = mToken.balanceOf(supplier);
+
+        vm.prank(supplier);
+        assertEq(
+            mToken.redeem(supplierTokens),
+            uint(Error.NO_ERROR),
+            "redeem failed"
+        );
+
+        assertEq(mToken.totalSupply(), 0, "mTokens outstanding");
+        assertEq(mToken.internalCash(), 0, "internalCash");
+        assertEq(
+            token.balanceOf(address(mToken)),
+            donationAmount,
+            "donation did not stay behind"
+        );
+        assertEq(
+            token.balanceOf(supplier),
+            supplyAmount,
+            "supplier took the donation"
+        );
+    }
+
+    /// ---------------------------------------------------------------------------
+    /// sweepTokenAndSync
+    /// ---------------------------------------------------------------------------
+
+    function testSweepRevertsForNonAdmin() public {
+        _mint(supplier, supplyAmount);
+        _donate(donationAmount);
+
+        vm.prank(supplier);
+        vm.expectRevert(
+            "MErc20::sweepTokenAndSync: only admin can sweep tokens"
+        );
+        mToken.sweepTokenAndSync(donationAmount);
+    }
+
+    function testSweepRevertsAboveSurplus() public {
+        _mint(supplier, supplyAmount);
+        _donate(donationAmount);
+
+        vm.expectRevert("MErc20::sweepTokenAndSync: amount exceeds surplus");
+        mToken.sweepTokenAndSync(donationAmount + 1);
+    }
+
+    /// @notice with no donation there is no surplus, so any non zero sweep is rejected
+    ///         rather than eating into supplier cash
+    function testSweepCannotTouchSupplierCash() public {
+        _mint(supplier, supplyAmount);
+
+        vm.expectRevert("MErc20::sweepTokenAndSync: amount exceeds surplus");
+        mToken.sweepTokenAndSync(1);
+
+        mToken.sweepTokenAndSync(0);
+
+        assertEq(mToken.internalCash(), supplyAmount, "internalCash moved");
+    }
+
+    /// @notice sweeping zero credits the donation to suppliers through the exchange rate
+    function testSweepZeroCreditsDonationToSuppliers() public {
+        _mint(supplier, supplyAmount);
+
+        uint256 exchangeRateBefore = mToken.exchangeRateStored();
+
+        _donate(donationAmount);
+
+        vm.expectEmit(true, true, true, true, address(mToken));
+        emit CashSynced(supplyAmount, supplyAmount + donationAmount);
+        mToken.sweepTokenAndSync(0);
+
+        assertEq(
+            mToken.internalCash(),
+            supplyAmount + donationAmount,
+            "internalCash not resynced"
+        );
+        assertEq(
+            mToken.internalCash(),
+            token.balanceOf(address(mToken)),
+            "internalCash diverged from balance"
+        );
+        assertGt(
+            mToken.exchangeRateStored(),
+            exchangeRateBefore,
+            "donation not credited to suppliers"
+        );
+
+        /// the supplier now redeems the donation along with their own deposit
+        uint256 supplierTokens = mToken.balanceOf(supplier);
+
+        vm.prank(supplier);
+        assertEq(
+            mToken.redeem(supplierTokens),
+            uint(Error.NO_ERROR),
+            "redeem failed"
+        );
+        assertEq(
+            token.balanceOf(supplier),
+            supplyAmount + donationAmount,
+            "supplier did not receive the donation"
+        );
+    }
+
+    /// @notice sweeping the whole surplus hands it to the admin and leaves suppliers
+    ///         exactly where they were
+    function testSweepFullSurplusToAdmin() public {
+        _mint(supplier, supplyAmount);
+
+        uint256 exchangeRateBefore = mToken.exchangeRateStored();
+
+        _donate(donationAmount);
+
+        vm.expectEmit(true, true, true, true, address(mToken));
+        emit UnderlyingSwept(address(this), donationAmount);
+        vm.expectEmit(true, true, true, true, address(mToken));
+        emit CashSynced(supplyAmount, supplyAmount);
+        mToken.sweepTokenAndSync(donationAmount);
+
+        assertEq(
+            token.balanceOf(address(this)),
+            donationAmount,
+            "admin did not receive the surplus"
+        );
+        assertEq(mToken.internalCash(), supplyAmount, "internalCash moved");
+        assertEq(
+            mToken.internalCash(),
+            token.balanceOf(address(mToken)),
+            "internalCash diverged from balance"
+        );
+        assertEq(
+            mToken.exchangeRateStored(),
+            exchangeRateBefore,
+            "exchange rate moved"
+        );
+    }
+
+    /// @notice what is left behind by a partial sweep is credited to suppliers
+    function testSweepPartialSurplusSplitsBetweenAdminAndSuppliers() public {
+        _mint(supplier, supplyAmount);
+        _donate(donationAmount);
+
+        uint256 sweepAmount = donationAmount / 4;
+        uint256 remainder = donationAmount - sweepAmount;
+
+        mToken.sweepTokenAndSync(sweepAmount);
+
+        assertEq(
+            token.balanceOf(address(this)),
+            sweepAmount,
+            "admin did not receive the swept portion"
+        );
+        assertEq(
+            mToken.internalCash(),
+            supplyAmount + remainder,
+            "remainder not credited"
+        );
+        assertEq(
+            mToken.internalCash(),
+            token.balanceOf(address(mToken)),
+            "internalCash diverged from balance"
+        );
+    }
+
+    /// @notice interest is booked at the pre sweep utilization, so the sweep cannot be
+    ///         timed to accrue against a cash balance that is about to change
+    function testSweepAccruesInterestBeforeSyncing() public {
+        _mint(supplier, supplyAmount);
+        _borrow(supplier, supplyAmount / 4);
+        _donate(donationAmount);
+
+        vm.warp(block.timestamp + 30 days);
+
+        uint256 borrowsBefore = mToken.totalBorrows();
+
+        mToken.sweepTokenAndSync(0);
+
+        assertEq(
+            mToken.accrualBlockTimestamp(),
+            block.timestamp,
+            "interest not accrued"
+        );
+        assertGt(mToken.totalBorrows(), borrowsBefore, "borrows did not grow");
+    }
+
+    /// ---------------------------------------------------------------------------
+    /// _becomeImplementation seeding
+    /// ---------------------------------------------------------------------------
+
+    /// @notice the state a live market is in the moment before it is upgraded: real
+    ///         underlying on hand, but no `internalCash` recorded yet
+    function testBecomeImplementationSeedsInternalCashFromBalance() public {
+        _mint(supplier, supplyAmount);
+
+        uint256 exchangeRateBefore = mToken.exchangeRateStored();
+
+        _clearCashTracking();
+
+        assertEq(
+            mToken.getCash(),
+            0,
+            "precondition: market should read zero cash while untracked"
+        );
+
+        MErc20Delegate newImplementation = new MErc20Delegate();
+
+        vm.expectEmit(true, true, true, true, address(mToken));
+        emit CashSynced(0, supplyAmount);
+        mToken._setImplementation(address(newImplementation), true, "");
+
+        assertTrue(
+            mToken.internalCashInitialized(),
+            "cash tracking not initialized"
+        );
+        assertEq(
+            mToken.internalCash(),
+            supplyAmount,
+            "internalCash not seeded"
+        );
+        assertEq(
+            mToken.exchangeRateStored(),
+            exchangeRateBefore,
+            "upgrade moved the exchange rate"
+        );
+    }
+
+    /// @notice a donation sitting in the market at upgrade time is seeded into
+    ///         `internalCash` because it is indistinguishable from supplier cash at that
+    ///         point; every donation after the upgrade is not
+    function testBecomeImplementationDoesNotReseedAfterInitialization() public {
+        _mint(supplier, supplyAmount);
+        _donate(donationAmount);
+
+        MErc20Delegate newImplementation = new MErc20Delegate();
+        mToken._setImplementation(address(newImplementation), true, "");
+
+        assertEq(
+            mToken.internalCash(),
+            supplyAmount,
+            "second upgrade reseeded internalCash from the donation"
+        );
+        assertEq(
+            mToken.getCash(),
+            supplyAmount,
+            "donation reached getCash through the upgrade"
+        );
+    }
+
+    /// @notice the rollback path called out in `_becomeImplementation`: cash tracking is
+    ///         already initialized, so rolling forward again leaves `internalCash` stale
+    ///         and the admin has to resync it explicitly
+    function testStaleCashAfterRollForwardIsFixedBySweepZero() public {
+        _mint(supplier, supplyAmount);
+
+        /// emulate a market that spent time on a balance based implementation: cash moved
+        /// while `internalCash` was not being maintained
+        vm.store(address(mToken), bytes32(INTERNAL_CASH_SLOT), bytes32(0));
+
+        MErc20Delegate newImplementation = new MErc20Delegate();
+        mToken._setImplementation(address(newImplementation), true, "");
+
+        assertEq(
+            mToken.internalCash(),
+            0,
+            "upgrade reseeded an already initialized market"
+        );
+
+        mToken.sweepTokenAndSync(0);
+
+        assertEq(
+            mToken.internalCash(),
+            supplyAmount,
+            "resync did not restore the tracked cash"
+        );
+    }
+
+    /// ---------------------------------------------------------------------------
+    /// helpers
+    /// ---------------------------------------------------------------------------
+
+    function _mint(address user, uint256 amount) private {
+        token.allocateTo(user, amount);
+
+        vm.startPrank(user);
+        token.approve(address(mToken), amount);
+        assertEq(mToken.mint(amount), uint(Error.NO_ERROR), "mint failed");
+        vm.stopPrank();
+    }
+
+    function _borrow(address user, uint256 amount) private {
+        address[] memory markets = new address[](1);
+        markets[0] = address(mToken);
+
+        vm.startPrank(user);
+        comptroller.enterMarkets(markets);
+        assertEq(mToken.borrow(amount), uint(Error.NO_ERROR), "borrow failed");
+        vm.stopPrank();
+    }
+
+    /// @dev collateral in the second market, so a borrow against it is limited by the
+    ///      first market's cash rather than by the borrower's collateral
+    function _supplyCollateral(address user, uint256 amount) private {
+        collateralToken.allocateTo(user, amount);
+
+        address[] memory markets = new address[](1);
+        markets[0] = address(mCollateral);
+
+        vm.startPrank(user);
+        collateralToken.approve(address(mCollateral), amount);
+        assertEq(
+            mCollateral.mint(amount),
+            uint(Error.NO_ERROR),
+            "collateral mint failed"
+        );
+        comptroller.enterMarkets(markets);
+        vm.stopPrank();
+    }
+
+    /// @dev underlying sent straight to the market, never through `doTransferIn`
+    function _donate(uint256 amount) private {
+        token.allocateTo(donor, amount);
+
+        vm.prank(donor);
+        token.transfer(address(mToken), amount);
+    }
+
+    /// @dev rewinds the two cash tracking slots to what a market looks like before it has
+    ///      ever run an implementation that maintains them
+    function _clearCashTracking() private {
+        vm.store(address(mToken), bytes32(INTERNAL_CASH_SLOT), bytes32(0));
+        vm.store(
+            address(mToken),
+            bytes32(INTERNAL_CASH_INITIALIZED_SLOT),
+            bytes32(0)
+        );
+
+        assertEq(mToken.internalCash(), 0, "internalCash slot mismatch");
+        assertFalse(
+            mToken.internalCashInitialized(),
+            "internalCashInitialized slot mismatch"
+        );
+    }
+}
+
+/// @notice `MWethDelegate` routes its transfers out through the unwrapper, so this checks
+///         that the WETH market debits `internalCash` exactly once on the way out and that
+///         donations are just as inert there as on a plain ERC-20 market.
+contract MWethDelegateInternalCashUnitTest is Test, TokenErrorReporter {
+    Comptroller public comptroller;
+    SimplePriceOracle public oracle;
+    MockWeth public weth;
+    WethUnwrapper public unwrapper;
+    MErc20Delegator public mToken;
+
+    address public constant supplier = address(0x51);
+
+    uint256 public constant supplyAmount = 10 ether;
+    uint256 public constant donationAmount = 1 ether;
+
+    function setUp() public {
+        comptroller = new Comptroller();
+        oracle = new SimplePriceOracle();
+        weth = new MockWeth();
+        unwrapper = new WethUnwrapper(address(weth));
+
+        mToken = new MErc20Delegator(
+            address(weth),
+            comptroller,
+            new WhitePaperInterestRateModel(0.1e18, 0.45e18),
+            1e18,
+            "Moonwell WETH",
+            "mWETH",
+            8,
+            payable(address(this)),
+            address(new MWethDelegate(address(unwrapper))),
+            ""
+        );
+
+        MultiRewardDistributor distributor = new MultiRewardDistributor();
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(distributor),
+            address(this),
+            abi.encodeWithSignature(
+                "initialize(address,address)",
+                address(comptroller),
+                address(this)
+            )
+        );
+
+        comptroller._setRewardDistributor(
+            MultiRewardDistributor(address(proxy))
+        );
+        comptroller._setPriceOracle(oracle);
+        comptroller._supportMarket(MToken(address(mToken)));
+        oracle.setUnderlyingPrice(MToken(address(mToken)), 1e18);
+    }
+
+    /// @notice the unwrapping transfer out debits `internalCash` once, not twice, and the
+    ///         redeemer is paid in raw ETH
+    function testRedeemDebitsInternalCashOnce() public {
+        _mint(supplyAmount);
+
+        uint256 redeemAmount = supplyAmount / 2;
+        uint256 ethBefore = supplier.balance;
+
+        vm.prank(supplier);
+        assertEq(
+            mToken.redeemUnderlying(redeemAmount),
+            uint(Error.NO_ERROR),
+            "redeem failed"
+        );
+
+        assertEq(
+            mToken.internalCash(),
+            supplyAmount - redeemAmount,
+            "internalCash debited more than once"
+        );
+        assertEq(
+            mToken.internalCash(),
+            weth.balanceOf(address(mToken)),
+            "internalCash diverged from balance"
+        );
+        assertEq(
+            supplier.balance - ethBefore,
+            redeemAmount,
+            "redeemer not paid in ETH"
+        );
+    }
+
+    function testDonationDoesNotMoveCash() public {
+        _mint(supplyAmount);
+
+        uint256 exchangeRateBefore = mToken.exchangeRateStored();
+
+        vm.deal(address(this), donationAmount);
+        weth.deposit{value: donationAmount}();
+        weth.transfer(address(mToken), donationAmount);
+
+        assertEq(mToken.getCash(), supplyAmount, "getCash moved");
+        assertEq(
+            mToken.exchangeRateStored(),
+            exchangeRateBefore,
+            "exchange rate moved"
+        );
+
+        /// the sweep hands WETH, not raw ETH, to the admin
+        mToken.sweepTokenAndSync(donationAmount);
+
+        assertEq(
+            weth.balanceOf(address(this)),
+            donationAmount,
+            "admin did not receive WETH"
+        );
+        assertEq(mToken.internalCash(), supplyAmount, "internalCash moved");
+    }
+
+    function _mint(uint256 amount) private {
+        vm.deal(supplier, amount);
+
+        vm.startPrank(supplier);
+        weth.deposit{value: amount}();
+        weth.approve(address(mToken), amount);
+        assertEq(mToken.mint(amount), uint(Error.NO_ERROR), "mint failed");
+        vm.stopPrank();
+    }
+
+    receive() external payable {}
+}

--- a/test/views/MoonwellViewsV1Moonriver.t.sol
+++ b/test/views/MoonwellViewsV1Moonriver.t.sol
@@ -8,7 +8,7 @@ import {DeployMoonwellViewsV1Moonriver} from "@script/DeployMoonwellViewsV1Moonr
 import {MoonwellViewsV1Moonriver} from "@protocol/views/MoonwellViewsV1Moonriver.sol";
 import {BaseMoonwellViews} from "@protocol/views/BaseMoonwellViews.sol";
 import {MToken} from "@protocol/MToken.sol";
-import {MErc20Interface} from "@protocol/MTokenInterfaces.sol";
+import {MTokenInterface} from "@protocol/MTokenInterfaces.sol";
 import {Comptroller} from "@protocol/Comptroller.sol";
 
 contract MoonwellViewsV1MoonriverTest is Test {
@@ -113,7 +113,7 @@ contract MoonwellViewsV1MoonriverTest is Test {
                 underlying = wmovr;
             } else {
                 underlying = address(
-                    MErc20Interface(markets[i].market).underlying()
+                    MTokenInterface(markets[i].market).underlying()
                 );
             }
 


### PR DESCRIPTION
## Track mToken cash internally to prevent donation-based accounting changes

Direct token transfers currently count as market cash even though they do not go through the normal supply flow. This means anyone can send underlying tokens directly to an mToken and change its exchange rate, available liquidity, and supply-cap accounting.

This PR makes each market track the cash received and sent through its own operations. Direct transfers are treated as surplus tokens and no longer affect normal market accounting.

### How it works

- Added `internalCash`, which increases when the market receives underlying and decreases when it sends underlying.
- Updated `getCash()` to use the tracked amount instead of the contract's token balance.
- Initialized `internalCash` from the existing balance during the first implementation upgrade. Later upgrades cannot initialize it again.
- Added the admin-only `sweepTokenAndSync(uint256)` function. It can return surplus underlying to the admin or sync the tracked cash after an upgrade rollback.
- Updated `LibCompound.viewExchangeRate` to use the market's tracked cash.
- Updated the WETH transfer path so tracked cash is reduced exactly once.

After this change, directly donated underlying is not borrowable or redeemable, does not increase the exchange rate, and does not count toward the supply cap. The admin can either sweep the surplus or sync it into market cash.

### Additional changes

These changes are not required for internal cash accounting itself, but they simplify the code being updated and make future mToken changes safer.

**Consolidate mToken storage**

This storage change was not strictly required. The new cash fields could have been added to `MErc20Delegate`, but then all logic using them would also need to live in that delegate. `MErc20` cannot access state declared in a contract derived from it, so cash tracking would require delegate-specific overrides of the existing transfer and cash functions.

Keeping the fields in `MTokenStorage` lets the cash accounting remain in `MErc20`, next to the transfer logic it updates. It also solves the same problem for future changes: previously, there was no safe place to add state that `MToken` itself could access. Adding it to `MTokenStorage` would shift the fields declared after it, while adding it to a delegate would make it unavailable to `MToken`.

This PR moves `underlying` and `implementation` into `MTokenStorage` without changing their slots, then adds the new cash fields after them. `MTokenInterface` carries this storage and is inherited throughout the mToken hierarchy, so the fields are available to both base and derived contracts. This gives future mToken state one shared place without changing the existing storage order.

Moving `underlying` also required a small cleanup in the contracts that read it, including the oracle wrappers, view contracts, fee redeemer, and automation deployment helper. These callers now use `MTokenInterface` instead of `MErc20Interface` or `MErc20Storage`. This only changes which Solidity interface describes the existing `underlying()` call. The function selector, return value, and on-chain behavior remain the same, so these contracts do not need to be upgraded because of this cleanup.

| Slots | Contents |
|---|---|
| 0–17 | Existing fields, unchanged |
| 18–19 | `underlying` and `implementation`, unchanged |
| 20–21 | `internalCash` and `internalCashInitialized` |
| 22–64 | Reserved storage gap |

The upgrade tests confirm that all existing values remain unchanged for both standard ERC-20 and WETH markets.

**Use `SafeERC20.safeTransfer`**

Changing the outbound transfer path was not required for internal cash accounting. However, since this PR already updates `doTransferOut`, it is a good time to replace its custom low-level transfer logic with OpenZeppelin's `SafeERC20.safeTransfer`.

This keeps support for ERC-20 tokens that do not return a value while making the transfer code shorter and easier to maintain. `doTransferIn` keeps its existing low-level logic because it must measure the actual amount received from fee-on-transfer tokens.

### Tests

- 20 unit tests cover cash changes during mint, redeem, borrow, repay, and reserve operations; direct donations; admin sweeping and syncing; upgrade initialization; rollback recovery; and WETH withdrawals.
- 4 Base fork tests reproduce the current donation behavior on mUSDC and mWETH, then confirm that the upgraded implementation keeps donations out of the exchange rate and supply-cap calculation.
- 2 Base fork tests confirm that existing market storage remains unchanged after upgrading standard ERC-20 and WETH markets.
- 6 Base fork tests cover the Base WETH admin setup, the temporary admin handover described below, normal market operations after the upgrade, reserve reduction through the wrapper, and the remaining sweep limitation.

The fork tests use Base block `50_590_315` and require an archive RPC.

### Open point: Base WETH rollout

The Base WETH market cannot use the normal upgrade path because its admin is `MWETH_OWNER_WRAPPER`, not the Temporal Governor. The wrapper only forwards a fixed set of admin calls and does not expose `_setImplementation` or `sweepTokenAndSync`.

The market can still be upgraded in one governance proposal without changing the wrapper:

1. Use the wrapper to set the Temporal Governor as the pending market admin.
2. Have the Temporal Governor accept admin.
3. Upgrade the market implementation.
4. Set the wrapper as the pending admin.
5. Use the wrapper to accept admin again.

The Base fork tests confirm that this round trip upgrades the market without changing its accounting and that the wrapper can still reduce reserves afterward. However, once admin returns to the wrapper, `sweepTokenAndSync` is still unavailable. Governance would need to repeat the temporary admin handover whenever a WETH surplus must be swept or synced.

The other option is to upgrade `MWETH_OWNER_WRAPPER` first and add passthroughs for `_setImplementation` and `sweepTokenAndSync`. I can add that wrapper change if we prefer a direct path for future WETH market upgrades and sweeps.
